### PR TITLE
fix(init): centralize schema constants, add topic-backfill, fix xref repair

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,18 +352,26 @@ claims:
 
 Before running any Python tool, ensure the correct environment is active. Detection priority:
 
-1. **Check for `.venv/`**: if present, prefix Bash commands with `source .venv/bin/activate &&`
+1. **Check for `.venv/`**: if present, use the venv interpreter directly — cross-platform safe.
+   - Unix/macOS: `.venv/bin/python` exists → call `.venv/bin/python tools/X.py`
+   - Windows: `.venv/Scripts/python.exe` exists → call `.venv/Scripts/python.exe tools/X.py`
 2. **Check for conda**: if no venv but conda is active, use `conda run -n <env>` or confirm env is activated
-3. **System Python**: if neither exists, use `python3` directly
+3. **System Python**: if neither exists, use `python3` (Unix/macOS) or `python` (Windows) directly
 
 **Example — calling a tool:**
 ```bash
-# If .venv/ exists
-source .venv/bin/activate && python3 tools/fetch_arxiv.py --hours 24
+# Unix/macOS, .venv/ exists
+.venv/bin/python tools/fetch_arxiv.py --hours 24
 
-# If no venv
-python3 tools/fetch_arxiv.py --hours 24
+# Windows, .venv/ exists (Git Bash or PowerShell both accept forward slashes)
+.venv/Scripts/python.exe tools/fetch_arxiv.py --hours 24
+
+# No venv
+python3 tools/fetch_arxiv.py --hours 24      # Unix/macOS
+python tools/fetch_arxiv.py --hours 24       # Windows
 ```
+
+Calling the venv interpreter directly avoids needing to `source activate` (Unix) vs `Activate.ps1` (Windows), and works identically across platforms.
 
 **Environment variables**: all Python tools auto-load API keys from `~/.env` and the project root `.env` via `tools/_env.py` — no manual `export` needed.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ npm install -g @anthropic-ai/claude-code
 claude login
 
 # 3. One-click setup
-chmod +x setup.sh && ./setup.sh
+chmod +x setup.sh && ./setup.sh        # Linux / macOS
+# Windows (PowerShell):
+#   powershell -ExecutionPolicy Bypass -File .\setup.ps1
 
 # 4. Put your papers in raw/papers/ (.tex or .pdf)
 
@@ -75,7 +77,7 @@ claude
 ```
 
 <details>
-<summary><b>Manual setup</b></summary>
+<summary><b>Manual setup (Linux / macOS)</b></summary>
 
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
@@ -83,6 +85,23 @@ pip install -r requirements.txt
 cp .env.example .env                 # Edit to add API keys
 cp config/settings.local.json.example .claude/settings.local.json
 ```
+
+</details>
+
+<details>
+<summary><b>Manual setup (Windows / PowerShell)</b></summary>
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+Copy-Item .env.example .env          # Edit to add API keys
+Copy-Item config\settings.local.json.example .claude\settings.local.json
+```
+
+Note: native Windows is supported for the local pipeline. Remote-GPU
+experiments via `/exp-run --env remote` rely on `ssh`/`rsync`/`screen`
+and are best run from WSL2 or Linux/macOS.
 
 </details>
 
@@ -301,13 +320,17 @@ npm install -g @anthropic-ai/claude-code
 claude login
 
 # 一键配置
-chmod +x setup.sh && ./setup.sh --lang zh
+chmod +x setup.sh && ./setup.sh --lang zh        # Linux / macOS
+# Windows (PowerShell):
+#   powershell -ExecutionPolicy Bypass -File .\setup.ps1 -Lang zh
 
 # 把论文放入 raw/papers/（.tex 或 .pdf）
 # 启动 Claude Code
 claude
 # 输入：/init <你的研究方向>
 ```
+
+> **Windows 用户**：本地 pipeline 已原生支持。`/exp-run --env remote` 远程 GPU 实验依赖 `ssh`/`rsync`/`screen`，建议在 WSL2 或 Linux/macOS 下运行。
 
 ### API Key 说明
 

--- a/i18n/en/CLAUDE.md
+++ b/i18n/en/CLAUDE.md
@@ -352,18 +352,26 @@ claims:
 
 Before running any Python tool, ensure the correct environment is active. Detection priority:
 
-1. **Check for `.venv/`**: if present, prefix Bash commands with `source .venv/bin/activate &&`
+1. **Check for `.venv/`**: if present, use the venv interpreter directly — cross-platform safe.
+   - Unix/macOS: `.venv/bin/python` exists → call `.venv/bin/python tools/X.py`
+   - Windows: `.venv/Scripts/python.exe` exists → call `.venv/Scripts/python.exe tools/X.py`
 2. **Check for conda**: if no venv but conda is active, use `conda run -n <env>` or confirm env is activated
-3. **System Python**: if neither exists, use `python3` directly
+3. **System Python**: if neither exists, use `python3` (Unix/macOS) or `python` (Windows) directly
 
 **Example — calling a tool:**
 ```bash
-# If .venv/ exists
-source .venv/bin/activate && python3 tools/fetch_arxiv.py --hours 24
+# Unix/macOS, .venv/ exists
+.venv/bin/python tools/fetch_arxiv.py --hours 24
 
-# If no venv
-python3 tools/fetch_arxiv.py --hours 24
+# Windows, .venv/ exists (Git Bash or PowerShell both accept forward slashes)
+.venv/Scripts/python.exe tools/fetch_arxiv.py --hours 24
+
+# No venv
+python3 tools/fetch_arxiv.py --hours 24      # Unix/macOS
+python tools/fetch_arxiv.py --hours 24       # Windows
 ```
+
+Calling the venv interpreter directly avoids needing to `source activate` (Unix) vs `Activate.ps1` (Windows), and works identically across platforms.
 
 **Environment variables**: all Python tools auto-load API keys from `~/.env` and the project root `.env` via `tools/_env.py` — no manual `export` needed.
 

--- a/i18n/en/skills/exp-design/SKILL.md
+++ b/i18n/en/skills/exp-design/SKILL.md
@@ -58,14 +58,14 @@ argument-hint: <idea-slug-or-hypothesis> [--review] [--budget <gpu-hours>]
 ### Step 1: Load Context
 
 1. **Parse idea input**:
-   - If slug: read `wiki/ideas/{slug}.md`, extract hypothesis, approach sketch, risks, origin_gaps, linked_papers
+   - If slug: read `wiki/ideas/{slug}.md`, extract `## Motivation`, `## Hypothesis`, `## Approach sketch`, `## Risks`, and the frontmatter fields `origin_gaps`, `tags`, `domain`, `priority` (per CLAUDE.md ideas template)
    - If free text: use directly as the hypothesis description
 2. **Load relevant wiki context**:
    - Read `wiki/graph/context_brief.md` (global context)
    - Read `wiki/graph/open_questions.md` (knowledge gaps)
-   - From idea's origin_gaps, read the corresponding `wiki/claims/*.md` (target claims)
+   - From the idea's `origin_gaps`, read the corresponding `wiki/claims/*.md` (target claims)
+   - From each target claim's `source_papers` field, read the corresponding `wiki/papers/*.md` for baseline setups and prior experiment protocols — this is the canonical path from idea → claim → paper (ideas do **not** carry a `linked_papers` field; use `origin_gaps` → `source_papers` instead)
    - Read existing `wiki/experiments/*.md` to check for similar experiments
-   - Read `wiki/papers/*.md` for related papers' experiment setups (as baseline reference)
 3. **If idea has no origin_gaps**: extract implied claims from the hypothesis description; search wiki/claims/ or flag as needing new claim creation
 
 ### Step 2: Scope Claims
@@ -92,7 +92,7 @@ Design experiment blocks for each scoped claim. Four types:
 **A. Baseline experiments (reproduce baseline)**:
 - Purpose: confirm the problem exists and the baseline is reproducible
 - Reproduce the core experiment from the most relevant paper
-- Success criterion: baseline results deviate < 5% from reported paper values
+- Success criterion: baseline results deviate < 5% from reported paper values (this threshold is the same one used by the Stage 1 decision gate below — do not introduce a different number elsewhere)
 - Compute: typically minimal
 
 **B. Validation experiments (validate Target claim)**:
@@ -136,7 +136,7 @@ Stage 0: Sanity check
 
 Stage 1: Baseline (reproduce baseline)
   └── Reproduce baseline results
-  └── Gate: baseline deviation > 10% → stop, check implementation
+  └── Gate: baseline deviation > 5% → stop, check implementation (same threshold as Step 3 success criterion)
 
 Stage 2: Validation (core verification)
   └── Validate core method on top of baseline
@@ -191,6 +191,7 @@ Revise the experiment plan based on Review LLM feedback (add missing experiments
    python3 tools/research_wiki.py slug "<experiment-title>"
    ```
    Create `wiki/experiments/{slug}.md`:
+   Create `wiki/experiments/{slug}.md` following the **CLAUDE.md experiments template exactly** — every field below must be present even if empty, because `/exp-run` later uses `tools/research_wiki.py set-meta` to update them, and `set-meta` refuses to create fields that don't already exist in the frontmatter (it only updates existing keys):
    ```yaml
    ---
    title: ""
@@ -207,12 +208,20 @@ Revise the experiment plan based on Review LLM feedback (add missing experiments
      framework: ""
    metrics: []
    baseline: ""
-   outcome: ""
-   key_result: ""
-   linked_idea: ""           # idea slug
+   outcome: ""                # empty until /exp-run Phase 4 — succeeded | failed | inconclusive
+   key_result: ""             # empty until /exp-run Phase 4
+   linked_idea: "{idea-slug}" # MANDATORY: the source idea slug (reverse link to wiki/ideas/{idea-slug}.md linked_experiments)
    date_planned: YYYY-MM-DD
-   date_completed: ""
-   run_log: ""
+   date_completed: ""         # empty until /exp-run Phase 4
+   run_log: ""                # empty until /exp-run Phase 2
+   started: ""                # empty until /exp-run Phase 2 (ISO timestamp, set via set-meta)
+   estimated_hours: 0         # 0 until /exp-run Phase 2 (set via set-meta)
+   remote:                    # full block must exist so /exp-run --env remote can populate sub-fields via Edit
+     server: ""
+     gpu: ""
+     session: ""
+     started: ""
+     completed: ""
    ---
 
    ## Objective

--- a/i18n/en/skills/exp-run/SKILL.md
+++ b/i18n/en/skills/exp-run/SKILL.md
@@ -175,10 +175,24 @@ argument-hint: <experiment-slug> [--review] [--collect] [--full] [--env local|re
      --cmd "bash experiments/code/{slug}/run.sh" \
      --gpu {gpu_index}
    ```
-6. Update `wiki/experiments/{slug}.md`:
-   - status: `running`
-   - run_log: `logs/exp-{slug}.log`
-   - Add `remote:` block to frontmatter (server, gpu, session, started)
+6. Update `wiki/experiments/{slug}.md` frontmatter — all of these fields already exist (empty) because `/exp-design` wrote the full CLAUDE.md template:
+   ```bash
+   # Top-level scalar fields — use set-meta
+   python3 tools/research_wiki.py set-meta wiki/experiments/{slug}.md status running
+   python3 tools/research_wiki.py set-meta wiki/experiments/{slug}.md run_log "logs/exp-{slug}.log"
+   ```
+
+   The nested `remote:` block cannot be updated via `set-meta` (it only handles top-level scalar fields). Use the `Edit` tool directly to replace the five empty sub-field values in place. The pre-existing block in the file looks like:
+   ```yaml
+   remote:
+     server: ""
+     gpu: ""
+     session: ""
+     started: ""
+     completed: ""
+   ```
+   Use five Edit calls (one per sub-field) to set `server`, `gpu`, `session`, `started`. Leave `completed: ""` — Phase 4 fills that. If you find the `remote:` block missing from the file, that means `/exp-design` did not write the full CLAUDE.md template; stop and report the bug rather than trying to append the block here (appending would drift the file away from the canonical order and break future edits).
+
 7. **Estimate runtime** and write to frontmatter (same estimation logic as local mode):
    ```bash
    python3 tools/research_wiki.py set-meta \

--- a/i18n/en/skills/ideate/SKILL.md
+++ b/i18n/en/skills/ideate/SKILL.md
@@ -224,27 +224,65 @@ Write the validated ideas to the wiki (including eliminated ideas, with their el
    # generate slug
    python3 tools/research_wiki.py slug "<idea-title>"
    ```
-   Create `wiki/ideas/{slug}.md`:
+   Create `wiki/ideas/{slug}.md` **following the CLAUDE.md ideas template exactly** (all fields required; `lint.py` enforces `status` and `priority`):
    ```yaml
    ---
-   title: ""
-   slug: ""
+   title: "<idea title>"
+   slug: "<idea-slug>"
    status: proposed
-   origin: "ideate"
-   origin_gaps: []           # [[claim-slug]] or gap description
-   linked_papers: []         # [[paper-slug]]
-   linked_experiments: []
+   origin: "ideate: <short description of the driving gap / weak claim / paper>"
+   origin_gaps: []           # [[claim-slug]] list — claims or topics this idea targets
+   tags: []                  # 2-5 topic tags (inherit from target claims / direction)
+   domain: ""                # NLP / CV / ML Systems / Robotics (inherit from direction)
+   priority: 3               # 1-5 — see Priority computation below
+   pilot_result: ""          # empty until /exp-eval fills it
+   failure_reason: ""        # empty for proposed ideas
+   linked_experiments: []    # empty until /exp-design creates experiments
    date_proposed: YYYY-MM-DD
-   pilot_result: ""
-   failure_reason: ""
+   date_resolved: ""         # empty until validated/failed
    ---
    ```
-   Body includes: Hypothesis, Approach sketch, Feasibility, Novelty score, Review summary, Risks
+
+   **Priority computation** (maps Phase 4 signals into the 1-5 scale):
+   - If `--skip-validation`: default `priority = 3`
+   - Otherwise start from `novelty_score` (1-5 from /novelty)
+   - `+1` if `gap_alignment_bonus > 0` (directly targets a gap_map entry)
+   - `-1` if `review_score <= 4` (major issues downgrade)
+   - Clamp to `[1, 5]`
+
+   **Body sections** (exactly match the CLAUDE.md template — do not rename):
+   ```markdown
+   ## Motivation
+   Which gap / weakly_supported claim / paper limitation drives this idea. Reference wiki pages via `[[slug]]`.
+
+   ## Hypothesis
+   1-2 sentences stating the testable proposition.
+
+   ## Approach sketch
+   3-5 sentences on the proposed method. Reference `[[paper-slug]]` or `[[concept-slug]]` for any component borrowed from existing work.
+
+   ## Expected outcome
+   What success looks like (metric / claim status change), plus the Phase 4 novelty & review summary:
+   - Novelty score: N/5 — <one-line reason from /novelty>
+   - Review score: M/10 — <one-line summary from /review>
+
+   ## Risks
+   Feasibility rating (high/medium/low) + top 2-3 risks. Include the main weaknesses surfaced by /review.
+
+   ## Pilot results
+   (empty — filled by /exp-eval after running the experiment)
+
+   ## Lessons learned
+   (empty — filled by /exp-eval after the idea reaches a terminal status)
+   ```
 
 2. **Write eliminated ideas** (status: failed):
-   For ideas eliminated in Phase 3/4, also create `wiki/ideas/{slug}.md`:
-   - status: failed
-   - failure_reason: specific elimination reason (e.g. "highly similar published work exists: [paper-title]", "insufficient feasibility: GPU requirements too high")
+   For ideas eliminated in Phase 3/4, also create `wiki/ideas/{slug}.md` using the **same template above**, with these overrides:
+   - `status: failed`
+   - `priority: 1` (eliminated ideas never block higher-priority work)
+   - `date_resolved: YYYY-MM-DD` (today)
+   - `failure_reason: "[filter] <specific elimination reason>"` — the `[filter]` prefix distinguishes ideate-stage eliminations from post-experiment failures (which /exp-eval tags differently). Examples: `"[filter] highly similar published work exists: <paper-title>"`, `"[filter] insufficient feasibility: GPU requirements too high"`
+   - Body `## Motivation` and `## Hypothesis` should still be filled (so future banlist matching has content); `## Approach sketch` may be brief; `## Expected outcome` and `## Risks` can note why the idea was eliminated
    - These failed ideas become the banlist for future ideate runs
 
 3. **Add graph edges**:

--- a/i18n/en/skills/init/SKILL.md
+++ b/i18n/en/skills/init/SKILL.md
@@ -316,7 +316,7 @@ Agent({
          SKIP — fetch_s2.py references <arxiv_id>           (same reason)
          SKIP — fetch_deepxiv.py head <arxiv_id>            (section structure not needed for batch bootstrap)
          SKIP — updating wiki/index.md                       (orchestrator runs rebuild-index after merge)
-         SKIP — updating wiki/topics/*.md                    (orchestrator runs lint --fix after merge to repair all xrefs)
+         SKIP — updating wiki/topics/*.md                    (orchestrator runs `topic-backfill` + `lint --fix` after merge to repair all xrefs)
          SKIP — research_wiki.py rebuild-context-brief       (graph/ files are derived; orchestrator rebuilds ONCE after all merges. Parallel rebuilds in worktrees create guaranteed merge conflicts on context_brief.md / open_questions.md.)
          SKIP — research_wiki.py rebuild-open-questions      (same reason — never touch wiki/graph/*.md inside a subagent)
          DO   — read .tex/.pdf source thoroughly
@@ -411,7 +411,7 @@ python3 tools/research_wiki.py checkpoint-clear wiki/ "init-session"
 - **Subagents must commit before reporting back** — every agent prompt mandates a final `git add wiki/ && git commit` step. Without it, Phase B merges produce empty results. Verify each branch has a commit during the Phase B sanity check.
 - **Wait for all N completion notifications** before starting Phase B
 - **Never bypass subagents** — all paper ingestion goes through subagents running the /ingest workflow
-- **Enforce init-mode skips** — the SKIP list above eliminates redundant API calls; `lint --fix` in Step 7 repairs all skipped xrefs
+- **Enforce init-mode skips** — the SKIP list above eliminates redundant API calls. Step 7 runs `topic-backfill` (to populate topic seminal_works / SOTA tracker from merged papers) followed by `lint --fix` (to repair concept↔paper, claim↔paper, idea↔claim, experiment↔claim reverse links). Together they cover every xref a subagent skipped.
 
 ### Step 6: Generate Initial Ideas (optional)
 
@@ -437,12 +437,20 @@ After all papers are ingested:
    ```bash
    # Rebuild index.md from entity frontmatter (subagents skipped this step)
    python3 tools/research_wiki.py rebuild-index wiki/
+   # Backfill topic seminal_works / SOTA tracker from merged papers
+   # (subagents skipped wiki/topics/*.md updates in INIT MODE)
+   python3 tools/research_wiki.py topic-backfill wiki/
    # Rebuild graph context and open questions
    python3 tools/research_wiki.py rebuild-context-brief wiki/
    python3 tools/research_wiki.py rebuild-open-questions wiki/
    ```
-2. Run lint for a basic health check:
+2. Auto-repair the deterministic xrefs the subagents skipped, then re-run lint
+   for a clean health report:
    ```bash
+   # --fix repairs concept↔paper, claim↔paper, idea↔claim, experiment↔claim
+   # reverse links (the bidirectional rules from CLAUDE.md). Topic xrefs are
+   # NOT in this set — those are handled by `topic-backfill` in step 1.
+   python3 tools/lint.py --wiki-dir wiki/ --fix
    python3 tools/lint.py --wiki-dir wiki/
    ```
 3. Get statistics:
@@ -520,6 +528,7 @@ Then output a summary including:
 - `python3 tools/research_wiki.py add-edge wiki/ ...` — add graph edge
 - `python3 tools/research_wiki.py dedup-edges wiki/` — remove duplicate edges after parallel ingest merge (Step 5, Phase C)
 - `python3 tools/research_wiki.py rebuild-index wiki/` — regenerate index.md from entity frontmatter (Step 7, after all subagents complete)
+- `python3 tools/research_wiki.py topic-backfill wiki/` — append matching papers to topic seminal_works / SOTA tracker (Step 7, repairs the wiki/topics/*.md updates that subagents skipped in INIT MODE)
 - `python3 tools/research_wiki.py rebuild-context-brief wiki/` — rebuild compressed context
 - `python3 tools/research_wiki.py rebuild-open-questions wiki/` — rebuild knowledge gap map
 - `python3 tools/research_wiki.py stats wiki/` — wiki statistics
@@ -531,7 +540,7 @@ Then output a summary including:
 - `python3 tools/fetch_s2.py references <arxiv_id>` — citation-chain expansion (references)
 - `python3 tools/fetch_s2.py citations <arxiv_id>` — citation-chain expansion (citations)
 - `python3 tools/fetch_deepxiv.py search "<topic>" --mode hybrid --limit 10` — DeepXiv semantic search (optional)
-- `python3 tools/lint.py --wiki-dir wiki/` — structural check
+- `python3 tools/lint.py --wiki-dir wiki/ --fix` — structural check + auto-repair (Step 7, repairs concept↔paper, claim↔paper, idea↔claim, experiment↔claim reverse links that subagents skipped)
 - `curl` — download arXiv e-print (tex) or PDF to raw/papers/
 
 ### Skills (via Agent subagent)

--- a/i18n/zh/CLAUDE.md
+++ b/i18n/zh/CLAUDE.md
@@ -350,18 +350,26 @@ claims:
 
 运行任何 Python 工具之前，必须确保使用正确的 Python 环境。按以下优先级检测并激活：
 
-1. **检查 `.venv/` 是否存在**：若存在，在 Bash 命令前加 `source .venv/bin/activate &&`
+1. **检查 `.venv/` 是否存在**：若存在，直接调用 venv 内的解释器 —— 跨平台最安全。
+   - Unix/macOS：存在 `.venv/bin/python` → 用 `.venv/bin/python tools/X.py`
+   - Windows：存在 `.venv/Scripts/python.exe` → 用 `.venv/Scripts/python.exe tools/X.py`
 2. **检查 `conda` 环境**：若当前无 venv 但有 conda，使用 `conda run -n <env>` 或确认 conda env 已激活
-3. **系统 Python**：若以上都不存在，直接使用 `python3`
+3. **系统 Python**：若以上都不存在，Unix/macOS 用 `python3`，Windows 用 `python`
 
 **示例：调用工具时**
 ```bash
-# 若 .venv/ 存在
-source .venv/bin/activate && python3 tools/fetch_arxiv.py --hours 24
+# Unix/macOS，存在 .venv/
+.venv/bin/python tools/fetch_arxiv.py --hours 24
 
-# 若无 venv，直接调用
-python3 tools/fetch_arxiv.py --hours 24
+# Windows，存在 .venv/（Git Bash 与 PowerShell 都支持正斜杠）
+.venv/Scripts/python.exe tools/fetch_arxiv.py --hours 24
+
+# 无 venv
+python3 tools/fetch_arxiv.py --hours 24      # Unix/macOS
+python tools/fetch_arxiv.py --hours 24       # Windows
 ```
+
+直接调用 venv 内的解释器，可以避免在 Unix 上 `source activate` 与 Windows 上 `Activate.ps1` 的差异，跨平台行为完全一致。
 
 **环境变量**：所有 Python 工具会自动从 `~/.env` 和项目根目录 `.env` 加载 API Key（通过 `tools/_env.py`），无需手动 export。
 

--- a/i18n/zh/skills/exp-design/SKILL.md
+++ b/i18n/zh/skills/exp-design/SKILL.md
@@ -58,14 +58,14 @@ argument-hint: <idea-slug-or-hypothesis> [--review] [--budget <gpu-hours>]
 ### Step 1: 加载上下文
 
 1. **解析 idea 输入**：
-   - 若为 slug：读取 `wiki/ideas/{slug}.md`，提取 hypothesis、approach sketch、risks、origin_gaps、linked_papers
+   - 若为 slug：读取 `wiki/ideas/{slug}.md`，提取 `## Motivation`、`## Hypothesis`、`## Approach sketch`、`## Risks`,以及 frontmatter 字段 `origin_gaps`、`tags`、`domain`、`priority`（遵循 CLAUDE.md 的 ideas template）
    - 若为自由文本：直接作为假设描述使用
 2. **加载相关 wiki 上下文**：
    - 读取 `wiki/graph/context_brief.md`（全局上下文）
    - 读取 `wiki/graph/open_questions.md`（知识缺口）
-   - 从 idea 的 origin_gaps 读取对应的 `wiki/claims/*.md`（目标 claims）
-   - 读取已有 `wiki/experiments/*.md`，检查是否已有类似实验
-   - 读取 `wiki/papers/*.md` 中相关论文的实验设置（作为 baseline 参考）
+   - 从 idea 的 `origin_gaps` 读取对应的 `wiki/claims/*.md`（目标 claims）
+   - 从每个目标 claim 的 `source_papers` 字段读取对应的 `wiki/papers/*.md`,获取 baseline setup 和已有实验协议 —— 这是 idea → claim → paper 的规范路径(ideas **不带** `linked_papers` 字段,改用 `origin_gaps` → `source_papers`)
+   - 读取已有 `wiki/experiments/*.md`,检查是否已有类似实验
 3. **若 idea 无 origin_gaps**：从假设描述中提取隐含的 claims，在 wiki/claims/ 中查找或标注需要新建
 
 ### Step 2: 界定 Claims（Scope Claims）
@@ -92,7 +92,7 @@ argument-hint: <idea-slug-or-hypothesis> [--review] [--budget <gpu-hours>]
 **A. Baseline 实验（基线复现）**：
 - 目的：确认问题存在、基线可复现
 - 复现最相关论文的核心实验
-- 成功标准：基线结果与论文报告的差异 < 5%
+- 成功标准：基线结果与论文报告的差异 < 5%（此阈值与下方 Stage 1 decision gate 一致 —— 不要在别处使用不同的数字）
 - 计算量：通常最小
 
 **B. Validation 实验（验证 Target claim）**：
@@ -136,7 +136,7 @@ Stage 0: Sanity check
 
 Stage 1: Baseline（基线复现）
   └── 复现基线结果
-  └── 门：若基线偏差 > 10% → 停止，检查实现
+  └── 门：若基线偏差 > 5% → 停止，检查实现（与 Step 3 成功标准同阈值）
 
 Stage 2: Validation（核心验证）
   └── 在基线之上验证核心方法
@@ -192,6 +192,8 @@ mcp__llm-review__chat:
    ```
    创建 `wiki/experiments/{slug}.md`：
    ```yaml
+   创建 `wiki/experiments/{slug}.md`，**严格遵循 CLAUDE.md experiments template** —— 下方所有字段都必须存在（即使为空），因为 `/exp-run` 稍后会用 `tools/research_wiki.py set-meta` 来更新它们，而 `set-meta` 拒绝创建 frontmatter 中不存在的字段（它只更新已存在的 key）：
+   ```yaml
    ---
    title: ""
    slug: ""
@@ -207,12 +209,20 @@ mcp__llm-review__chat:
      framework: ""
    metrics: []
    baseline: ""
-   outcome: ""
-   key_result: ""
-   linked_idea: ""           # idea slug
+   outcome: ""                # 留空，由 /exp-run Phase 4 填写 — succeeded | failed | inconclusive
+   key_result: ""             # 留空，由 /exp-run Phase 4 填写
+   linked_idea: "{idea-slug}" # 必填：源 idea slug（与 wiki/ideas/{idea-slug}.md 的 linked_experiments 互为双向链接）
    date_planned: YYYY-MM-DD
-   date_completed: ""
-   run_log: ""
+   date_completed: ""         # 留空，由 /exp-run Phase 4 填写
+   run_log: ""                # 留空，由 /exp-run Phase 2 填写
+   started: ""                # 留空，由 /exp-run Phase 2 填写（ISO 时间戳，通过 set-meta）
+   estimated_hours: 0         # 0，由 /exp-run Phase 2 更新（通过 set-meta）
+   remote:                    # 完整 block 必须存在，以便 /exp-run --env remote 通过 Edit 填充子字段
+     server: ""
+     gpu: ""
+     session: ""
+     started: ""
+     completed: ""
    ---
 
    ## Objective

--- a/i18n/zh/skills/exp-run/SKILL.md
+++ b/i18n/zh/skills/exp-run/SKILL.md
@@ -175,10 +175,23 @@ argument-hint: <experiment-slug> [--review] [--collect] [--full] [--env local|re
      --cmd "bash experiments/code/{slug}/run.sh" \
      --gpu {gpu_index}
    ```
-6. 更新 `wiki/experiments/{slug}.md`：
-   - status: `running`
-   - run_log: `logs/exp-{slug}.log`
-   - 新增 `remote:` 块到 frontmatter（server, gpu, session, started）
+6. 更新 `wiki/experiments/{slug}.md` frontmatter —— 以下字段已由 /exp-design 写入完整 CLAUDE.md 模板,都是空值:
+   ```bash
+   # 顶层 scalar 字段 —— 用 set-meta
+   python3 tools/research_wiki.py set-meta wiki/experiments/{slug}.md status running
+   python3 tools/research_wiki.py set-meta wiki/experiments/{slug}.md run_log "logs/exp-{slug}.log"
+   ```
+
+   嵌套 `remote:` 块无法通过 `set-meta` 更新（set-meta 只处理顶层 scalar 字段）。直接用 `Edit` 工具就地替换这五个空的子字段值。文件里已有的 block 形如：
+   ```yaml
+   remote:
+     server: ""
+     gpu: ""
+     session: ""
+     started: ""
+     completed: ""
+   ```
+   用 5 次 Edit 调用（每个子字段一次）设置 `server`、`gpu`、`session`、`started`。`completed: ""` 留空由 Phase 4 填写。如果发现文件里没有 `remote:` block,说明 /exp-design 没写完整的 CLAUDE.md 模板;停下来报 bug,不要在这里追加 block（追加会让字段顺序偏离 canonical 模板,破坏后续 edit 的匹配）。
 7. **估算运行时长**，写入 frontmatter（同 local 模式估算逻辑）：
    ```bash
    python3 tools/research_wiki.py set-meta \

--- a/i18n/zh/skills/ideate/SKILL.md
+++ b/i18n/zh/skills/ideate/SKILL.md
@@ -224,27 +224,65 @@ argument-hint: "[research-direction-or-topic] [--max-ideas N] [--skip-validation
    # 生成 slug
    python3 tools/research_wiki.py slug "<idea-title>"
    ```
-   创建 `wiki/ideas/{slug}.md`：
+   创建 `wiki/ideas/{slug}.md`，**严格遵循 CLAUDE.md 的 ideas template**（所有字段必填；`lint.py` 强制要求 `status` 和 `priority`）：
    ```yaml
    ---
-   title: ""
-   slug: ""
+   title: "<idea 标题>"
+   slug: "<idea-slug>"
    status: proposed
-   origin: "ideate"
-   origin_gaps: []           # [[claim-slug]] or gap description
-   linked_papers: []         # [[paper-slug]]
-   linked_experiments: []
+   origin: "ideate: <驱动该 idea 的 gap / 弱 claim / 论文的简短描述>"
+   origin_gaps: []           # [[claim-slug]] 列表 — 该 idea 针对的 claim 或 topic
+   tags: []                  # 2-5 个主题标签（从目标 claim / direction 继承）
+   domain: ""                # NLP / CV / ML Systems / Robotics（从 direction 继承）
+   priority: 3               # 1-5 — 见下方 Priority 计算
+   pilot_result: ""          # 留空，由 /exp-eval 填写
+   failure_reason: ""        # proposed ideas 留空
+   linked_experiments: []    # 留空，由 /exp-design 创建 experiment 后填写
    date_proposed: YYYY-MM-DD
-   pilot_result: ""
-   failure_reason: ""
+   date_resolved: ""         # 留空，validated/failed 时填写
    ---
    ```
-   正文包含：Hypothesis、Approach sketch、Feasibility、Novelty score、Review summary、Risks
+
+   **Priority 计算**（把 Phase 4 信号映射到 1-5 分）：
+   - 若 `--skip-validation`：默认 `priority = 3`
+   - 否则从 `novelty_score`（/novelty 给出的 1-5）开始
+   - `+1` 若 `gap_alignment_bonus > 0`（直接命中 gap_map 条目）
+   - `-1` 若 `review_score <= 4`（major issues 降权）
+   - Clamp 到 `[1, 5]`
+
+   **正文结构**（必须与 CLAUDE.md 模板严格一致 — 不要改名）：
+   ```markdown
+   ## Motivation
+   哪个 gap / weakly_supported claim / 论文限制驱动了这个 idea。用 `[[slug]]` 引用 wiki 页面。
+
+   ## Hypothesis
+   1-2 句话陈述可验证的命题。
+
+   ## Approach sketch
+   3-5 句描述提出的方法。任何借用现有工作的组件用 `[[paper-slug]]` 或 `[[concept-slug]]` 标注。
+
+   ## Expected outcome
+   成功的表现（指标 / claim 状态变化），加上 Phase 4 的 novelty 与 review 总结：
+   - Novelty score: N/5 — <来自 /novelty 的一行理由>
+   - Review score: M/10 — <来自 /review 的一行总结>
+
+   ## Risks
+   可行性评级（high/medium/low）+ top 2-3 风险。包含 /review 揭示的主要弱点。
+
+   ## Pilot results
+   （留空 — 由 /exp-eval 跑完实验后填写）
+
+   ## Lessons learned
+   （留空 — 由 /exp-eval 在 idea 达到终态后填写）
+   ```
 
 2. **写入被淘汰的 ideas**（status: failed）：
-   对 Phase 3/4 中被淘汰的 ideas，也创建 `wiki/ideas/{slug}.md`：
-   - status: failed
-   - failure_reason: 具体的淘汰原因（如 "已有高度相似的发表工作: [paper-title]"、"可行性不足: GPU 需求过高"）
+   对 Phase 3/4 中被淘汰的 ideas，也用**上方同一模板**创建 `wiki/ideas/{slug}.md`，应用以下覆盖：
+   - `status: failed`
+   - `priority: 1`（被淘汰的 ideas 永远不会阻塞更高优先级的工作）
+   - `date_resolved: YYYY-MM-DD`（今天）
+   - `failure_reason: "[filter] <具体淘汰原因>"` — `[filter]` 前缀用于区分 ideate 阶段淘汰和实验后失败（/exp-eval 用不同标签）。例如：`"[filter] 已有高度相似的发表工作: <paper-title>"`、`"[filter] 可行性不足：GPU 需求过高"`
+   - `## Motivation` 和 `## Hypothesis` 仍需填写（供未来 banlist 匹配）；`## Approach sketch` 可简略；`## Expected outcome` 和 `## Risks` 可说明淘汰原因
    - 这些 failed ideas 成为未来 ideate 的 banlist
 
 3. **添加 graph edges**：

--- a/i18n/zh/skills/init/SKILL.md
+++ b/i18n/zh/skills/init/SKILL.md
@@ -315,7 +315,7 @@ Agent({
          跳过 — fetch_s2.py references <arxiv_id>           （同上）
          跳过 — fetch_deepxiv.py head <arxiv_id>            （批量引导不需要章节结构）
          跳过 — 更新 wiki/index.md                           （主流程合并后执行 rebuild-index）
-         跳过 — 更新 wiki/topics/*.md                        （主流程在合并后执行 lint --fix 修复所有 xref）
+         跳过 — 更新 wiki/topics/*.md                        （主流程在合并后依次执行 `topic-backfill` 和 `lint --fix` 修复所有 xref）
          跳过 — research_wiki.py rebuild-context-brief       （graph/ 文件是派生的；由主流程在所有合并完成后统一重建一次。在 worktree 中并行重建必然导致 context_brief.md / open_questions.md 的合并冲突。）
          跳过 — research_wiki.py rebuild-open-questions      （同上 — 子代理绝不可写 wiki/graph/*.md）
          执行 — 完整阅读 .tex/.pdf 来源
@@ -409,7 +409,7 @@ python3 tools/research_wiki.py checkpoint-clear wiki/ "init-session"
 - **子代理必须在汇报前 commit** — 每个 agent prompt 都强制要求最后一步 `git add wiki/ && git commit`，否则 Phase B 会合入空结果。Phase B sanity check 必须验证每个 branch 都有 commit。
 - **spawn 完所有 N 个 agent 后，等待所有 N 个完成通知**，再进入 Phase B
 - **绝不绕过子代理** — 所有论文 ingest 必须通过子代理运行 /ingest 工作流
-- **强制执行 init 模式跳过项** — SKIP 列表不得移除；`lint --fix`（Step 7）负责修复所有跳过的 xref
+- **强制执行 init 模式跳过项** — SKIP 列表不得移除。Step 7 先跑 `topic-backfill`（把已合并的论文按 tag 重叠 + importance 阈值回填到 topic 的 seminal_works / SOTA tracker），再跑 `lint --fix`（修复 concept↔paper、claim↔paper、idea↔claim、experiment↔claim 的反向链接）。两者合起来覆盖子代理跳过的全部 xref。
 
 ### Step 6: 生成初始 Ideas（可选）
 
@@ -435,12 +435,19 @@ python3 tools/research_wiki.py checkpoint-clear wiki/ "init-session"
    ```bash
    # 从 entity frontmatter 重建 index.md（子代理已跳过此步骤）
    python3 tools/research_wiki.py rebuild-index wiki/
+   # 把已合并的论文按 tag 重叠 + importance 阈值回填到 topic 页面
+   #（INIT MODE 下子代理跳过了 wiki/topics/*.md 的更新）
+   python3 tools/research_wiki.py topic-backfill wiki/
    # 重建 graph 上下文与开放问题
    python3 tools/research_wiki.py rebuild-context-brief wiki/
    python3 tools/research_wiki.py rebuild-open-questions wiki/
    ```
-2. 运行 lint 检查基本健康：
+2. 自动修复子代理跳过的确定性 xref，再跑一次裸 lint 看最终健康状态：
    ```bash
+   # --fix 修复 concept↔paper、claim↔paper、idea↔claim、experiment↔claim
+   # 的反向链接（CLAUDE.md 里那张双向规则表）。topic 相关的 xref
+   # 不在此列 —— 那些由上面的 topic-backfill 处理。
+   python3 tools/lint.py --wiki-dir wiki/ --fix
    python3 tools/lint.py --wiki-dir wiki/
    ```
 3. 获取统计信息：
@@ -518,6 +525,7 @@ fi
 - `python3 tools/research_wiki.py add-edge wiki/ ...` — 添加 graph edge
 - `python3 tools/research_wiki.py dedup-edges wiki/` — 删除并行 ingest 合并后的重复 edges（Step 5，Phase C）
 - `python3 tools/research_wiki.py rebuild-index wiki/` — 从 entity frontmatter 重建 index.md（Step 7，所有子代理完成后）
+- `python3 tools/research_wiki.py topic-backfill wiki/` — 把已合并的论文按 tag 重叠 + importance 阈值回填到 topic 的 seminal_works / SOTA tracker（Step 7，修复子代理在 INIT MODE 下跳过的 wiki/topics/*.md 更新）
 - `python3 tools/research_wiki.py rebuild-context-brief wiki/` — 重建压缩上下文
 - `python3 tools/research_wiki.py rebuild-open-questions wiki/` — 重建知识缺口地图
 - `python3 tools/research_wiki.py stats wiki/` — wiki 统计
@@ -529,7 +537,7 @@ fi
 - `python3 tools/fetch_s2.py references <arxiv_id>` — 引用链扩展（参考文献）
 - `python3 tools/fetch_s2.py citations <arxiv_id>` — 引用链扩展（被引用）
 - `python3 tools/fetch_deepxiv.py search "<topic>" --mode hybrid --limit 10` — DeepXiv 语义搜索（可选）
-- `python3 tools/lint.py --wiki-dir wiki/` — 结构检查
+- `python3 tools/lint.py --wiki-dir wiki/ --fix` — 结构检查 + 自动修复（Step 7，修复子代理跳过的 concept↔paper、claim↔paper、idea↔claim、experiment↔claim 反向链接）
 - `curl` — 下载 arXiv e-print（tex）或 PDF 到 raw/papers/
 
 ### Skills（via Agent 子代理）

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,234 @@
+# ============================================================================
+# OmegaWiki - One-Click Setup (Windows / PowerShell)
+# ============================================================================
+# Usage:
+#   powershell -ExecutionPolicy Bypass -File .\setup.ps1            # English (default)
+#   powershell -ExecutionPolicy Bypass -File .\setup.ps1 -Lang zh   # Chinese
+#
+# Mirrors setup.sh: prerequisites -> venv + deps -> config -> activate i18n -> verify.
+# API key configuration (Semantic Scholar, DeepXiv, Review LLM) is handled
+# interactively by Claude Code - run /setup after starting Claude Code.
+# ============================================================================
+
+[CmdletBinding()]
+param(
+    [ValidateSet("en", "zh")]
+    [string]$Lang = "en"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Info($msg) { Write-Host "[INFO]  $msg" -ForegroundColor Blue }
+function Write-Ok($msg)   { Write-Host "[OK]    $msg" -ForegroundColor Green }
+function Write-Warn2($msg){ Write-Host "[WARN]  $msg" -ForegroundColor Yellow }
+function Write-Fail($msg) { Write-Host "[FAIL]  $msg" -ForegroundColor Red }
+
+$ProjectRoot = $PSScriptRoot
+$I18nDir = Join-Path $ProjectRoot "i18n\$Lang"
+if (-not (Test-Path $I18nDir)) {
+    Write-Fail "i18n\$Lang not found - run from the project root"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "============================================"
+Write-Host "  OmegaWiki - Setup (Windows)"
+Write-Host "============================================"
+Write-Host ""
+
+# -- Step 1: Check prerequisites -------------------------------------------
+Write-Info "Checking prerequisites..."
+
+# Python: prefer `python`, fall back to `py -3`
+$PythonCmd = $null
+foreach ($candidate in @("python", "python3", "py")) {
+    if (Get-Command $candidate -ErrorAction SilentlyContinue) {
+        $PythonCmd = $candidate
+        break
+    }
+}
+if (-not $PythonCmd) {
+    Write-Fail "Python not found. Install Python 3.9+ from https://www.python.org/downloads/"
+    exit 1
+}
+
+$pyVersionRaw = & $PythonCmd --version 2>&1
+if ($pyVersionRaw -match "(\d+)\.(\d+)\.(\d+)") {
+    $pyMajor = [int]$Matches[1]
+    $pyMinor = [int]$Matches[2]
+    if ($pyMajor -lt 3 -or ($pyMajor -eq 3 -and $pyMinor -lt 9)) {
+        Write-Fail "Python >= 3.9 required, found $pyVersionRaw"
+        exit 1
+    }
+    Write-Ok "Python $pyVersionRaw"
+} else {
+    Write-Fail "Could not parse Python version: $pyVersionRaw"
+    exit 1
+}
+
+# pip
+& $PythonCmd -m pip --version 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Fail "pip not found. Run: $PythonCmd -m ensurepip"
+    exit 1
+}
+Write-Ok "pip available"
+
+# Claude Code
+if (Get-Command claude -ErrorAction SilentlyContinue) {
+    Write-Ok "Claude Code installed"
+} else {
+    Write-Warn2 "Claude Code not found."
+    Write-Host ""
+    Write-Host "  Claude Code is required to use OmegaWiki skills."
+    Write-Host "  Install with:"
+    Write-Host "    npm install -g @anthropic-ai/claude-code"
+    Write-Host ""
+    $reply = Read-Host "  Continue setup without Claude Code? [y/N]"
+    if ($reply -notmatch '^[Yy]$') {
+        Write-Host "  Install Claude Code first, then re-run setup.ps1"
+        exit 1
+    }
+}
+
+# -- Step 2: Python environment + dependencies -----------------------------
+Write-Host ""
+Write-Info "Setting up Python environment..."
+
+Push-Location $ProjectRoot
+try {
+    $UsingExisting = $false
+    if ($env:VIRTUAL_ENV) {
+        Write-Ok "Using active venv: $env:VIRTUAL_ENV"
+        $UsingExisting = $true
+    } elseif ($env:CONDA_DEFAULT_ENV -and $env:CONDA_DEFAULT_ENV -ne "base") {
+        Write-Ok "Using active conda env: $env:CONDA_DEFAULT_ENV"
+        $UsingExisting = $true
+    } else {
+        if (Test-Path ".venv") {
+            Write-Warn2 ".venv already exists, using it"
+        } else {
+            & $PythonCmd -m venv .venv
+            if ($LASTEXITCODE -ne 0) { throw "venv creation failed" }
+            Write-Ok "Created .venv"
+        }
+    }
+
+    # Resolve the python interpreter to use for installs + verification
+    if ($UsingExisting) {
+        $VenvPython = $PythonCmd
+    } else {
+        $VenvPython = Join-Path $ProjectRoot ".venv\Scripts\python.exe"
+        if (-not (Test-Path $VenvPython)) {
+            Write-Fail "Expected $VenvPython but it does not exist"
+            exit 1
+        }
+        Write-Ok "Using .venv\Scripts\python.exe"
+    }
+
+    Write-Info "Installing dependencies..."
+    & $VenvPython -m pip install -r requirements.txt -q
+    if ($LASTEXITCODE -ne 0) { throw "pip install failed" }
+    Write-Ok "Dependencies installed"
+
+    # -- Step 3: Configuration files ---------------------------------------
+    Write-Host ""
+    Write-Info "Setting up configuration..."
+
+    if (Test-Path ".env") {
+        Write-Warn2 ".env already exists, not overwriting"
+    } else {
+        Copy-Item ".env.example" ".env"
+        Write-Ok "Created .env from template"
+    }
+
+    if (-not (Test-Path ".claude")) { New-Item -ItemType Directory -Path ".claude" | Out-Null }
+    if (Test-Path ".claude\settings.local.json") {
+        Write-Warn2 ".claude\settings.local.json already exists, not overwriting"
+    } else {
+        Copy-Item "config\settings.local.json.example" ".claude\settings.local.json"
+        Write-Ok "Created .claude\settings.local.json"
+    }
+
+    # -- Step 3b: Activate language files ----------------------------------
+    Write-Host ""
+    Write-Info "Activating language: $Lang"
+    Copy-Item (Join-Path $I18nDir "CLAUDE.md") "CLAUDE.md" -Force
+
+    $skillsSrc = Join-Path $I18nDir "skills"
+    Get-ChildItem -Path $skillsSrc -Directory | ForEach-Object {
+        $name = $_.Name
+        $destDir = Join-Path ".claude\skills" $name
+        if (-not (Test-Path $destDir)) { New-Item -ItemType Directory -Path $destDir -Force | Out-Null }
+        Get-ChildItem -Path $_.FullName -File | ForEach-Object {
+            Copy-Item $_.FullName (Join-Path $destDir $_.Name) -Force
+        }
+    }
+
+    $sharedDest = ".claude\skills\shared-references"
+    if (-not (Test-Path $sharedDest)) { New-Item -ItemType Directory -Path $sharedDest -Force | Out-Null }
+    Get-ChildItem -Path (Join-Path $I18nDir "shared-references") -Filter "*.md" | ForEach-Object {
+        Copy-Item $_.FullName (Join-Path $sharedDest $_.Name) -Force
+    }
+    Set-Content -Path ".claude\.current-lang" -Value $Lang -NoNewline
+    Write-Ok "Language files activated ($Lang)"
+
+    # -- Step 4: Verify installation ---------------------------------------
+    Write-Host ""
+    Write-Info "Verifying installation..."
+
+    $errors = 0
+    $checks = @(
+        @{ name = "fetch_arxiv";    import = "from fetch_arxiv import fetch_recent" },
+        @{ name = "fetch_s2";       import = "from fetch_s2 import search" },
+        @{ name = "fetch_deepxiv";  import = "from fetch_deepxiv import search" },
+        @{ name = "research_wiki";  import = "from research_wiki import slugify" },
+        @{ name = "lint";           import = "from lint import check_missing_fields" }
+    )
+    Push-Location "tools"
+    try {
+        foreach ($c in $checks) {
+            & $VenvPython -c $c.import 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Ok ("tools/{0}.py" -f $c.name)
+            } else {
+                Write-Fail ("tools/{0}.py import error" -f $c.name)
+                $errors++
+            }
+        }
+    } finally {
+        Pop-Location
+    }
+} finally {
+    Pop-Location
+}
+
+# -- Done ------------------------------------------------------------------
+Write-Host ""
+Write-Host "============================================"
+if ($errors -eq 0) {
+    Write-Host "  Setup complete!" -ForegroundColor Green
+} else {
+    Write-Host "  Setup complete with $errors warning(s)" -ForegroundColor Yellow
+}
+Write-Host "============================================"
+Write-Host ""
+Write-Host "  Next steps:"
+Write-Host ""
+Write-Host "  1. Authenticate Claude Code (if not already):"
+Write-Host "       claude login"
+Write-Host ""
+Write-Host "  2. Activate the venv in your shell (optional, for manual tool use):"
+Write-Host "       .\.venv\Scripts\Activate.ps1"
+Write-Host ""
+Write-Host "  3. Start Claude Code:"
+Write-Host "       claude"
+Write-Host ""
+Write-Host "  4. Complete API key configuration (guided):"
+Write-Host "       /setup"
+Write-Host ""
+Write-Host "  5. Then initialize your wiki:"
+Write-Host "       /init <your-research-topic>"
+Write-Host ""
+Write-Host "  For more, see README.md"
+Write-Host ""

--- a/tests/test_research_wiki.py
+++ b/tests/test_research_wiki.py
@@ -150,6 +150,21 @@ class TestAddEdge:
             rw.add_edge(str(wiki), f"a{i}", f"b{i}", t)
         assert len(rw.load_edges(str(wiki))) == len(rw.VALID_EDGE_TYPES)
 
+    def test_schema_constants_are_shared_with_lint(self):
+        """research_wiki and lint must read from the same _schemas module —
+        anything else means the enum sets can drift apart silently."""
+        import sys as _sys
+        _sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+        import _schemas
+        import lint as lint_mod
+        assert rw.VALID_EDGE_TYPES is _schemas.VALID_EDGE_TYPES
+        assert rw.ENTITY_DIRS is _schemas.ENTITY_DIRS
+        assert lint_mod.VALID_EDGE_TYPES is _schemas.VALID_EDGE_TYPES
+        assert lint_mod.VALID_VALUES is _schemas.VALID_VALUES
+        assert lint_mod.REQUIRED_FIELDS is _schemas.REQUIRED_FIELDS
+        assert lint_mod.FIELD_DEFAULTS is _schemas.FIELD_DEFAULTS
+        assert lint_mod.ENTITY_DIRS is _schemas.ENTITY_DIRS
+
     def test_entity_validation_warns(self, wiki, capsys):
         """add-edge with nonexistent entities should still succeed but warn."""
         rw.add_edge(str(wiki), "papers/nonexistent", "claims/missing", "supports")
@@ -1384,6 +1399,167 @@ class TestRebuildIndex:
         out = json.loads(capsys.readouterr().out)
         assert out["status"] == "ok"
         assert all(v == 0 for v in out["entities"].values())
+
+
+class TestTopicBackfill:
+    """Post-merge sweep that repairs the topics/*.md updates skipped by
+    /init INIT MODE subagents. See research_wiki.topic_backfill docstring."""
+
+    def _topic(self, wiki, slug, tags, sections=("## Seminal works", "## SOTA tracker")):
+        body = "## Overview\nTBD\n\n" + "\n".join(f"{s}\n" for s in sections)
+        _write_page(wiki, "topics", slug, f"title: {slug}\ntags: [{', '.join(tags)}]", body)
+
+    def _paper(self, wiki, slug, tags, importance, domain=""):
+        fm = f"title: {slug}\nslug: {slug}\ntags: [{', '.join(tags)}]\nimportance: {importance}"
+        if domain:
+            fm += f"\ndomain: {domain}"
+        _write_page(wiki, "papers", slug, fm)
+
+    def test_matches_by_tag_overlap(self, wiki, capsys):
+        self._topic(wiki, "efficient-llm", ["efficiency", "llm"])
+        self._paper(wiki, "lora", ["fine-tuning", "llm"], 5)
+        self._paper(wiki, "robotics", ["robotics"], 5)  # no overlap
+        capsys.readouterr()
+        rw.topic_backfill(str(wiki))
+        out = json.loads(capsys.readouterr().out)
+        assert out["status"] == "ok"
+        topic_md = (wiki / "topics" / "efficient-llm.md").read_text()
+        assert "[[lora]]" in topic_md
+        assert "[[robotics]]" not in topic_md
+
+    def test_seminal_vs_sota_split_by_importance(self, wiki, capsys):
+        self._topic(wiki, "t1", ["x"])
+        self._paper(wiki, "important", ["x"], 5)
+        self._paper(wiki, "alsoimportant", ["x"], 4)
+        self._paper(wiki, "minor", ["x"], 2)
+        capsys.readouterr()
+        rw.topic_backfill(str(wiki))
+        topic_md = (wiki / "topics" / "t1.md").read_text()
+        seminal = topic_md.split("## Seminal works")[1].split("## SOTA tracker")[0]
+        sota = topic_md.split("## SOTA tracker")[1]
+        assert "[[important]]" in seminal
+        assert "[[alsoimportant]]" in seminal
+        assert "[[minor]]" in sota
+        assert "[[important]]" not in sota
+        assert "[[minor]]" not in seminal
+
+    def test_idempotent(self, wiki, capsys):
+        self._topic(wiki, "t1", ["x"])
+        self._paper(wiki, "p1", ["x"], 5)
+        capsys.readouterr()
+        rw.topic_backfill(str(wiki))
+        first = (wiki / "topics" / "t1.md").read_text()
+        capsys.readouterr()
+        rw.topic_backfill(str(wiki))
+        second = (wiki / "topics" / "t1.md").read_text()
+        assert first == second
+        out = json.loads(capsys.readouterr().out)
+        assert out["lines_added"] == 0
+        assert out["lines_skipped_existing"] == 1
+
+    def test_creates_section_if_missing(self, wiki, capsys):
+        # Topic page intentionally has no Seminal works section
+        _write_page(wiki, "topics", "t1", "title: t1\ntags: [x]",
+                    body="## Overview\nfoo\n")
+        self._paper(wiki, "p1", ["x"], 5)
+        capsys.readouterr()
+        rw.topic_backfill(str(wiki))
+        topic_md = (wiki / "topics" / "t1.md").read_text()
+        assert "## Seminal works" in topic_md
+        assert "[[p1]]" in topic_md
+
+    def test_topic_with_no_tags_is_skipped(self, wiki, capsys):
+        _write_page(wiki, "topics", "untagged", "title: untagged\ntags: []",
+                    body="## Seminal works\n")
+        self._paper(wiki, "p1", ["x"], 5)
+        capsys.readouterr()
+        rw.topic_backfill(str(wiki))
+        out = json.loads(capsys.readouterr().out)
+        assert out["per_topic"]["untagged"]["note"] == "topic has no tags"
+        topic_md = (wiki / "topics" / "untagged.md").read_text()
+        assert "[[p1]]" not in topic_md
+
+    def test_domain_field_counts_as_tag(self, wiki, capsys):
+        self._topic(wiki, "nlp-topic", ["nlp"])
+        # Paper has no overlapping `tags`, only matching `domain`
+        self._paper(wiki, "p1", ["fine-tuning"], 5, domain="nlp")
+        capsys.readouterr()
+        rw.topic_backfill(str(wiki))
+        topic_md = (wiki / "topics" / "nlp-topic.md").read_text()
+        assert "[[p1]]" in topic_md
+
+    def test_heading_prefix_collision_does_not_corrupt(self, wiki, capsys):
+        """Regression: a topic page with `## Seminal works (extended)` must
+        NOT be matched as `## Seminal works`. Previously the loose fallback
+        match landed inside the heading text and corrupted the file."""
+        body = (
+            "## Overview\nOV\n\n"
+            "## Seminal works (extended)\nold-content-here\n\n"
+            "## SOTA tracker\n"
+        )
+        _write_page(wiki, "topics", "t1", "title: t1\ntags: [x]", body=body)
+        self._paper(wiki, "p1", ["x"], 5)
+        capsys.readouterr()
+        rw.topic_backfill(str(wiki))
+        topic_md = (wiki / "topics" / "t1.md").read_text()
+        # The (extended) heading and its body must be intact
+        assert "## Seminal works (extended)\nold-content-here" in topic_md
+        # A real `## Seminal works` section must have been created (at EOF)
+        assert "\n## Seminal works\n" in topic_md
+        # The new bullet must be in the new exact-match section, not jammed
+        # into the (extended) heading
+        sw_idx = topic_md.find("\n## Seminal works\n")
+        assert "[[p1]]" in topic_md[sw_idx:]
+        assert "Seminal works- [[p1]]" not in topic_md
+        assert "Seminal works(extended)" not in topic_md
+
+    def test_missing_section_dedup_is_section_scoped(self, wiki, capsys):
+        """Regression: when the seminal_works section is absent and the paper
+        slug already appears in some other section (e.g. ## Overview prose),
+        topic-backfill must STILL add it to the new seminal_works section.
+        Previously the missing-section branch dedup'd against the whole file."""
+        body = (
+            "## Overview\nWe survey methods including [[lora]] and others.\n\n"
+            "## SOTA tracker\n"
+        )
+        _write_page(wiki, "topics", "t1", "title: t1\ntags: [x]", body=body)
+        self._paper(wiki, "lora", ["x"], 5)
+        capsys.readouterr()
+        rw.topic_backfill(str(wiki))
+        topic_md = (wiki / "topics" / "t1.md").read_text()
+        assert "## Seminal works" in topic_md
+        sw_section = topic_md.split("## Seminal works")[1]
+        assert "[[lora]]" in sw_section, \
+            "missing-section dedup leaked across the file"
+
+    def test_existing_section_dedup_is_section_scoped(self, wiki, capsys):
+        """The existing-section branch already does this, but pin it down: a
+        paper mentioned in another section should NOT be skipped when added
+        to seminal_works."""
+        body = (
+            "## Overview\nMentions [[other]] in prose.\n\n"
+            "## Seminal works\n- [[other]]\n\n"
+            "## SOTA tracker\n"
+        )
+        _write_page(wiki, "topics", "t1", "title: t1\ntags: [x]", body=body)
+        self._paper(wiki, "other", ["x"], 5)  # already in seminal — skip
+        self._paper(wiki, "newone", ["x"], 5)  # not in seminal — add
+        capsys.readouterr()
+        rw.topic_backfill(str(wiki))
+        topic_md = (wiki / "topics" / "t1.md").read_text()
+        sw = topic_md.split("## Seminal works")[1].split("## SOTA")[0]
+        assert sw.count("[[other]]") == 1  # not duplicated
+        assert "[[newone]]" in sw
+
+    def test_missing_topics_dir_is_no_op(self, tmp_path, capsys):
+        # No init_wiki — neither topics/ nor papers/ exists
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        capsys.readouterr()
+        rw.topic_backfill(str(empty))
+        out = json.loads(capsys.readouterr().out)
+        assert out["status"] == "ok"
+        assert out["topics_scanned"] == 0
 
 
 # ── CLI integration ───────────────────────────────────────────────────────

--- a/tools/_schemas.py
+++ b/tools/_schemas.py
@@ -1,0 +1,71 @@
+"""Single source of truth for ΩmegaWiki entity schemas.
+
+Centralizes the constants that lint.py and research_wiki.py both need:
+entity directories, valid edge types, required frontmatter fields per
+entity, valid enum values, and safe defaults for `lint --fix`.
+
+If you change anything here, also update the matching template comments
+in `i18n/en/CLAUDE.md` and `i18n/zh/CLAUDE.md` (and re-run setup.sh).
+The Cross-Reference table in those files is the human-facing spec; this
+file is the machine-facing copy that the tools actually consume.
+"""
+
+from __future__ import annotations
+
+# All 9 entity directories (Summary lives at the wiki root, not under entities,
+# but lint treats it as an entity directory because it has frontmatter pages).
+ENTITY_DIRS = [
+    "papers", "concepts", "topics", "people",
+    "ideas", "experiments", "claims", "Summary",
+    "foundations",
+]
+
+# Typed graph edges (graph/edges.jsonl). New types must be added here AND
+# documented in CLAUDE.md's graph/ section.
+VALID_EDGE_TYPES = {
+    "extends", "contradicts", "supports", "inspired_by",
+    "tested_by", "invalidates", "supersedes", "addresses_gap",
+    "derived_from",
+}
+
+# Required frontmatter fields per entity type (lint.py reports a 🔴 if missing).
+REQUIRED_FIELDS = {
+    "papers": ["title", "slug", "tags", "importance"],
+    "concepts": ["title", "tags", "maturity", "key_papers"],
+    "topics": ["title", "tags"],
+    "people": ["name", "tags"],
+    "Summary": ["title", "scope", "key_topics"],
+    "ideas": ["title", "slug", "status", "origin", "tags", "priority"],
+    "experiments": ["title", "slug", "status", "target_claim", "hypothesis", "tags"],
+    "claims": ["title", "slug", "status", "confidence", "tags", "source_papers", "evidence"],
+    "foundations": ["title", "slug", "domain", "status"],
+}
+
+# Valid enum values per entity-qualified field. Format: "{entity}.{field}".
+VALID_VALUES = {
+    "papers.importance": {"1", "2", "3", "4", "5"},
+    "concepts.maturity": {"stable", "active", "emerging", "deprecated"},
+    "ideas.status": {"proposed", "in_progress", "tested", "validated", "failed"},
+    "ideas.priority": {"1", "2", "3", "4", "5"},
+    "experiments.status": {"planned", "running", "completed", "abandoned"},
+    "experiments.outcome": {"succeeded", "failed", "inconclusive", ""},
+    "claims.status": {"proposed", "weakly_supported", "supported", "challenged", "deprecated"},
+    "foundations.status": {"mainstream", "historical"},
+}
+
+# Safe defaults for `lint --fix`. Only fields where a neutral default is
+# reasonable. Note: `importance: "3"` and `confidence: "0.5"` are biased
+# defaults for bulk-ingested wikis (3=field-standard, 0.5=coin-flip), but
+# fixing that is a separate concern from centralizing the schema — see
+# devlog for the discussion. Preserved as-is here.
+FIELD_DEFAULTS = {
+    "papers": {"tags": "[]", "importance": "3"},
+    "concepts": {"tags": "[]", "maturity": "active", "key_papers": "[]"},
+    "topics": {"tags": "[]"},
+    "people": {"tags": "[]"},
+    "Summary": {"key_topics": "[]"},
+    "ideas": {"tags": "[]", "priority": "3"},
+    "experiments": {"tags": "[]"},
+    "claims": {"tags": "[]", "confidence": "0.5"},
+    "foundations": {"status": "mainstream"},
+}

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -30,50 +30,18 @@ import re
 import sys
 from pathlib import Path
 
+# Schema constants — single source of truth shared with research_wiki.py.
+# See tools/_schemas.py for the spec; do not duplicate the definitions here.
+from _schemas import (
+    ENTITY_DIRS,
+    FIELD_DEFAULTS,
+    REQUIRED_FIELDS,
+    VALID_EDGE_TYPES,
+    VALID_VALUES,
+)
+
 WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]*)?\]\]")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
-
-# All 8 entity directories + Summary
-ENTITY_DIRS = ["papers", "concepts", "topics", "people", "foundations",
-               "ideas", "experiments", "claims", "Summary"]
-
-# Required fields per entity type
-REQUIRED_FIELDS = {
-    "papers": ["title", "slug", "tags", "importance"],
-    "concepts": ["title", "tags", "maturity", "key_papers"],
-    "topics": ["title", "tags"],
-    "people": ["name", "tags"],
-    "Summary": ["title", "scope", "key_topics"],
-    "ideas": ["title", "slug", "status", "origin", "tags", "priority"],
-    "experiments": ["title", "slug", "status", "target_claim", "hypothesis", "tags"],
-    "claims": ["title", "slug", "status", "confidence", "tags", "source_papers", "evidence"],
-    "foundations": ["title", "slug", "domain", "status"],
-}
-
-# Valid enum values
-VALID_VALUES = {
-    "papers.importance": {"1", "2", "3", "4", "5"},
-    "concepts.maturity": {"stable", "active", "emerging", "deprecated"},
-    "ideas.status": {"proposed", "in_progress", "tested", "validated", "failed"},
-    "ideas.priority": {"1", "2", "3", "4", "5"},
-    "experiments.status": {"planned", "running", "completed", "abandoned"},
-    "experiments.outcome": {"succeeded", "failed", "inconclusive", ""},
-    "claims.status": {"proposed", "weakly_supported", "supported", "challenged", "deprecated"},
-    "foundations.status": {"mainstream", "historical"},
-}
-
-# Safe default values for --fix mode (only fields where a neutral default is reasonable)
-FIELD_DEFAULTS = {
-    "papers": {"tags": "[]", "importance": "3"},
-    "concepts": {"tags": "[]", "maturity": "active", "key_papers": "[]"},
-    "topics": {"tags": "[]"},
-    "people": {"tags": "[]"},
-    "Summary": {"key_topics": "[]"},
-    "ideas": {"tags": "[]", "priority": "3"},
-    "experiments": {"tags": "[]"},
-    "claims": {"tags": "[]", "confidence": "0.5"},
-    "foundations": {"status": "mainstream"},
-}
 
 
 class LintIssue:
@@ -401,9 +369,7 @@ def check_graph_edges(wiki_dir: Path, pages: dict[str, Path]) -> list[LintIssue]
     if not edges_path.exists():
         return issues
 
-    valid_types = {"extends", "contradicts", "supports", "inspired_by",
-                   "tested_by", "invalidates", "supersedes", "addresses_gap",
-                   "derived_from"}
+    valid_types = VALID_EDGE_TYPES
 
     line_num = 0
     for line in edges_path.read_text(encoding="utf-8").strip().split("\n"):

--- a/tools/research_wiki.py
+++ b/tools/research_wiki.py
@@ -61,19 +61,11 @@ from pathlib import Path
 # Constants
 # ---------------------------------------------------------------------------
 
-ENTITY_DIRS = [
-    "papers", "concepts", "topics", "people",
-    "ideas", "experiments", "claims", "Summary",
-    "foundations",
-]
+# ENTITY_DIRS / VALID_EDGE_TYPES are re-exported from _schemas so this module
+# and lint.py share a single source of truth — see tools/_schemas.py.
+from _schemas import ENTITY_DIRS, VALID_EDGE_TYPES  # noqa: E402
 
 DERIVED_DIR = "graph"
-
-VALID_EDGE_TYPES = {
-    "extends", "contradicts", "supports", "inspired_by",
-    "tested_by", "invalidates", "supersedes", "addresses_gap",
-    "derived_from",
-}
 
 STOP_WORDS = frozenset({
     "a", "an", "the", "of", "for", "in", "on", "with", "via",
@@ -1565,6 +1557,195 @@ def rebuild_index(wiki_root: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Topic backfill (post-merge sweep for /init INIT MODE)
+# ---------------------------------------------------------------------------
+
+def topic_backfill(wiki_root: str) -> None:
+    """Append matching papers to each topic's seminal_works / SOTA tracker.
+
+    Re-implements the deterministic half of /ingest Step 5 Part B in a
+    post-merge sweep. /init's INIT MODE tells subagents to skip topic updates
+    so parallel ingest doesn't conflict on shared topic files; this command
+    is what finally repairs them after Phase B merges complete.
+
+    Matching rule (matches /ingest Part B):
+      - paper.tags ∩ topic.tags must be non-empty (or paper.domain in topic.tags)
+      - importance >= 4 → append `- [[paper-slug]]` to ## Seminal works
+      - importance < 4  → append `- [[paper-slug]]` to ## SOTA tracker
+      - existing entries are detected and skipped (idempotent)
+
+    NOT handled here (deferred to a later /ingest or /edit pass):
+      - topic.key_people backfill (requires "is the author a key figure"
+        judgment, which is fuzzy and not safe to automate)
+      - topic.tags inference (topics that have no tags get no matches)
+
+    Idempotent: re-running on a wiki that's already backfilled is a no-op.
+    """
+    root = Path(wiki_root)
+    topics_dir = root / "topics"
+    papers_dir = root / "papers"
+
+    if not topics_dir.exists() or not papers_dir.exists():
+        print(json.dumps({
+            "status": "ok",
+            "topics_scanned": 0,
+            "topics_matched": 0,
+            "lines_added": 0,
+            "lines_skipped_existing": 0,
+            "per_topic": {},
+            "note": "topics/ or papers/ missing",
+        }))
+        return
+
+    def _as_str_set(val) -> set[str]:
+        if not val:
+            return set()
+        if isinstance(val, str):
+            return {val.strip().lower()} if val.strip() else set()
+        if isinstance(val, list):
+            return {str(t).strip().lower() for t in val if str(t).strip()}
+        return set()
+
+    # Pre-load all paper frontmatter once
+    papers: list[dict] = []
+    for p in sorted(papers_dir.glob("*.md")):
+        fm = _parse_frontmatter(p)
+        slug = p.stem
+        tags = _as_str_set(fm.get("tags"))
+        domain = str(fm.get("domain", "")).strip().lower()
+        if domain:
+            tags.add(domain)
+        try:
+            importance = int(str(fm.get("importance", "3")).strip())
+        except (TypeError, ValueError):
+            importance = 3
+        papers.append({"slug": slug, "tags": tags, "importance": importance})
+
+    added = 0
+    skipped_existing = 0
+    matched_topics = 0
+    per_topic: dict[str, dict[str, int]] = {}
+
+    for tpath in sorted(topics_dir.glob("*.md")):
+        topic_slug = tpath.stem
+        tfm = _parse_frontmatter(tpath)
+        ttags = _as_str_set(tfm.get("tags"))
+        if not ttags:
+            per_topic[topic_slug] = {"added": 0, "skipped": 0,
+                                      "note": "topic has no tags"}
+            continue
+
+        seminal: list[str] = []
+        sota: list[str] = []
+        for paper in papers:
+            if not (ttags & paper["tags"]):
+                continue
+            link = f"- [[{paper['slug']}]]"
+            if paper["importance"] >= 4:
+                seminal.append(link)
+            else:
+                sota.append(link)
+
+        if not seminal and not sota:
+            per_topic[topic_slug] = {"added": 0, "skipped": 0}
+            continue
+
+        matched_topics += 1
+        t_added, t_skipped = 0, 0
+        if seminal:
+            a, s = _append_lines_to_section(tpath, "## Seminal works", seminal)
+            t_added += a
+            t_skipped += s
+        if sota:
+            a, s = _append_lines_to_section(tpath, "## SOTA tracker", sota)
+            t_added += a
+            t_skipped += s
+
+        added += t_added
+        skipped_existing += t_skipped
+        per_topic[topic_slug] = {"added": t_added, "skipped": t_skipped}
+
+    print(json.dumps({
+        "status": "ok",
+        "topics_scanned": len(per_topic),
+        "topics_matched": matched_topics,
+        "lines_added": added,
+        "lines_skipped_existing": skipped_existing,
+        "per_topic": per_topic,
+    }, ensure_ascii=False))
+
+
+def _find_section_heading(content: str, heading: str) -> int:
+    """Locate an exact markdown heading in `content`.
+
+    Returns the offset of the leading newline of the matched heading line, or
+    -1 if not found. The match must be exact: the character following
+    `heading` has to be `\\n`, `\\r`, or end-of-string. This rejects prefix
+    collisions like `## Seminal works (extended)` matching `## Seminal works`,
+    which would otherwise let the caller insert text inside another heading.
+    """
+    needle = f"\n{heading}"
+    start = 0
+    while True:
+        idx = content.find(needle, start)
+        if idx == -1:
+            return -1
+        end_of_match = idx + len(needle)
+        if end_of_match == len(content) or content[end_of_match] in "\n\r":
+            return idx
+        start = idx + 1
+
+
+def _append_lines_to_section(fpath: Path, heading: str,
+                              lines: list[str]) -> tuple[int, int]:
+    """Append lines under a markdown heading. Returns (added, skipped).
+
+    - Idempotent: re-appending an already-present line in the same section
+      returns it as `skipped`, not `added`.
+    - Dedup is **section-scoped** in both branches (existing section AND
+      newly-created section). The previous version dedup'd the
+      missing-section path against the entire file, which silently dropped
+      lines that happened to appear in unrelated prose like ## Overview.
+    - Heading match is exact (see `_find_section_heading`) to prevent
+      `## Seminal works (extended)` collisions corrupting the file.
+    - Inserts new lines immediately after the heading (and any blank lines
+      that follow it), before existing content.
+    """
+    content = fpath.read_text(encoding="utf-8")
+    section_start = _find_section_heading(content, heading)
+
+    if section_start == -1:
+        # Section missing — create it at EOF. The new section starts empty,
+        # so dedup is unnecessary; just append all requested lines.
+        body = "\n".join(lines)
+        content = content.rstrip() + f"\n\n{heading}\n\n{body}\n"
+        fpath.write_text(content, encoding="utf-8")
+        return (len(lines), 0)
+
+    # Slice that belongs to this section (up to next ## heading or EOF).
+    body_start = section_start + 1 + len(heading)
+    rest = content[body_start:]
+    next_section = re.search(r"\n## ", rest)
+    section_end = body_start + (next_section.start() if next_section else len(rest))
+    section_text = content[body_start:section_end]
+
+    new_lines = [l for l in lines if l.strip() not in section_text]
+    skipped = len(lines) - len(new_lines)
+    if not new_lines:
+        return (0, skipped)
+
+    # Insert immediately after the heading line + any blank lines following it.
+    insert_pos = body_start
+    while insert_pos < section_end and content[insert_pos] == "\n":
+        insert_pos += 1
+
+    insertion = "\n".join(new_lines) + "\n"
+    new_content = content[:insert_pos] + insertion + content[insert_pos:]
+    fpath.write_text(new_content, encoding="utf-8")
+    return (len(new_lines), skipped)
+
+
+# ---------------------------------------------------------------------------
 # Audit log
 # ---------------------------------------------------------------------------
 
@@ -2194,6 +2375,11 @@ def main():
     p = sub.add_parser("rebuild-index", help="Regenerate index.md from entity dirs")
     p.add_argument("wiki_root")
 
+    # topic-backfill
+    p = sub.add_parser("topic-backfill",
+                       help="Append matching papers to topic seminal_works / SOTA tracker (post-merge sweep for /init)")
+    p.add_argument("wiki_root")
+
     # checkpoint-save
     p = sub.add_parser("checkpoint-save", help="Save item to batch checkpoint")
     p.add_argument("wiki_root")
@@ -2301,6 +2487,8 @@ def main():
         dedup_edges(args.wiki_root)
     elif args.command == "rebuild-index":
         rebuild_index(args.wiki_root)
+    elif args.command == "topic-backfill":
+        topic_backfill(args.wiki_root)
     elif args.command == "checkpoint-save":
         checkpoint_save(args.wiki_root, args.task_id, args.item,
                         status="failed" if args.failed else "completed")


### PR DESCRIPTION
## Summary

- **Schema centralization**: Extracted 7 duplicated constants (`ENTITY_DIRS`, `VALID_EDGE_TYPES`, `REQUIRED_FIELDS`, `VALID_VALUES`, `FIELD_DEFAULTS`) from `lint.py` and `research_wiki.py` into `tools/_schemas.py` — single source of truth. Both tools now import from `_schemas`.
- **init Step 7 lint --fix**: Step 7 ran bare `lint.py` (no `--fix`), contradicting the Step 5 SKIP comment and constraint #6 that promised "orchestrator runs lint --fix after merge". Now runs `lint --fix` then `lint` for a clean report.
- **topic-backfill command**: Even `lint --fix` couldn't repair topic xrefs (no topic patterns in `_fix_xref`). Added `topic-backfill` command that scans papers by tag-overlap and populates topic `## Seminal works` / `## SOTA tracker` sections. init Step 7 runs it before lint.

### Bug fixes

- `_append_lines_to_section`: extracted `_find_section_heading()` with exact heading match (rejects prefix collisions like `## Seminal works (extended)` matching `## Seminal works`)
- Section-scoped dedup in both branches (existing section AND missing section) — the previous version dedup'd against the entire file in the missing-section path

### Tests

- 10 new tests in `TestTopicBackfill` (tag overlap, seminal/sota split, idempotency, heading collision, section-scoped dedup)
- Schema identity test: asserts `is` identity across `_schemas`, `lint`, and `research_wiki`

### Also bundled

- Windows cross-platform support (`setup.ps1`, CLAUDE.md venv path updates)
- exp-design/exp-run/ideate SKILL.md template clarifications

## Test plan

- [x] `python -m pytest tests/ -v` — 2327 passed
- [x] Schema identity test verifies all 3 modules share the same objects
- [x] topic-backfill idempotency verified (second run adds 0 lines)
- [x] Heading prefix collision regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)