### PR TITLE
fix(init): resolve 3 spec/impl inconsistencies (raw/ read-only, double log, checkpoint metadata)

### DIFF
--- a/.claude/skills/daily-arxiv/SKILL.md
+++ b/.claude/skills/daily-arxiv/SKILL.md
@@ -191,7 +191,7 @@ Output summary:
 
 - **Only ingest papers with relevance >= 3**: leave the rest for user judgment, do not auto-create wiki pages
 - **At most `--max-ingest` papers per run** (default 5): prevents single-run wiki overload
-- **raw/ is read-only**: do not modify files under `raw/`
+- **raw/ is read-only for `/daily-arxiv`**: do not write, modify, or delete anything under `raw/`. (Note: only `/init` Step 2 has the sanctioned exception to append newly-discovered sources into `raw/papers/`; this skill does not.)
 - **graph/ maintained via tools only**: do not manually edit graph files
 - **Bidirectional links**: guaranteed by /ingest
 - **Deduplication must be strict**: double-check by both arxiv_url and arxiv_id

--- a/.claude/skills/init/SKILL.md
+++ b/.claude/skills/init/SKILL.md
@@ -460,13 +460,19 @@ After all papers are ingested:
 
 ```bash
 STASH_REF=$(python3 tools/research_wiki.py checkpoint-get-meta wiki/ init-session stash_ref)
-if [ -n "$STASH_REF" ]; then
-  git stash pop "$STASH_REF" || echo "⚠ stash pop failed — check 'git stash list' and resolve manually"
+if [ -z "$STASH_REF" ]; then
+  # Nothing was stashed in 4.5.b (working tree was clean) — just clear the checkpoint.
+  python3 tools/research_wiki.py checkpoint-clear wiki/ init-session
+elif git stash pop "$STASH_REF"; then
+  python3 tools/research_wiki.py checkpoint-clear wiki/ init-session
+else
+  echo "⚠ stash pop failed — checkpoint preserved at .checkpoints/init-session.json"
+  echo "  Run 'git stash list' and resolve manually, then:"
+  echo "    python3 tools/research_wiki.py checkpoint-clear wiki/ init-session"
 fi
-python3 tools/research_wiki.py checkpoint-clear wiki/ init-session
 ```
 
-`checkpoint-get-meta` with a key prints the raw value (empty string if absent), so `[ -n "$STASH_REF" ]` is the correct guard. Only clear the checkpoint after the pop succeeds; a failed pop should leave the checkpoint intact so the user can re-run the pop sequence manually.
+`checkpoint-get-meta` with a key prints the raw value (empty string if absent), so `[ -z "$STASH_REF" ]` cleanly distinguishes "nothing to pop" from "pop succeeded" from "pop failed". Only clear the checkpoint after a successful pop — a failed pop MUST leave the checkpoint (and its `stash_ref` metadata) intact so the user can recover manually. Do not collapse this into `pop || echo`: `echo` always exits 0, which would swallow the pop failure and run `checkpoint-clear` unconditionally, losing the stash ref.
 
 Then output a summary including:
 - Page creation counts (broken down by all 8 entity types)

--- a/.claude/skills/init/SKILL.md
+++ b/.claude/skills/init/SKILL.md
@@ -72,10 +72,7 @@ This creates:
 
 If `wiki/CLAUDE.md` does not exist, copy from the product template.
 
-Append log:
-```bash
-python3 tools/research_wiki.py log wiki/ "init | initialized wiki directory structure"
-```
+The `init` command already appends `init | wiki initialized` to `log.md` automatically — do not add a second log call here.
 
 ### Step 2: Collect Raw Sources + Smart Expansion
 
@@ -127,21 +124,31 @@ From the combined results:
 
 **If DeepXiv is unavailable**: rely on S2 search only.
 
-#### Phase D — Download selected papers
+#### Phase D — Download selected papers (additions only)
 
 For each paper selected in Phase B + C:
 
-```bash
-# Prefer tex source (arXiv e-print)
-curl -sL -o raw/papers/<slug>.tar.gz "https://arxiv.org/e-print/<arxiv_id>"
-mkdir -p raw/papers/<slug> && tar -xzf raw/papers/<slug>.tar.gz -C raw/papers/<slug>/
-rm raw/papers/<slug>.tar.gz
+**Skip-if-exists guard (mandatory)** — before downloading, check that neither `raw/papers/<slug>/` nor `raw/papers/<slug>.pdf` already exists. If either is present, SKIP the download entirely. `/init` is forbidden from overwriting anything already under `raw/` (see the Constraints section); the user's existing materials are authoritative.
 
-# If e-print fails or no arXiv ID, fall back to PDF
-curl -sL -o raw/papers/<slug>.pdf "https://arxiv.org/pdf/<arxiv_id>"
+```bash
+if [ -d "raw/papers/<slug>" ] || [ -f "raw/papers/<slug>.pdf" ]; then
+  echo "skip: raw/papers/<slug> already exists"
+else
+  # Prefer tex source (arXiv e-print)
+  curl -sL -o raw/papers/<slug>.tar.gz "https://arxiv.org/e-print/<arxiv_id>"
+  if [ -s raw/papers/<slug>.tar.gz ]; then
+    mkdir -p raw/papers/<slug> && tar -xzf raw/papers/<slug>.tar.gz -C raw/papers/<slug>/
+    rm raw/papers/<slug>.tar.gz
+  else
+    rm -f raw/papers/<slug>.tar.gz
+    # Fall back to PDF
+    curl -sL -o raw/papers/<slug>.pdf "https://arxiv.org/pdf/<arxiv_id>"
+    [ -s raw/papers/<slug>.pdf ] || { rm -f raw/papers/<slug>.pdf; echo "download failed: <slug>"; }
+  fi
+fi
 ```
 
-After download, verify the file is valid (not empty, correct content type).
+After each download, verify the artifact is non-empty (`test -s`) and of the expected content type; if the check fails, delete the partial file and log the failure — never leave a zero-byte stub in `raw/papers/`.
 
 #### Phase E — Compile final source list
 
@@ -152,7 +159,7 @@ Log what was expanded:
 python3 tools/research_wiki.py log wiki/ "init | source expansion: <N> local + <M> discovered via citation chains and search"
 ```
 
-**Transparency**: when reporting to the user (Step 8), clearly separate "papers you provided" from "papers we discovered" so the user can verify relevance.
+**Transparency**: papers downloaded in Phase D become permanent additions to the user's `raw/papers/`. Step 8's report MUST list them under a separate "papers we discovered and downloaded" section (distinct from "papers you provided") so the user can review and `git rm` any they reject.
 
 ### Step 3: Domain Analysis
 
@@ -207,7 +214,14 @@ if [ -n "$UNRELATED" ]; then
 fi
 ```
 
-**Record the stash ref** (`git stash list | head -1`) into `init-session` checkpoint metadata so Step 8 can pop it back at the end. If you cannot record it durably, at minimum print it to the user and remind them to `git stash pop` themselves after `/init` completes.
+**Record the stash ref** into the `init-session` checkpoint metadata so Step 8 can pop it back at the end, even if `/init` is interrupted and resumed later:
+
+```bash
+STASH_REF=$(git stash list | head -1 | cut -d: -f1)
+python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session stash_ref "$STASH_REF"
+```
+
+This writes `{"metadata": {"stash_ref": "stash@{0}"}}` into `.checkpoints/init-session.json`; Step 8 reads it back via `checkpoint-get-meta` before clearing the checkpoint. If the stash step in 4.5.b produced no stash (nothing unrelated was dirty), skip this command — Step 8 will see an empty `stash_ref` and simply not pop.
 
 **Why stash and not "ask the user"**: a previous version of this step asked the user instead of stashing automatically. That left dirty files in the working tree, and Phase B's first `git merge` then failed with `your local changes ... would be overwritten by merge` even when those files had nothing to do with the merge — git's safety check is conservative and refuses any merge while the work tree is dirty. Stash → init → pop is the standard workflow; the user's work is never lost.
 
@@ -440,15 +454,29 @@ After all papers are ingested:
    python3 tools/research_wiki.py log wiki/ "init | completed: N papers, M concepts, K claims, L topics"
    ```
 
-### Step 8: Report to User
+### Step 8: Restore stash, Report to User
 
-Output a summary including:
+**Before reporting, restore the pre-init working tree state.** Read the stash ref recorded in 4.5.b back from checkpoint metadata and pop it:
+
+```bash
+STASH_REF=$(python3 tools/research_wiki.py checkpoint-get-meta wiki/ init-session stash_ref)
+if [ -n "$STASH_REF" ]; then
+  git stash pop "$STASH_REF" || echo "⚠ stash pop failed — check 'git stash list' and resolve manually"
+fi
+python3 tools/research_wiki.py checkpoint-clear wiki/ init-session
+```
+
+`checkpoint-get-meta` with a key prints the raw value (empty string if absent), so `[ -n "$STASH_REF" ]` is the correct guard. Only clear the checkpoint after the pop succeeds; a failed pop should leave the checkpoint intact so the user can re-run the pop sequence manually.
+
+Then output a summary including:
 - Page creation counts (broken down by all 8 entity types)
 - Domain overview (topics and Summary digest)
 - Overview of extracted claims
 - Number of graph edges
 - Issues found by lint (if any)
 - Initial ideas generated (if any)
+- **Papers we discovered and downloaded** in Step 2 Phase D (listed separately from papers the user provided, so the user can `git rm` any they reject)
+- Whether the pre-init stash was popped cleanly (and how to recover if not)
 - Suggested next steps:
   - Manually `/ingest` more papers
   - Read `wiki/Summary/` for the domain landscape
@@ -457,7 +485,7 @@ Output a summary including:
 
 ## Constraints
 
-- **raw/ is read-only**: do not modify files under `raw/`
+- **raw/ is append-only for `/init`, read-only for everything else**: Step 2 Phase D is the one sanctioned place where `raw/papers/` receives new files (discovered via citation-chain / keyword search). Only additions are allowed — never overwrite or delete an existing `raw/papers/*` entry. All `/ingest` subagents spawned in Step 5 treat `raw/` as strictly read-only (they consume `raw/papers/<slug>/` but never write back)
 - **graph/ maintained via tools only**: do not manually edit files under `graph/`; use `tools/research_wiki.py` exclusively
 - **Bidirectional links**: when writing a forward link, simultaneously write the reverse link (follow the Cross Reference rules in CLAUDE.md)
 - **tex preferred**: .tex > .pdf > vision API fallback
@@ -472,7 +500,7 @@ Output a summary including:
 - **raw/ is empty**: fetch papers via arXiv/S2 search only; note in report
 - **arXiv/S2/DeepXiv search fails**: skip the failing external source, use the remaining available sources + files already in raw/
 - **Single paper ingest fails**: record to checkpoint (`--failed`), skip that paper and continue; list failures in the final report
-- **Interrupted mid-run**: next time `/init` runs, it automatically detects the checkpoint and resumes from where it left off (skipping already-completed papers)
+- **Interrupted mid-run**: next time `/init` runs, it automatically detects the checkpoint and resumes from where it left off (skipping already-completed papers). The `stash_ref` recorded in 4.5.b persists across restarts via checkpoint metadata, so Step 8 of the resumed run will still pop it — do NOT pop the stash at the start of a resumed run, only at Step 8 as usual.
 - **wiki/ already has content**: detect existing pages, skip entities that already exist, only supplement new content (idempotent)
 - **Topic generation uncertain**: prefer fewer and more precise; 2–3 high-quality topics beats 5 vague ones
 - **Worktree isolation appears to have failed** (no worktree branches after Phase A, but `wiki/` is already populated): the subagent prompts likely contained absolute paths. Stop, audit the prompts, fix the orchestrator behavior, and re-run from a clean checkpoint. Do NOT proceed to Phase C without Phase B merge — the wiki will end up with many duplicate concepts and claims.
@@ -490,6 +518,9 @@ Output a summary including:
 - `python3 tools/research_wiki.py rebuild-open-questions wiki/` — rebuild knowledge gap map
 - `python3 tools/research_wiki.py stats wiki/` — wiki statistics
 - `python3 tools/research_wiki.py log wiki/ "<message>"` — append log
+- `python3 tools/research_wiki.py checkpoint-save/load/clear wiki/ init-session ...` — resume support for Step 5 parallel ingest
+- `python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session <key> <value>` — persist cross-step state (e.g. the Step 4.5.b stash ref) in checkpoint metadata
+- `python3 tools/research_wiki.py checkpoint-get-meta wiki/ init-session [<key>]` — read a metadata value (raw) or the whole metadata dict (JSON) in Step 8
 - `python3 tools/fetch_s2.py search "<topic>" 20` — Semantic Scholar keyword search
 - `python3 tools/fetch_s2.py references <arxiv_id>` — citation-chain expansion (references)
 - `python3 tools/fetch_s2.py citations <arxiv_id>` — citation-chain expansion (citations)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,7 +371,7 @@ python3 tools/fetch_arxiv.py --hours 24
 
 ## Constraints
 
-- **raw/ is read-only**: never modify files under `raw/`.
+- **raw/ is append-only, and only for `/init`**: `/init` Step 2 may download newly-discovered sources into `raw/papers/` (additions only — never overwrite an existing file). Every other skill, tool, and subagent (including `/ingest`, `/daily-arxiv`, and all `/init` subagents running `/ingest` in INIT MODE) treats `raw/` as strictly read-only: never modify, overwrite, or delete anything under `raw/`.
 - **graph/ is auto-generated**: never manually edit files in `graph/` — only via `tools/research_wiki.py`.
 - **Bidirectional links**: always write the reverse link when writing a forward link.
 - **tex priority**: .tex > .pdf; fallback chain: tex fails → PDF parse, PDF fails → vision API.

--- a/i18n/en/CLAUDE.md
+++ b/i18n/en/CLAUDE.md
@@ -371,7 +371,7 @@ python3 tools/fetch_arxiv.py --hours 24
 
 ## Constraints
 
-- **raw/ is read-only**: never modify files under `raw/`.
+- **raw/ is append-only, and only for `/init`**: `/init` Step 2 may download newly-discovered sources into `raw/papers/` (additions only — never overwrite an existing file). Every other skill, tool, and subagent (including `/ingest`, `/daily-arxiv`, and all `/init` subagents running `/ingest` in INIT MODE) treats `raw/` as strictly read-only: never modify, overwrite, or delete anything under `raw/`.
 - **graph/ is auto-generated**: never manually edit files in `graph/` — only via `tools/research_wiki.py`.
 - **Bidirectional links**: always write the reverse link when writing a forward link.
 - **tex priority**: .tex > .pdf; fallback chain: tex fails → PDF parse, PDF fails → vision API.

--- a/i18n/en/skills/daily-arxiv/SKILL.md
+++ b/i18n/en/skills/daily-arxiv/SKILL.md
@@ -191,7 +191,7 @@ Output summary:
 
 - **Only ingest papers with relevance >= 3**: leave the rest for user judgment, do not auto-create wiki pages
 - **At most `--max-ingest` papers per run** (default 5): prevents single-run wiki overload
-- **raw/ is read-only**: do not modify files under `raw/`
+- **raw/ is read-only for `/daily-arxiv`**: do not write, modify, or delete anything under `raw/`. (Note: only `/init` Step 2 has the sanctioned exception to append newly-discovered sources into `raw/papers/`; this skill does not.)
 - **graph/ maintained via tools only**: do not manually edit graph files
 - **Bidirectional links**: guaranteed by /ingest
 - **Deduplication must be strict**: double-check by both arxiv_url and arxiv_id

--- a/i18n/en/skills/init/SKILL.md
+++ b/i18n/en/skills/init/SKILL.md
@@ -460,13 +460,19 @@ After all papers are ingested:
 
 ```bash
 STASH_REF=$(python3 tools/research_wiki.py checkpoint-get-meta wiki/ init-session stash_ref)
-if [ -n "$STASH_REF" ]; then
-  git stash pop "$STASH_REF" || echo "⚠ stash pop failed — check 'git stash list' and resolve manually"
+if [ -z "$STASH_REF" ]; then
+  # Nothing was stashed in 4.5.b (working tree was clean) — just clear the checkpoint.
+  python3 tools/research_wiki.py checkpoint-clear wiki/ init-session
+elif git stash pop "$STASH_REF"; then
+  python3 tools/research_wiki.py checkpoint-clear wiki/ init-session
+else
+  echo "⚠ stash pop failed — checkpoint preserved at .checkpoints/init-session.json"
+  echo "  Run 'git stash list' and resolve manually, then:"
+  echo "    python3 tools/research_wiki.py checkpoint-clear wiki/ init-session"
 fi
-python3 tools/research_wiki.py checkpoint-clear wiki/ init-session
 ```
 
-`checkpoint-get-meta` with a key prints the raw value (empty string if absent), so `[ -n "$STASH_REF" ]` is the correct guard. Only clear the checkpoint after the pop succeeds; a failed pop should leave the checkpoint intact so the user can re-run the pop sequence manually.
+`checkpoint-get-meta` with a key prints the raw value (empty string if absent), so `[ -z "$STASH_REF" ]` cleanly distinguishes "nothing to pop" from "pop succeeded" from "pop failed". Only clear the checkpoint after a successful pop — a failed pop MUST leave the checkpoint (and its `stash_ref` metadata) intact so the user can recover manually. Do not collapse this into `pop || echo`: `echo` always exits 0, which would swallow the pop failure and run `checkpoint-clear` unconditionally, losing the stash ref.
 
 Then output a summary including:
 - Page creation counts (broken down by all 8 entity types)

--- a/i18n/en/skills/init/SKILL.md
+++ b/i18n/en/skills/init/SKILL.md
@@ -72,10 +72,7 @@ This creates:
 
 If `wiki/CLAUDE.md` does not exist, copy from the product template.
 
-Append log:
-```bash
-python3 tools/research_wiki.py log wiki/ "init | initialized wiki directory structure"
-```
+The `init` command already appends `init | wiki initialized` to `log.md` automatically — do not add a second log call here.
 
 ### Step 2: Collect Raw Sources + Smart Expansion
 
@@ -127,21 +124,31 @@ From the combined results:
 
 **If DeepXiv is unavailable**: rely on S2 search only.
 
-#### Phase D — Download selected papers
+#### Phase D — Download selected papers (additions only)
 
 For each paper selected in Phase B + C:
 
-```bash
-# Prefer tex source (arXiv e-print)
-curl -sL -o raw/papers/<slug>.tar.gz "https://arxiv.org/e-print/<arxiv_id>"
-mkdir -p raw/papers/<slug> && tar -xzf raw/papers/<slug>.tar.gz -C raw/papers/<slug>/
-rm raw/papers/<slug>.tar.gz
+**Skip-if-exists guard (mandatory)** — before downloading, check that neither `raw/papers/<slug>/` nor `raw/papers/<slug>.pdf` already exists. If either is present, SKIP the download entirely. `/init` is forbidden from overwriting anything already under `raw/` (see the Constraints section); the user's existing materials are authoritative.
 
-# If e-print fails or no arXiv ID, fall back to PDF
-curl -sL -o raw/papers/<slug>.pdf "https://arxiv.org/pdf/<arxiv_id>"
+```bash
+if [ -d "raw/papers/<slug>" ] || [ -f "raw/papers/<slug>.pdf" ]; then
+  echo "skip: raw/papers/<slug> already exists"
+else
+  # Prefer tex source (arXiv e-print)
+  curl -sL -o raw/papers/<slug>.tar.gz "https://arxiv.org/e-print/<arxiv_id>"
+  if [ -s raw/papers/<slug>.tar.gz ]; then
+    mkdir -p raw/papers/<slug> && tar -xzf raw/papers/<slug>.tar.gz -C raw/papers/<slug>/
+    rm raw/papers/<slug>.tar.gz
+  else
+    rm -f raw/papers/<slug>.tar.gz
+    # Fall back to PDF
+    curl -sL -o raw/papers/<slug>.pdf "https://arxiv.org/pdf/<arxiv_id>"
+    [ -s raw/papers/<slug>.pdf ] || { rm -f raw/papers/<slug>.pdf; echo "download failed: <slug>"; }
+  fi
+fi
 ```
 
-After download, verify the file is valid (not empty, correct content type).
+After each download, verify the artifact is non-empty (`test -s`) and of the expected content type; if the check fails, delete the partial file and log the failure — never leave a zero-byte stub in `raw/papers/`.
 
 #### Phase E — Compile final source list
 
@@ -152,7 +159,7 @@ Log what was expanded:
 python3 tools/research_wiki.py log wiki/ "init | source expansion: <N> local + <M> discovered via citation chains and search"
 ```
 
-**Transparency**: when reporting to the user (Step 8), clearly separate "papers you provided" from "papers we discovered" so the user can verify relevance.
+**Transparency**: papers downloaded in Phase D become permanent additions to the user's `raw/papers/`. Step 8's report MUST list them under a separate "papers we discovered and downloaded" section (distinct from "papers you provided") so the user can review and `git rm` any they reject.
 
 ### Step 3: Domain Analysis
 
@@ -207,7 +214,14 @@ if [ -n "$UNRELATED" ]; then
 fi
 ```
 
-**Record the stash ref** (`git stash list | head -1`) into `init-session` checkpoint metadata so Step 8 can pop it back at the end. If you cannot record it durably, at minimum print it to the user and remind them to `git stash pop` themselves after `/init` completes.
+**Record the stash ref** into the `init-session` checkpoint metadata so Step 8 can pop it back at the end, even if `/init` is interrupted and resumed later:
+
+```bash
+STASH_REF=$(git stash list | head -1 | cut -d: -f1)
+python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session stash_ref "$STASH_REF"
+```
+
+This writes `{"metadata": {"stash_ref": "stash@{0}"}}` into `.checkpoints/init-session.json`; Step 8 reads it back via `checkpoint-get-meta` before clearing the checkpoint. If the stash step in 4.5.b produced no stash (nothing unrelated was dirty), skip this command — Step 8 will see an empty `stash_ref` and simply not pop.
 
 **Why stash and not "ask the user"**: a previous version of this step asked the user instead of stashing automatically. That left dirty files in the working tree, and Phase B's first `git merge` then failed with `your local changes ... would be overwritten by merge` even when those files had nothing to do with the merge — git's safety check is conservative and refuses any merge while the work tree is dirty. Stash → init → pop is the standard workflow; the user's work is never lost.
 
@@ -440,15 +454,29 @@ After all papers are ingested:
    python3 tools/research_wiki.py log wiki/ "init | completed: N papers, M concepts, K claims, L topics"
    ```
 
-### Step 8: Report to User
+### Step 8: Restore stash, Report to User
 
-Output a summary including:
+**Before reporting, restore the pre-init working tree state.** Read the stash ref recorded in 4.5.b back from checkpoint metadata and pop it:
+
+```bash
+STASH_REF=$(python3 tools/research_wiki.py checkpoint-get-meta wiki/ init-session stash_ref)
+if [ -n "$STASH_REF" ]; then
+  git stash pop "$STASH_REF" || echo "⚠ stash pop failed — check 'git stash list' and resolve manually"
+fi
+python3 tools/research_wiki.py checkpoint-clear wiki/ init-session
+```
+
+`checkpoint-get-meta` with a key prints the raw value (empty string if absent), so `[ -n "$STASH_REF" ]` is the correct guard. Only clear the checkpoint after the pop succeeds; a failed pop should leave the checkpoint intact so the user can re-run the pop sequence manually.
+
+Then output a summary including:
 - Page creation counts (broken down by all 8 entity types)
 - Domain overview (topics and Summary digest)
 - Overview of extracted claims
 - Number of graph edges
 - Issues found by lint (if any)
 - Initial ideas generated (if any)
+- **Papers we discovered and downloaded** in Step 2 Phase D (listed separately from papers the user provided, so the user can `git rm` any they reject)
+- Whether the pre-init stash was popped cleanly (and how to recover if not)
 - Suggested next steps:
   - Manually `/ingest` more papers
   - Read `wiki/Summary/` for the domain landscape
@@ -457,7 +485,7 @@ Output a summary including:
 
 ## Constraints
 
-- **raw/ is read-only**: do not modify files under `raw/`
+- **raw/ is append-only for `/init`, read-only for everything else**: Step 2 Phase D is the one sanctioned place where `raw/papers/` receives new files (discovered via citation-chain / keyword search). Only additions are allowed — never overwrite or delete an existing `raw/papers/*` entry. All `/ingest` subagents spawned in Step 5 treat `raw/` as strictly read-only (they consume `raw/papers/<slug>/` but never write back)
 - **graph/ maintained via tools only**: do not manually edit files under `graph/`; use `tools/research_wiki.py` exclusively
 - **Bidirectional links**: when writing a forward link, simultaneously write the reverse link (follow the Cross Reference rules in CLAUDE.md)
 - **tex preferred**: .tex > .pdf > vision API fallback
@@ -472,7 +500,7 @@ Output a summary including:
 - **raw/ is empty**: fetch papers via arXiv/S2 search only; note in report
 - **arXiv/S2/DeepXiv search fails**: skip the failing external source, use the remaining available sources + files already in raw/
 - **Single paper ingest fails**: record to checkpoint (`--failed`), skip that paper and continue; list failures in the final report
-- **Interrupted mid-run**: next time `/init` runs, it automatically detects the checkpoint and resumes from where it left off (skipping already-completed papers)
+- **Interrupted mid-run**: next time `/init` runs, it automatically detects the checkpoint and resumes from where it left off (skipping already-completed papers). The `stash_ref` recorded in 4.5.b persists across restarts via checkpoint metadata, so Step 8 of the resumed run will still pop it — do NOT pop the stash at the start of a resumed run, only at Step 8 as usual.
 - **wiki/ already has content**: detect existing pages, skip entities that already exist, only supplement new content (idempotent)
 - **Topic generation uncertain**: prefer fewer and more precise; 2–3 high-quality topics beats 5 vague ones
 - **Worktree isolation appears to have failed** (no worktree branches after Phase A, but `wiki/` is already populated): the subagent prompts likely contained absolute paths. Stop, audit the prompts, fix the orchestrator behavior, and re-run from a clean checkpoint. Do NOT proceed to Phase C without Phase B merge — the wiki will end up with many duplicate concepts and claims.
@@ -490,6 +518,9 @@ Output a summary including:
 - `python3 tools/research_wiki.py rebuild-open-questions wiki/` — rebuild knowledge gap map
 - `python3 tools/research_wiki.py stats wiki/` — wiki statistics
 - `python3 tools/research_wiki.py log wiki/ "<message>"` — append log
+- `python3 tools/research_wiki.py checkpoint-save/load/clear wiki/ init-session ...` — resume support for Step 5 parallel ingest
+- `python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session <key> <value>` — persist cross-step state (e.g. the Step 4.5.b stash ref) in checkpoint metadata
+- `python3 tools/research_wiki.py checkpoint-get-meta wiki/ init-session [<key>]` — read a metadata value (raw) or the whole metadata dict (JSON) in Step 8
 - `python3 tools/fetch_s2.py search "<topic>" 20` — Semantic Scholar keyword search
 - `python3 tools/fetch_s2.py references <arxiv_id>` — citation-chain expansion (references)
 - `python3 tools/fetch_s2.py citations <arxiv_id>` — citation-chain expansion (citations)

--- a/i18n/zh/CLAUDE.md
+++ b/i18n/zh/CLAUDE.md
@@ -369,7 +369,7 @@ python3 tools/fetch_arxiv.py --hours 24
 
 ## 约束
 
-- **raw/ 只读**：不得修改 `raw/` 下的文件。
+- **raw/ 仅 `/init` 可追加写，其它一律只读**：`/init` Step 2 可以把新发现的源文件下载到 `raw/papers/`（只允许新增，绝不覆盖已有文件）。其它所有 skill、tool、subagent（包括 `/ingest`、`/daily-arxiv`、以及 `/init` 在 INIT MODE 下 fan-out 的 `/ingest` subagents）都必须把 `raw/` 视为严格只读：不得修改、覆盖或删除 `raw/` 下的任何内容。
 - **graph/ 自动生成**：不得手动编辑 `graph/` 下的文件，仅通过 `tools/research_wiki.py` 维护。
 - **双向链接**：写正向链接时同步写反向链接。
 - **tex 优先**：.tex > .pdf，fallback 链：tex 失败 → PDF 解析，PDF 失败 → vision API。

--- a/i18n/zh/skills/daily-arxiv/SKILL.md
+++ b/i18n/zh/skills/daily-arxiv/SKILL.md
@@ -191,7 +191,7 @@ argument-hint: "[--hours 24] [--max-ingest 5] [--dry-run]"
 
 - **只 ingest 相关性 >= 3 的论文**：其余留给用户判断，不自动创建 wiki 页面
 - **每次最多 ingest `--max-ingest` 篇**（默认 5）：防止 wiki 单次过载
-- **raw/ 只读**：不得修改 `raw/` 下的文件
+- **`/daily-arxiv` 对 raw/ 严格只读**：不得写入、修改或删除 `raw/` 下的任何内容。（注：`/init` Step 2 是唯一合法的例外——可以向 `raw/papers/` 追加新发现的论文；本 skill 没有这个例外。）
 - **graph/ 仅通过 tools 维护**：不得手动编辑 `graph/` 下的文件
 - **双向链接**：通过 /ingest 保证
 - **去重必须严格**：按 arxiv_url 和 arxiv_id 双重检查

--- a/i18n/zh/skills/init/SKILL.md
+++ b/i18n/zh/skills/init/SKILL.md
@@ -458,13 +458,19 @@ python3 tools/research_wiki.py checkpoint-clear wiki/ "init-session"
 
 ```bash
 STASH_REF=$(python3 tools/research_wiki.py checkpoint-get-meta wiki/ init-session stash_ref)
-if [ -n "$STASH_REF" ]; then
-  git stash pop "$STASH_REF" || echo "⚠ stash pop 失败 — 请 'git stash list' 查看并手工处理"
+if [ -z "$STASH_REF" ]; then
+  # 4.5.b 没有 stash 任何东西（工作树本来就干净）——直接清理 checkpoint。
+  python3 tools/research_wiki.py checkpoint-clear wiki/ init-session
+elif git stash pop "$STASH_REF"; then
+  python3 tools/research_wiki.py checkpoint-clear wiki/ init-session
+else
+  echo "⚠ stash pop 失败 — checkpoint 已保留在 .checkpoints/init-session.json"
+  echo "  请运行 'git stash list' 查看并手工处理，然后再："
+  echo "    python3 tools/research_wiki.py checkpoint-clear wiki/ init-session"
 fi
-python3 tools/research_wiki.py checkpoint-clear wiki/ init-session
 ```
 
-`checkpoint-get-meta` 带 key 时会直接把原始值写到 stdout（不存在时写空字符串），因此 `[ -n "$STASH_REF" ]` 可以安全守护。仅在 pop 成功后才清理 checkpoint；pop 失败应保留 checkpoint 以便用户后续重试。
+`checkpoint-get-meta` 带 key 时会直接把原始值写到 stdout（不存在时写空字符串），因此 `[ -z "$STASH_REF" ]` 能干净地区分"无需 pop"、"pop 成功"、"pop 失败"三种情况。**仅在** pop 成功后才清理 checkpoint——pop 失败**必须**保留 checkpoint（含 `stash_ref` metadata），以便用户手工恢复。不要把这段压缩成 `pop || echo`：`echo` 永远返回 0，会把 pop 的非零退出码吞掉，导致 `checkpoint-clear` 无条件执行并丢失 stash ref。
 
 然后输出摘要，包含：
 - 创建的页面统计（按 8 种 entity 分类）

--- a/i18n/zh/skills/init/SKILL.md
+++ b/i18n/zh/skills/init/SKILL.md
@@ -72,10 +72,7 @@ python3 tools/research_wiki.py init wiki/
 
 若 `wiki/CLAUDE.md` 不存在，从产品模板复制。
 
-记录日志：
-```bash
-python3 tools/research_wiki.py log wiki/ "init | initialized wiki directory structure"
-```
+`init` 命令本身已经自动向 `log.md` 追加了一条 `init | wiki initialized`——不要在此再追加一次。
 
 ### Step 2: 收集 Raw Sources + 智能扩展
 
@@ -127,21 +124,31 @@ python3 tools/fetch_deepxiv.py search "<topic>" --mode hybrid --limit 10
 
 **若 DeepXiv 不可用**：仅依赖 S2 搜索。
 
-#### Phase D — 下载已选论文
+#### Phase D — 下载已选论文（只新增，不覆盖）
 
 对 Phase B + C 选出的每篇论文：
 
-```bash
-# 优先下载 tex source（arXiv e-print）
-curl -sL -o raw/papers/<slug>.tar.gz "https://arxiv.org/e-print/<arxiv_id>"
-mkdir -p raw/papers/<slug> && tar -xzf raw/papers/<slug>.tar.gz -C raw/papers/<slug>/
-rm raw/papers/<slug>.tar.gz
+**已存在则跳过（强制规则）**——下载前先检查 `raw/papers/<slug>/` 或 `raw/papers/<slug>.pdf` 是否已经存在。任一存在，则**完全跳过**本次下载。`/init` 严禁覆盖 `raw/` 下任何已有内容（见 Constraints 段）；用户本地已有的素材是权威。
 
-# 若 e-print 失败或无 arXiv ID，回退到 PDF
-curl -sL -o raw/papers/<slug>.pdf "https://arxiv.org/pdf/<arxiv_id>"
+```bash
+if [ -d "raw/papers/<slug>" ] || [ -f "raw/papers/<slug>.pdf" ]; then
+  echo "skip: raw/papers/<slug> already exists"
+else
+  # 优先下载 tex source（arXiv e-print）
+  curl -sL -o raw/papers/<slug>.tar.gz "https://arxiv.org/e-print/<arxiv_id>"
+  if [ -s raw/papers/<slug>.tar.gz ]; then
+    mkdir -p raw/papers/<slug> && tar -xzf raw/papers/<slug>.tar.gz -C raw/papers/<slug>/
+    rm raw/papers/<slug>.tar.gz
+  else
+    rm -f raw/papers/<slug>.tar.gz
+    # 回退到 PDF
+    curl -sL -o raw/papers/<slug>.pdf "https://arxiv.org/pdf/<arxiv_id>"
+    [ -s raw/papers/<slug>.pdf ] || { rm -f raw/papers/<slug>.pdf; echo "download failed: <slug>"; }
+  fi
+fi
 ```
 
-下载后验证文件有效（非空、内容类型正确）。
+每次下载后验证文件非空（`test -s`）、类型正确；若校验失败，立即删除残留文件并记录失败——永远不要在 `raw/papers/` 里留下 0 字节的空壳。
 
 #### Phase E — 汇总最终来源列表
 
@@ -152,7 +159,7 @@ curl -sL -o raw/papers/<slug>.pdf "https://arxiv.org/pdf/<arxiv_id>"
 python3 tools/research_wiki.py log wiki/ "init | source expansion: <N> local + <M> discovered via citation chains and search"
 ```
 
-**透明度**：在最终报告（Step 8）中，明确区分"用户提供的论文"和"系统发现的论文"，方便用户核实相关性。
+**透明度**：Phase D 下载的论文会永久成为用户 `raw/papers/` 的一部分。Step 8 的最终报告**必须**把它们单独列在"我们发现并下载的论文"一节里（与"用户提供的论文"分开），方便用户检视并 `git rm` 自己不要的那几篇。
 
 ### Step 3: 领域分析
 
@@ -207,7 +214,14 @@ if [ -n "$UNRELATED" ]; then
 fi
 ```
 
-**记录 stash ref**（`git stash list | head -1`）到 `init-session` checkpoint metadata，供 Step 8 在末尾自动 pop 回来。如果无法持久化存储，至少要打印给用户并提醒他们 `/init` 结束后自己 `git stash pop`。
+**记录 stash ref** 到 `init-session` checkpoint 的 metadata，这样即使 `/init` 中途被中断、之后重启，Step 8 也能读回并 pop：
+
+```bash
+STASH_REF=$(git stash list | head -1 | cut -d: -f1)
+python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session stash_ref "$STASH_REF"
+```
+
+这会把 `{"metadata": {"stash_ref": "stash@{0}"}}` 写入 `.checkpoints/init-session.json`；Step 8 在 `checkpoint-clear` 之前通过 `checkpoint-get-meta` 读回。若 4.5.b 的 stash 没有产生任何 entry（没有无关脏文件），跳过本条命令即可——Step 8 读到空字符串时会跳过 pop。
 
 **为什么是 stash 而不是"问用户"**：上一个版本曾要求问用户，而不是自动 stash。那会把脏文件留在工作树里，Phase B 第一次 `git merge` 就会报 `your local changes ... would be overwritten by merge` — 即使那些文件跟合并毫无关系，git 的安全检查也会拒绝在 dirty 工作树上合并。stash → init → pop 才是标准工作流，用户的修改不会丢失。
 
@@ -438,15 +452,29 @@ python3 tools/research_wiki.py checkpoint-clear wiki/ "init-session"
    python3 tools/research_wiki.py log wiki/ "init | completed: N papers, M concepts, K claims, L topics"
    ```
 
-### Step 8: 报告给用户
+### Step 8: 恢复 stash、报告给用户
 
-输出摘要，包含：
+**在报告之前，先把 4.5.b 存起来的 stash 恢复到工作树**。从 checkpoint metadata 读回 stash ref 并 pop：
+
+```bash
+STASH_REF=$(python3 tools/research_wiki.py checkpoint-get-meta wiki/ init-session stash_ref)
+if [ -n "$STASH_REF" ]; then
+  git stash pop "$STASH_REF" || echo "⚠ stash pop 失败 — 请 'git stash list' 查看并手工处理"
+fi
+python3 tools/research_wiki.py checkpoint-clear wiki/ init-session
+```
+
+`checkpoint-get-meta` 带 key 时会直接把原始值写到 stdout（不存在时写空字符串），因此 `[ -n "$STASH_REF" ]` 可以安全守护。仅在 pop 成功后才清理 checkpoint；pop 失败应保留 checkpoint 以便用户后续重试。
+
+然后输出摘要，包含：
 - 创建的页面统计（按 8 种 entity 分类）
 - 领域概况（topics 和 Summary 摘要）
 - 提取的 claims 总览
 - graph edges 数量
 - lint 发现的问题（若有）
 - 生成的初始 ideas（若有）
+- **Step 2 Phase D 新发现并下载的论文**（单独列出，与用户自己提供的论文区分，方便用户 `git rm` 自己不要的那几篇）
+- stash 是否成功 pop（以及 pop 失败时的恢复方式）
 - 建议下一步：
   - 手动 `/ingest` 更多论文
   - 阅读 `wiki/Summary/` 查看领域全景
@@ -455,7 +483,7 @@ python3 tools/research_wiki.py checkpoint-clear wiki/ "init-session"
 
 ## Constraints
 
-- **raw/ 只读**：不得修改 `raw/` 下的文件
+- **raw/ 对 `/init` 是追加写的，其它 skill 只读**：Step 2 Phase D 是 `raw/papers/` 接收新文件的唯一合法入口（通过引用链/关键词搜索发现的论文）。只允许新增，绝不覆盖或删除 `raw/papers/*` 下已有的条目。Step 5 派生出的所有 `/ingest` subagent 都必须把 `raw/` 当成严格只读（只消费 `raw/papers/<slug>/`，绝不回写）
 - **graph/ 仅通过 tools 维护**：不得手动编辑 `graph/` 下的文件
 - **双向链接**：写正向链接时同步写反向链接（参照 CLAUDE.md Cross Reference 规则表）
 - **tex 优先**：.tex > .pdf > vision API fallback
@@ -470,7 +498,7 @@ python3 tools/research_wiki.py checkpoint-clear wiki/ "init-session"
 - **raw/ 为空**：仅通过 arXiv/S2 搜索获取论文，在报告中注明
 - **arXiv/S2/DeepXiv 搜索失败**：跳过失败的外部搜索源，使用其余可用源 + raw/ 中已有文件
 - **单篇论文 ingest 失败**：记录到 checkpoint（`--failed`），跳过该论文继续处理，在最终报告中列出失败项
-- **中途中断**：下次运行 `/init` 时自动检测 checkpoint，从断点继续（跳过已完成的论文）
+- **中途中断**：下次运行 `/init` 时自动检测 checkpoint，从断点继续（跳过已完成的论文）。4.5.b 记录的 `stash_ref` 保存在 checkpoint metadata 里、可跨重启保留，因此**续跑的那次**到 Step 8 仍然会 pop——续跑开始时**不要**先 pop，只在最后 Step 8 pop。
 - **wiki/ 已存在内容**：检测已有页面，跳过已存在的 entity，仅补充新内容（幂等性）
 - **topic 生成不确定**：优先少而准，2-3 个高质量 topic 优于 5 个模糊 topic
 - **worktree 隔离明显失效**（Phase A 后没有 worktree branch 但 `wiki/` 已被写入）：子代理 prompt 很可能含有绝对路径。停止、审计 prompt、修正主流程行为，从干净的 checkpoint 重跑。**绝不可**在缺少 Phase B 合并的情况下进入 Phase C — 这会导致 wiki 含大量重复 concept 和 claim。
@@ -488,6 +516,9 @@ python3 tools/research_wiki.py checkpoint-clear wiki/ "init-session"
 - `python3 tools/research_wiki.py rebuild-open-questions wiki/` — 重建知识缺口地图
 - `python3 tools/research_wiki.py stats wiki/` — wiki 统计
 - `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+- `python3 tools/research_wiki.py checkpoint-save/load/clear wiki/ init-session ...` — Step 5 并行 ingest 的 resume 支持
+- `python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session <key> <value>` — 把跨步骤状态（例如 4.5.b 的 stash ref）持久化到 checkpoint metadata
+- `python3 tools/research_wiki.py checkpoint-get-meta wiki/ init-session [<key>]` — Step 8 读回单个 metadata 值（原始字符串）或整个 metadata dict（JSON）
 - `python3 tools/fetch_s2.py search "<topic>" 20` — Semantic Scholar 关键词搜索
 - `python3 tools/fetch_s2.py references <arxiv_id>` — 引用链扩展（参考文献）
 - `python3 tools/fetch_s2.py citations <arxiv_id>` — 引用链扩展（被引用）

--- a/tests/test_research_wiki.py
+++ b/tests/test_research_wiki.py
@@ -104,10 +104,17 @@ class TestInitWiki:
         assert (wiki / "index.md").read_text() == "custom content"
 
     def test_log_entry_written(self, tmp_path):
+        """init_wiki must append exactly one `init | wiki initialized` line to log.md.
+
+        /init SKILL.md Step 1 deliberately does NOT call `log` manually and relies
+        on this internal append — if this test breaks, revisit init/SKILL.md Step 1.
+        """
         wiki = tmp_path / "wiki"
         rw.init_wiki(str(wiki))
         log = (wiki / "log.md").read_text()
-        assert "init" in log
+        assert "init | wiki initialized" in log
+        # Exactly one init line — guards against accidental double-logging.
+        assert log.count("init | wiki initialized") == 1
 
 
 # ── add_edge ──────────────────────────────────────────────────────────────
@@ -1619,6 +1626,56 @@ class TestCheckpoint:
 
         rw.checkpoint_get_meta(str(wiki), "no-such-task", "")
         assert capsys.readouterr().out.strip() == "{}"
+
+    def test_load_corrupt_checkpoint_reports_error(self, wiki, capsys):
+        """Corrupt JSON must surface as exists:false + error — not silently become an empty checkpoint."""
+        cp_dir = wiki / ".checkpoints"
+        cp_dir.mkdir(parents=True, exist_ok=True)
+        (cp_dir / "corrupt.json").write_text("{not valid json,,,")
+
+        rw.checkpoint_load(str(wiki), "corrupt")
+        out = json.loads(capsys.readouterr().out.strip())
+        assert out["exists"] is False
+        assert out.get("error") == "corrupt checkpoint"
+        assert out["completed"] == []
+        assert out["metadata"] == {}
+
+    def test_load_non_dict_json_reports_error(self, wiki, capsys):
+        """Top-level JSON that isn't a dict (e.g. a list) is also corruption."""
+        cp_dir = wiki / ".checkpoints"
+        cp_dir.mkdir(parents=True, exist_ok=True)
+        (cp_dir / "bad-shape.json").write_text("[]")
+
+        rw.checkpoint_load(str(wiki), "bad-shape")
+        out = json.loads(capsys.readouterr().out.strip())
+        assert out["exists"] is False
+        assert out.get("error") == "corrupt checkpoint"
+
+    def test_set_meta_repairs_corrupt_file(self, wiki):
+        """Writers are permissive: set-meta on a corrupt file silently rewrites it fresh.
+
+        This is intentional — we don't want a one-byte corruption to permanently wedge
+        a long-running /init. The read path (checkpoint_load) still reports the
+        corruption for one call, then the next write repairs it.
+        """
+        cp_dir = wiki / ".checkpoints"
+        cp_dir.mkdir(parents=True, exist_ok=True)
+        (cp_dir / "recover.json").write_text("garbage")
+
+        rw.checkpoint_set_meta(str(wiki), "recover", "stash_ref", "stash@{0}")
+
+        data = json.loads((cp_dir / "recover.json").read_text())
+        assert data["metadata"] == {"stash_ref": "stash@{0}"}
+        assert data["completed"] == []
+        assert data["failed"] == []
+
+    def test_set_meta_unicode_roundtrip(self, wiki, capsys):
+        """ensure_ascii=False should preserve non-ASCII values end-to-end."""
+        rw.checkpoint_set_meta(str(wiki), "i18n", "note", "初始化已完成 ✓")
+        capsys.readouterr()
+
+        rw.checkpoint_get_meta(str(wiki), "i18n", "note")
+        assert capsys.readouterr().out.strip() == "初始化已完成 ✓"
 
     def test_load_old_checkpoint_without_metadata_field(self, wiki, capsys):
         """Backward compat: pre-metadata checkpoints load cleanly."""

--- a/tests/test_research_wiki.py
+++ b/tests/test_research_wiki.py
@@ -1640,15 +1640,21 @@ class TestCheckpoint:
         assert out["completed"] == []
         assert out["metadata"] == {}
 
-    def test_load_non_dict_json_reports_error(self, wiki, capsys):
-        """Top-level JSON that isn't a dict (e.g. a list) is also corruption."""
+    @pytest.mark.parametrize("payload", ["[]", "null", "\"string\"", "42"])
+    def test_load_non_dict_json_reports_error(self, wiki, capsys, payload):
+        """Any top-level JSON that isn't an object is corruption.
+
+        Must cover `null` specifically — it parses to Python None, which is
+        easy to conflate with "parse failed" via a truthy sentinel. The
+        _PARSE_FAILED sentinel in _checkpoint_read distinguishes the two.
+        """
         cp_dir = wiki / ".checkpoints"
         cp_dir.mkdir(parents=True, exist_ok=True)
-        (cp_dir / "bad-shape.json").write_text("[]")
+        (cp_dir / "bad-shape.json").write_text(payload)
 
         rw.checkpoint_load(str(wiki), "bad-shape")
         out = json.loads(capsys.readouterr().out.strip())
-        assert out["exists"] is False
+        assert out["exists"] is False, f"payload {payload!r} should be flagged corrupt"
         assert out.get("error") == "corrupt checkpoint"
 
     def test_set_meta_repairs_corrupt_file(self, wiki):

--- a/tests/test_research_wiki.py
+++ b/tests/test_research_wiki.py
@@ -1555,6 +1555,117 @@ class TestCheckpoint:
         out = json.loads(capsys.readouterr().out.strip().split("\n")[-1])
         assert out["cleared"] is True
 
+    # ── metadata ───────────────────────────────────────────────────────────
+
+    def test_set_meta_creates_file(self, wiki):
+        """set_meta on a task with no existing checkpoint creates the file."""
+        rw.checkpoint_set_meta(str(wiki), "meta-new", "stash_ref", "stash@{0}")
+
+        cp_file = wiki / ".checkpoints" / "meta-new.json"
+        assert cp_file.exists()
+        data = json.loads(cp_file.read_text())
+        assert data["metadata"] == {"stash_ref": "stash@{0}"}
+        assert data["completed"] == []
+        assert data["failed"] == []
+
+    def test_set_meta_preserves_lists(self, wiki):
+        """set_meta must not clobber pre-existing completed/failed lists."""
+        rw.checkpoint_save(str(wiki), "meta-task", "paper-1")
+        rw.checkpoint_save(str(wiki), "meta-task", "paper-2", status="failed")
+        rw.checkpoint_set_meta(str(wiki), "meta-task", "stash_ref", "stash@{2}")
+
+        data = json.loads((wiki / ".checkpoints" / "meta-task.json").read_text())
+        assert data["completed"] == ["paper-1"]
+        assert data["failed"] == ["paper-2"]
+        assert data["metadata"]["stash_ref"] == "stash@{2}"
+
+    def test_set_meta_overwrites_value_but_not_sibling_keys(self, wiki):
+        """Re-setting the same key updates it; other keys survive."""
+        rw.checkpoint_set_meta(str(wiki), "meta-task", "stash_ref", "stash@{0}")
+        rw.checkpoint_set_meta(str(wiki), "meta-task", "run_id", "abc")
+        rw.checkpoint_set_meta(str(wiki), "meta-task", "stash_ref", "stash@{1}")
+
+        data = json.loads((wiki / ".checkpoints" / "meta-task.json").read_text())
+        assert data["metadata"] == {"stash_ref": "stash@{1}", "run_id": "abc"}
+
+    def test_get_meta_single_key(self, wiki, capsys):
+        rw.checkpoint_set_meta(str(wiki), "meta-task", "stash_ref", "stash@{0}")
+        capsys.readouterr()  # clear save output
+
+        rw.checkpoint_get_meta(str(wiki), "meta-task", "stash_ref")
+        assert capsys.readouterr().out.strip() == "stash@{0}"
+
+    def test_get_meta_missing_key_prints_empty(self, wiki, capsys):
+        """A missing key prints an empty line, exit 0 — safe for bash capture."""
+        rw.checkpoint_set_meta(str(wiki), "meta-task", "other", "x")
+        capsys.readouterr()
+
+        rw.checkpoint_get_meta(str(wiki), "meta-task", "stash_ref")
+        assert capsys.readouterr().out.strip() == ""
+
+    def test_get_meta_no_key_prints_dict(self, wiki, capsys):
+        rw.checkpoint_set_meta(str(wiki), "meta-task", "stash_ref", "stash@{0}")
+        rw.checkpoint_set_meta(str(wiki), "meta-task", "run_id", "abc")
+        capsys.readouterr()
+
+        rw.checkpoint_get_meta(str(wiki), "meta-task", "")
+        out = json.loads(capsys.readouterr().out.strip())
+        assert out == {"stash_ref": "stash@{0}", "run_id": "abc"}
+
+    def test_get_meta_nonexistent_task(self, wiki, capsys):
+        """Reading meta on a task with no checkpoint file returns empty."""
+        rw.checkpoint_get_meta(str(wiki), "no-such-task", "anything")
+        assert capsys.readouterr().out.strip() == ""
+
+        rw.checkpoint_get_meta(str(wiki), "no-such-task", "")
+        assert capsys.readouterr().out.strip() == "{}"
+
+    def test_load_old_checkpoint_without_metadata_field(self, wiki, capsys):
+        """Backward compat: pre-metadata checkpoints load cleanly."""
+        cp_dir = wiki / ".checkpoints"
+        cp_dir.mkdir(parents=True, exist_ok=True)
+        (cp_dir / "legacy.json").write_text(
+            json.dumps({"task_id": "legacy", "completed": ["a"], "failed": []}))
+
+        rw.checkpoint_load(str(wiki), "legacy")
+        out = json.loads(capsys.readouterr().out.strip())
+        assert out["exists"] is True
+        assert out["completed"] == ["a"]
+        assert out["metadata"] == {}
+
+    def test_cli_set_get_meta(self, tmp_path):
+        """End-to-end: CLI set-meta → CLI get-meta round-trip."""
+        TOOL = str(Path(__file__).resolve().parent.parent / "tools" / "research_wiki.py")
+        wiki = tmp_path / "wiki"
+        subprocess.run([sys.executable, TOOL, "init", str(wiki)],
+                       capture_output=True)
+
+        subprocess.run(
+            [sys.executable, TOOL, "checkpoint-set-meta",
+             str(wiki), "init-session", "stash_ref", "stash@{0}"],
+            capture_output=True, check=True)
+
+        # Single key → raw value on stdout (shell-capture-friendly)
+        result = subprocess.run(
+            [sys.executable, TOOL, "checkpoint-get-meta",
+             str(wiki), "init-session", "stash_ref"],
+            capture_output=True, text=True, check=True)
+        assert result.stdout.strip() == "stash@{0}"
+
+        # No key → JSON dict
+        result = subprocess.run(
+            [sys.executable, TOOL, "checkpoint-get-meta",
+             str(wiki), "init-session"],
+            capture_output=True, text=True, check=True)
+        assert json.loads(result.stdout) == {"stash_ref": "stash@{0}"}
+
+        # Missing key → empty output, exit 0
+        result = subprocess.run(
+            [sys.executable, TOOL, "checkpoint-get-meta",
+             str(wiki), "init-session", "missing"],
+            capture_output=True, text=True, check=True)
+        assert result.stdout.strip() == ""
+
     def test_cli_checkpoint_roundtrip(self, tmp_path):
         TOOL = str(Path(__file__).resolve().parent.parent / "tools" / "research_wiki.py")
         wiki = tmp_path / "wiki"

--- a/tests/test_skill_init.py
+++ b/tests/test_skill_init.py
@@ -341,8 +341,17 @@ class TestSubagentIngest:
 class TestConstraints:
     """Constraints match CLAUDE.md rules."""
 
-    def test_raw_readonly(self, skill_content):
-        assert "raw/ 只读" in skill_content or "raw/ is read-only" in skill_content.lower()
+    def test_raw_append_only_constraint(self, skill_content):
+        """Init is the one sanctioned place that may append to raw/papers/; everything else is read-only.
+
+        Accepts either the English or Chinese phrasing of the two-tier rule.
+        """
+        lowered = skill_content.lower()
+        en_ok = "raw/ is append-only" in lowered and "read-only" in lowered
+        zh_ok = "raw/ 对 `/init` 是追加写的" in skill_content or "追加写" in skill_content
+        assert en_ok or zh_ok, \
+            "init SKILL.md must document the two-tier raw/ rule " \
+            "(append-only for /init, read-only for everything else)"
 
     def test_graph_via_tools(self, skill_content):
         assert "graph/" in skill_content and "tools" in skill_content.lower()

--- a/tools/research_wiki.py
+++ b/tools/research_wiki.py
@@ -1941,21 +1941,32 @@ def _checkpoint_path(wiki_root: str, task_id: str) -> Path:
     return Path(wiki_root) / ".checkpoints" / f"{task_id}.json"
 
 
-def _checkpoint_read(wiki_root: str, task_id: str) -> dict:
+def _checkpoint_read(wiki_root: str, task_id: str, strict: bool = False) -> dict:
     """Load a checkpoint file and normalize it to the current schema.
 
     Backward-compat: old checkpoints written before the `metadata` field existed
     load cleanly — the missing key is filled with an empty dict on next write.
+
+    strict=False (default, used by writers like checkpoint_save / checkpoint_set_meta):
+        Corrupt files are silently treated as empty so the next write repairs them.
+        A non-dict top-level JSON (e.g. `[]` or `"null"`) is also ignored.
+    strict=True (used by checkpoint_load):
+        Re-raises json.JSONDecodeError and raises ValueError on non-dict top-level JSON.
+        Lets checkpoint_load surface an explicit corruption report to the caller.
     """
     cp_file = _checkpoint_path(wiki_root, task_id)
     data = {"task_id": task_id, "completed": [], "failed": [], "metadata": {}}
     if cp_file.exists():
         try:
             loaded = json.loads(cp_file.read_text(encoding="utf-8"))
-            if isinstance(loaded, dict):
-                data.update(loaded)
         except json.JSONDecodeError:
-            pass
+            if strict:
+                raise
+            loaded = None
+        if isinstance(loaded, dict):
+            data.update(loaded)
+        elif loaded is not None and strict:
+            raise ValueError("checkpoint top-level JSON is not an object")
     data.setdefault("completed", [])
     data.setdefault("failed", [])
     data.setdefault("metadata", {})
@@ -2018,7 +2029,13 @@ def checkpoint_get_meta(wiki_root: str, task_id: str, key: str = "") -> None:
 
 
 def checkpoint_load(wiki_root: str, task_id: str) -> None:
-    """Load checkpoint state for a task. Returns JSON with completed/failed/metadata."""
+    """Load checkpoint state for a task. Returns JSON with completed/failed/metadata.
+
+    A missing file reports `exists: false` with empty lists/dict.
+    A corrupt or non-dict file reports `exists: false` with `error: "corrupt checkpoint"`
+    — the writers (checkpoint_save / checkpoint_set_meta) will silently repair it on
+    the next write, but the read path surfaces the corruption so tooling can flag it.
+    """
     cp_file = _checkpoint_path(wiki_root, task_id)
 
     if not cp_file.exists():
@@ -2027,13 +2044,15 @@ def checkpoint_load(wiki_root: str, task_id: str) -> None:
         return
 
     try:
-        data = _checkpoint_read(wiki_root, task_id)
-        data["exists"] = True
-        print(json.dumps(data))
-    except json.JSONDecodeError:
+        data = _checkpoint_read(wiki_root, task_id, strict=True)
+    except (json.JSONDecodeError, ValueError):
         print(json.dumps({"task_id": task_id, "completed": [], "failed": [],
                           "metadata": {}, "exists": False,
                           "error": "corrupt checkpoint"}))
+        return
+
+    data["exists"] = True
+    print(json.dumps(data))
 
 
 def checkpoint_clear(wiki_root: str, task_id: str) -> None:

--- a/tools/research_wiki.py
+++ b/tools/research_wiki.py
@@ -1956,16 +1956,18 @@ def _checkpoint_read(wiki_root: str, task_id: str, strict: bool = False) -> dict
     """
     cp_file = _checkpoint_path(wiki_root, task_id)
     data = {"task_id": task_id, "completed": [], "failed": [], "metadata": {}}
+    _PARSE_FAILED = object()  # sentinel: distinguishes parse-failed from parsed-to-None
     if cp_file.exists():
         try:
             loaded = json.loads(cp_file.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
             if strict:
                 raise
-            loaded = None
+            loaded = _PARSE_FAILED
         if isinstance(loaded, dict):
             data.update(loaded)
-        elif loaded is not None and strict:
+        elif loaded is not _PARSE_FAILED and strict:
+            # loaded parsed successfully but is not a dict (e.g. null, [], "str", 42)
             raise ValueError("checkpoint top-level JSON is not an object")
     data.setdefault("completed", [])
     data.setdefault("failed", [])

--- a/tools/research_wiki.py
+++ b/tools/research_wiki.py
@@ -43,6 +43,8 @@ Commands:
     checkpoint-save <wiki_root> <task_id> <item> [--failed]
     checkpoint-load <wiki_root> <task_id>
     checkpoint-clear <wiki_root> <task_id>
+    checkpoint-set-meta <wiki_root> <task_id> <key> <value>
+    checkpoint-get-meta <wiki_root> <task_id> [<key>]
 """
 
 from __future__ import annotations
@@ -1935,47 +1937,103 @@ def set_meta(path: str, field: str, value: str, append: bool = False) -> None:
 # Checkpoint management (for resumable batch operations)
 # ---------------------------------------------------------------------------
 
+def _checkpoint_path(wiki_root: str, task_id: str) -> Path:
+    return Path(wiki_root) / ".checkpoints" / f"{task_id}.json"
+
+
+def _checkpoint_read(wiki_root: str, task_id: str) -> dict:
+    """Load a checkpoint file and normalize it to the current schema.
+
+    Backward-compat: old checkpoints written before the `metadata` field existed
+    load cleanly — the missing key is filled with an empty dict on next write.
+    """
+    cp_file = _checkpoint_path(wiki_root, task_id)
+    data = {"task_id": task_id, "completed": [], "failed": [], "metadata": {}}
+    if cp_file.exists():
+        try:
+            loaded = json.loads(cp_file.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                data.update(loaded)
+        except json.JSONDecodeError:
+            pass
+    data.setdefault("completed", [])
+    data.setdefault("failed", [])
+    data.setdefault("metadata", {})
+    if not isinstance(data["metadata"], dict):
+        data["metadata"] = {}
+    return data
+
+
+def _checkpoint_write(wiki_root: str, task_id: str, data: dict) -> None:
+    cp_dir = Path(wiki_root) / ".checkpoints"
+    cp_dir.mkdir(parents=True, exist_ok=True)
+    cp_file = cp_dir / f"{task_id}.json"
+    cp_file.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
 def checkpoint_save(wiki_root: str, task_id: str, item: str,
                     status: str = "completed") -> None:
     """Record an item as completed/failed in a checkpoint file."""
-    root = Path(wiki_root)
-    cp_dir = root / ".checkpoints"
-    cp_dir.mkdir(parents=True, exist_ok=True)
-    cp_file = cp_dir / f"{task_id}.json"
-
-    data = {"task_id": task_id, "completed": [], "failed": []}
-    if cp_file.exists():
-        try:
-            data = json.loads(cp_file.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            pass
+    data = _checkpoint_read(wiki_root, task_id)
 
     target_list = "completed" if status == "completed" else "failed"
     if item not in data[target_list]:
         data[target_list].append(item)
 
-    cp_file.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    _checkpoint_write(wiki_root, task_id, data)
     print(json.dumps({"status": "ok", "task_id": task_id,
                       "item": item, "item_status": status}))
 
 
+def checkpoint_set_meta(wiki_root: str, task_id: str, key: str, value: str) -> None:
+    """Persist a key/value pair in the checkpoint's metadata dict.
+
+    Creates the checkpoint file if it does not exist. Preserves the existing
+    completed/failed lists. Designed for small pieces of cross-step state
+    like the `/init` stash ref that must survive an interrupted run.
+    """
+    data = _checkpoint_read(wiki_root, task_id)
+    data["metadata"][key] = value
+    _checkpoint_write(wiki_root, task_id, data)
+    print(json.dumps({"status": "ok", "task_id": task_id,
+                      "key": key, "value": value}))
+
+
+def checkpoint_get_meta(wiki_root: str, task_id: str, key: str = "") -> None:
+    """Read a metadata value (by key) or the whole metadata dict (if key is empty).
+
+    - With a key: prints the raw value (empty string if missing). Exit code 0 either way.
+    - Without a key: prints the metadata dict as JSON.
+    Useful for bash capture via `$(...)` — a missing key prints nothing, so
+    callers can safely `[ -n "$x" ]` to check.
+    """
+    data = _checkpoint_read(wiki_root, task_id)
+    meta = data.get("metadata", {})
+    if key:
+        value = meta.get(key, "")
+        # Print a raw value (no JSON wrapping) so shell capture is clean.
+        print(value)
+    else:
+        print(json.dumps(meta, ensure_ascii=False))
+
+
 def checkpoint_load(wiki_root: str, task_id: str) -> None:
-    """Load checkpoint state for a task. Returns JSON with completed/failed lists."""
-    root = Path(wiki_root)
-    cp_file = root / ".checkpoints" / f"{task_id}.json"
+    """Load checkpoint state for a task. Returns JSON with completed/failed/metadata."""
+    cp_file = _checkpoint_path(wiki_root, task_id)
 
     if not cp_file.exists():
         print(json.dumps({"task_id": task_id, "completed": [], "failed": [],
-                          "exists": False}))
+                          "metadata": {}, "exists": False}))
         return
 
     try:
-        data = json.loads(cp_file.read_text(encoding="utf-8"))
+        data = _checkpoint_read(wiki_root, task_id)
         data["exists"] = True
         print(json.dumps(data))
     except json.JSONDecodeError:
         print(json.dumps({"task_id": task_id, "completed": [], "failed": [],
-                          "exists": False, "error": "corrupt checkpoint"}))
+                          "metadata": {}, "exists": False,
+                          "error": "corrupt checkpoint"}))
 
 
 def checkpoint_clear(wiki_root: str, task_id: str) -> None:
@@ -2132,6 +2190,22 @@ def main():
     p.add_argument("wiki_root")
     p.add_argument("task_id")
 
+    # checkpoint-set-meta
+    p = sub.add_parser("checkpoint-set-meta",
+                       help="Persist a key/value pair in checkpoint metadata")
+    p.add_argument("wiki_root")
+    p.add_argument("task_id")
+    p.add_argument("key")
+    p.add_argument("value")
+
+    # checkpoint-get-meta
+    p = sub.add_parser("checkpoint-get-meta",
+                       help="Read a metadata value (raw) or the whole metadata dict (JSON)")
+    p.add_argument("wiki_root")
+    p.add_argument("task_id")
+    p.add_argument("key", nargs="?", default="",
+                   help="If given, print the raw value; otherwise print the whole metadata dict as JSON")
+
     args = parser.parse_args()
 
     if args.command == "init":
@@ -2213,6 +2287,10 @@ def main():
         checkpoint_load(args.wiki_root, args.task_id)
     elif args.command == "checkpoint-clear":
         checkpoint_clear(args.wiki_root, args.task_id)
+    elif args.command == "checkpoint-set-meta":
+        checkpoint_set_meta(args.wiki_root, args.task_id, args.key, args.value)
+    elif args.command == "checkpoint-get-meta":
+        checkpoint_get_meta(args.wiki_root, args.task_id, args.key)
     else:
         parser.print_help()
         sys.exit(1)


### PR DESCRIPTION
## Summary

Fixes three P0 inconsistencies between `/init` SKILL.md and the `tools/research_wiki.py` implementation, flagged by an external review of the current `/init` flow. Each was verified against source before fixing.

- **A. `raw/` read-only contract contradicted itself.** `CLAUDE.md` + `init/SKILL.md` constraint blocks said `raw/ is read-only`, but `/init` Step 2 Phase D downloaded new arXiv sources into `raw/papers/` and Step 4.5.c `git add`-ed them. Relaxed the constraint to a two-tier rule: `/init` Step 2 may **append** new files to `raw/papers/` (additions only, skip-if-exists guard, no overwrites), every other skill/tool/subagent stays strictly read-only. Hardened Phase D with directory+PDF existence checks and zero-byte cleanup. Step 8 report must now list discovered papers separately so the user can `git rm` any they reject.

- **B. Double logging on fresh wiki.** `research_wiki.py` `init_wiki()` already appends `init | wiki initialized` to `log.md` internally; `init/SKILL.md` Step 1 then asked Claude to append a second nearly-identical line. Deleted the skill's manual call; kept the tool's internal one (smaller blast radius, the tool owns the invariant). Tightened `test_log_entry_written` to assert the exact line appears exactly once.

- **C. Checkpoint metadata field didn't exist.** `init/SKILL.md` Step 4.5.b told Claude to persist the Step-4.5.b `git stash` ref into `init-session` checkpoint metadata so Step 8 could pop it back after an interrupted/resumed run — but the checkpoint JSON only had `{task_id, completed, failed}`, no metadata field. Extended the schema with `metadata: {}`, added `checkpoint-set-meta` and `checkpoint-get-meta` CLI subcommands (raw value on stdout for shell capture, full dict as JSON with no key). Rewired Step 4.5.b to issue a concrete `set-meta` call and Step 8 to `get-meta` → `git stash pop` → `checkpoint-clear`. Backward compatible with pre-metadata checkpoint files.

## Review rounds

Two independent review passes caught additional bugs, each fixed in its own follow-up commit:

**Round 1 (commit `d91b06f`):**
- **Step 8 stash pop ordering bug.** Original form `git stash pop "\$STASH_REF" || echo ...` followed by unconditional `checkpoint-clear` silently swallowed pop failures (`echo` always exits 0), losing `stash_ref` from durable storage — the exact opposite of the documented intent. Replaced with an explicit three-way `if -z / elif pop / else` block: empty ref → clear only; successful pop → clear; failed pop → preserve checkpoint + print recovery instructions. Applied to both `en` and `zh`.
- **`checkpoint_load` corrupt-detection regression.** The schema refactor made `_checkpoint_read` swallow `JSONDecodeError`, turning the `try/except` in `checkpoint_load` into dead code. Corrupt files reported as `exists:true, completed:[]` instead of `exists:false, error:"corrupt checkpoint"`, and the next write silently overwrote the corruption. Added `strict=True` mode to `_checkpoint_read` that re-raises `JSONDecodeError` and rejects non-dict top-level JSON with `ValueError`. `checkpoint_load` uses strict mode; writers stay permissive so a one-byte corruption can't wedge a long-running `/init`.

**Round 2 (commit `e2b9313`):**
- **Top-level `null` JSON still read as empty-but-existing in strict mode.** `_checkpoint_read`'s guard used `loaded is not None` to distinguish "parse failed" from "parsed to non-dict", but JSON `null` parses to Python `None`, hitting neither branch and returning a fresh default dict — contradicting the docstring. Replaced with a `_PARSE_FAILED` sentinel so the two cases are cleanly disambiguated. Parametrized `test_load_non_dict_json_reports_error` over \`[[], null, "string", 42]\` to cover all four non-dict shapes.

## Test plan

- [x] `python -m pytest tests/ -q` — **2316 passed** (was 2309 at branch base; +7 net new tests)
- [x] Ran under both `./setup.sh --lang en` and `./setup.sh --lang zh` — full suite passes in both
- [x] Smoke-tested `tools/research_wiki.py init /tmp/scratch/wiki/` — `log.md` shows exactly one `init | wiki initialized` line (fix B)
- [x] Smoke-tested `checkpoint-set-meta` → `checkpoint-get-meta` → `checkpoint-load` round-trip — metadata surfaces through all three paths
- [x] Smoke-tested corrupt checkpoint file: `checkpoint-load` reports `exists:false, error:"corrupt checkpoint"` (fix round 1)
- [x] Smoke-tested each Step 8 branch (empty `STASH_REF`, successful pop, failed pop) — only the success path clears the checkpoint
- [x] i18n/en and i18n/zh verified in parity for all three fixes, including the Step 8 three-way branch

## Files changed

**Code:**
- `tools/research_wiki.py` — checkpoint schema + `_checkpoint_read`/`_checkpoint_write` helpers + `set-meta`/`get-meta` functions + CLI subcommands
- `tests/test_research_wiki.py` — 13 new/tightened tests (checkpoint metadata happy paths, corrupt detection across 4 non-dict shapes, writer self-heal, unicode round-trip, init log exact-count)
- `tests/test_skill_init.py` — `test_raw_readonly` → `test_raw_append_only_constraint`, accepts either en/zh phrasing

**Docs (English canonical):**
- `i18n/en/CLAUDE.md` — rewrote `raw/` constraint line
- `i18n/en/skills/init/SKILL.md` — Step 1 (no manual log), Step 2 Phase D (skip-if-exists), Phase E (report transparency), Step 4.5.b (concrete `set-meta` call), Step 8 (three-way stash pop + discovered-papers reporting), Constraints, Error Handling, Dependencies
- `i18n/en/skills/daily-arxiv/SKILL.md` — clarifying note on the two-tier asymmetry

**Docs (Chinese mirror):**
- `i18n/zh/CLAUDE.md`, `i18n/zh/skills/init/SKILL.md`, `i18n/zh/skills/daily-arxiv/SKILL.md` — parallel changes

**Active copies** (synced by `setup.sh`):
- `CLAUDE.md`, `.claude/skills/init/SKILL.md`, `.claude/skills/daily-arxiv/SKILL.md`

## Commits

- `5243790` fix(init): resolve 3 spec/impl inconsistencies in /init
- `d91b06f` fix(init): address review feedback — stash-pop ordering + corrupt detection
- `e2b9313` fix(checkpoint): treat top-level \`null\` JSON as corrupt in strict mode

## Known follow-ups (non-blocking, not in this PR)

- `_checkpoint_write` is not atomic (no temp+`os.replace`). Now load-bearing given the documented permissive-writer policy — worth a dedicated PR with crash-mid-write tests.
- Phase D skip-if-exists guard doesn't detect stranded `.tar.gz` from a crashed prior run or partial extractions missing a `.tex` file.
- Defensive `STASH_REF` whitespace stripping in Step 8 (cosmetic).
- Concurrent checkpoint writers are not tested (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)