### PR TITLE
fix(skills): dedup stray lines in exp-design spec and sync active copies

### DIFF
--- a/.claude/skills/exp-design/SKILL.md
+++ b/.claude/skills/exp-design/SKILL.md
@@ -58,14 +58,14 @@ argument-hint: <idea-slug-or-hypothesis> [--review] [--budget <gpu-hours>]
 ### Step 1: Load Context
 
 1. **Parse idea input**:
-   - If slug: read `wiki/ideas/{slug}.md`, extract hypothesis, approach sketch, risks, origin_gaps, linked_papers
+   - If slug: read `wiki/ideas/{slug}.md`, extract `## Motivation`, `## Hypothesis`, `## Approach sketch`, `## Risks`, and the frontmatter fields `origin_gaps`, `tags`, `domain`, `priority` (per CLAUDE.md ideas template)
    - If free text: use directly as the hypothesis description
 2. **Load relevant wiki context**:
    - Read `wiki/graph/context_brief.md` (global context)
    - Read `wiki/graph/open_questions.md` (knowledge gaps)
-   - From idea's origin_gaps, read the corresponding `wiki/claims/*.md` (target claims)
+   - From the idea's `origin_gaps`, read the corresponding `wiki/claims/*.md` (target claims)
+   - From each target claim's `source_papers` field, read the corresponding `wiki/papers/*.md` for baseline setups and prior experiment protocols — this is the canonical path from idea → claim → paper (ideas do **not** carry a `linked_papers` field; use `origin_gaps` → `source_papers` instead)
    - Read existing `wiki/experiments/*.md` to check for similar experiments
-   - Read `wiki/papers/*.md` for related papers' experiment setups (as baseline reference)
 3. **If idea has no origin_gaps**: extract implied claims from the hypothesis description; search wiki/claims/ or flag as needing new claim creation
 
 ### Step 2: Scope Claims
@@ -92,7 +92,7 @@ Design experiment blocks for each scoped claim. Four types:
 **A. Baseline experiments (reproduce baseline)**:
 - Purpose: confirm the problem exists and the baseline is reproducible
 - Reproduce the core experiment from the most relevant paper
-- Success criterion: baseline results deviate < 5% from reported paper values
+- Success criterion: baseline results deviate < 5% from reported paper values (this threshold is the same one used by the Stage 1 decision gate below — do not introduce a different number elsewhere)
 - Compute: typically minimal
 
 **B. Validation experiments (validate Target claim)**:
@@ -136,7 +136,7 @@ Stage 0: Sanity check
 
 Stage 1: Baseline (reproduce baseline)
   └── Reproduce baseline results
-  └── Gate: baseline deviation > 10% → stop, check implementation
+  └── Gate: baseline deviation > 5% → stop, check implementation (same threshold as Step 3 success criterion)
 
 Stage 2: Validation (core verification)
   └── Validate core method on top of baseline
@@ -190,7 +190,7 @@ Revise the experiment plan based on Review LLM feedback (add missing experiments
    ```bash
    python3 tools/research_wiki.py slug "<experiment-title>"
    ```
-   Create `wiki/experiments/{slug}.md`:
+   Create `wiki/experiments/{slug}.md` following the **CLAUDE.md experiments template exactly** — every field below must be present even if empty, because `/exp-run` later uses `tools/research_wiki.py set-meta` to update them, and `set-meta` refuses to create fields that don't already exist in the frontmatter (it only updates existing keys):
    ```yaml
    ---
    title: ""
@@ -207,12 +207,20 @@ Revise the experiment plan based on Review LLM feedback (add missing experiments
      framework: ""
    metrics: []
    baseline: ""
-   outcome: ""
-   key_result: ""
-   linked_idea: ""           # idea slug
+   outcome: ""                # empty until /exp-run Phase 4 — succeeded | failed | inconclusive
+   key_result: ""             # empty until /exp-run Phase 4
+   linked_idea: "{idea-slug}" # MANDATORY: the source idea slug (reverse link to wiki/ideas/{idea-slug}.md linked_experiments)
    date_planned: YYYY-MM-DD
-   date_completed: ""
-   run_log: ""
+   date_completed: ""         # empty until /exp-run Phase 4
+   run_log: ""                # empty until /exp-run Phase 2
+   started: ""                # empty until /exp-run Phase 2 (ISO timestamp, set via set-meta)
+   estimated_hours: 0         # 0 until /exp-run Phase 2 (set via set-meta)
+   remote:                    # full block must exist so /exp-run --env remote can populate sub-fields via Edit
+     server: ""
+     gpu: ""
+     session: ""
+     started: ""
+     completed: ""
    ---
 
    ## Objective

--- a/.claude/skills/exp-run/SKILL.md
+++ b/.claude/skills/exp-run/SKILL.md
@@ -175,10 +175,24 @@ argument-hint: <experiment-slug> [--review] [--collect] [--full] [--env local|re
      --cmd "bash experiments/code/{slug}/run.sh" \
      --gpu {gpu_index}
    ```
-6. Update `wiki/experiments/{slug}.md`:
-   - status: `running`
-   - run_log: `logs/exp-{slug}.log`
-   - Add `remote:` block to frontmatter (server, gpu, session, started)
+6. Update `wiki/experiments/{slug}.md` frontmatter — all of these fields already exist (empty) because `/exp-design` wrote the full CLAUDE.md template:
+   ```bash
+   # Top-level scalar fields — use set-meta
+   python3 tools/research_wiki.py set-meta wiki/experiments/{slug}.md status running
+   python3 tools/research_wiki.py set-meta wiki/experiments/{slug}.md run_log "logs/exp-{slug}.log"
+   ```
+
+   The nested `remote:` block cannot be updated via `set-meta` (it only handles top-level scalar fields). Use the `Edit` tool directly to replace the five empty sub-field values in place. The pre-existing block in the file looks like:
+   ```yaml
+   remote:
+     server: ""
+     gpu: ""
+     session: ""
+     started: ""
+     completed: ""
+   ```
+   Use five Edit calls (one per sub-field) to set `server`, `gpu`, `session`, `started`. Leave `completed: ""` — Phase 4 fills that. If you find the `remote:` block missing from the file, that means `/exp-design` did not write the full CLAUDE.md template; stop and report the bug rather than trying to append the block here (appending would drift the file away from the canonical order and break future edits).
+
 7. **Estimate runtime** and write to frontmatter (same estimation logic as local mode):
    ```bash
    python3 tools/research_wiki.py set-meta \

--- a/.claude/skills/ideate/SKILL.md
+++ b/.claude/skills/ideate/SKILL.md
@@ -224,27 +224,65 @@ Write the validated ideas to the wiki (including eliminated ideas, with their el
    # generate slug
    python3 tools/research_wiki.py slug "<idea-title>"
    ```
-   Create `wiki/ideas/{slug}.md`:
+   Create `wiki/ideas/{slug}.md` **following the CLAUDE.md ideas template exactly** (all fields required; `lint.py` enforces `status` and `priority`):
    ```yaml
    ---
-   title: ""
-   slug: ""
+   title: "<idea title>"
+   slug: "<idea-slug>"
    status: proposed
-   origin: "ideate"
-   origin_gaps: []           # [[claim-slug]] or gap description
-   linked_papers: []         # [[paper-slug]]
-   linked_experiments: []
+   origin: "ideate: <short description of the driving gap / weak claim / paper>"
+   origin_gaps: []           # [[claim-slug]] list — claims or topics this idea targets
+   tags: []                  # 2-5 topic tags (inherit from target claims / direction)
+   domain: ""                # NLP / CV / ML Systems / Robotics (inherit from direction)
+   priority: 3               # 1-5 — see Priority computation below
+   pilot_result: ""          # empty until /exp-eval fills it
+   failure_reason: ""        # empty for proposed ideas
+   linked_experiments: []    # empty until /exp-design creates experiments
    date_proposed: YYYY-MM-DD
-   pilot_result: ""
-   failure_reason: ""
+   date_resolved: ""         # empty until validated/failed
    ---
    ```
-   Body includes: Hypothesis, Approach sketch, Feasibility, Novelty score, Review summary, Risks
+
+   **Priority computation** (maps Phase 4 signals into the 1-5 scale):
+   - If `--skip-validation`: default `priority = 3`
+   - Otherwise start from `novelty_score` (1-5 from /novelty)
+   - `+1` if `gap_alignment_bonus > 0` (directly targets a gap_map entry)
+   - `-1` if `review_score <= 4` (major issues downgrade)
+   - Clamp to `[1, 5]`
+
+   **Body sections** (exactly match the CLAUDE.md template — do not rename):
+   ```markdown
+   ## Motivation
+   Which gap / weakly_supported claim / paper limitation drives this idea. Reference wiki pages via `[[slug]]`.
+
+   ## Hypothesis
+   1-2 sentences stating the testable proposition.
+
+   ## Approach sketch
+   3-5 sentences on the proposed method. Reference `[[paper-slug]]` or `[[concept-slug]]` for any component borrowed from existing work.
+
+   ## Expected outcome
+   What success looks like (metric / claim status change), plus the Phase 4 novelty & review summary:
+   - Novelty score: N/5 — <one-line reason from /novelty>
+   - Review score: M/10 — <one-line summary from /review>
+
+   ## Risks
+   Feasibility rating (high/medium/low) + top 2-3 risks. Include the main weaknesses surfaced by /review.
+
+   ## Pilot results
+   (empty — filled by /exp-eval after running the experiment)
+
+   ## Lessons learned
+   (empty — filled by /exp-eval after the idea reaches a terminal status)
+   ```
 
 2. **Write eliminated ideas** (status: failed):
-   For ideas eliminated in Phase 3/4, also create `wiki/ideas/{slug}.md`:
-   - status: failed
-   - failure_reason: specific elimination reason (e.g. "highly similar published work exists: [paper-title]", "insufficient feasibility: GPU requirements too high")
+   For ideas eliminated in Phase 3/4, also create `wiki/ideas/{slug}.md` using the **same template above**, with these overrides:
+   - `status: failed`
+   - `priority: 1` (eliminated ideas never block higher-priority work)
+   - `date_resolved: YYYY-MM-DD` (today)
+   - `failure_reason: "[filter] <specific elimination reason>"` — the `[filter]` prefix distinguishes ideate-stage eliminations from post-experiment failures (which /exp-eval tags differently). Examples: `"[filter] highly similar published work exists: <paper-title>"`, `"[filter] insufficient feasibility: GPU requirements too high"`
+   - Body `## Motivation` and `## Hypothesis` should still be filled (so future banlist matching has content); `## Approach sketch` may be brief; `## Expected outcome` and `## Risks` can note why the idea was eliminated
    - These failed ideas become the banlist for future ideate runs
 
 3. **Add graph edges**:

--- a/.claude/skills/init/SKILL.md
+++ b/.claude/skills/init/SKILL.md
@@ -316,7 +316,7 @@ Agent({
          SKIP — fetch_s2.py references <arxiv_id>           (same reason)
          SKIP — fetch_deepxiv.py head <arxiv_id>            (section structure not needed for batch bootstrap)
          SKIP — updating wiki/index.md                       (orchestrator runs rebuild-index after merge)
-         SKIP — updating wiki/topics/*.md                    (orchestrator runs lint --fix after merge to repair all xrefs)
+         SKIP — updating wiki/topics/*.md                    (orchestrator runs `topic-backfill` + `lint --fix` after merge to repair all xrefs)
          SKIP — research_wiki.py rebuild-context-brief       (graph/ files are derived; orchestrator rebuilds ONCE after all merges. Parallel rebuilds in worktrees create guaranteed merge conflicts on context_brief.md / open_questions.md.)
          SKIP — research_wiki.py rebuild-open-questions      (same reason — never touch wiki/graph/*.md inside a subagent)
          DO   — read .tex/.pdf source thoroughly
@@ -411,7 +411,7 @@ python3 tools/research_wiki.py checkpoint-clear wiki/ "init-session"
 - **Subagents must commit before reporting back** — every agent prompt mandates a final `git add wiki/ && git commit` step. Without it, Phase B merges produce empty results. Verify each branch has a commit during the Phase B sanity check.
 - **Wait for all N completion notifications** before starting Phase B
 - **Never bypass subagents** — all paper ingestion goes through subagents running the /ingest workflow
-- **Enforce init-mode skips** — the SKIP list above eliminates redundant API calls; `lint --fix` in Step 7 repairs all skipped xrefs
+- **Enforce init-mode skips** — the SKIP list above eliminates redundant API calls. Step 7 runs `topic-backfill` (to populate topic seminal_works / SOTA tracker from merged papers) followed by `lint --fix` (to repair concept↔paper, claim↔paper, idea↔claim, experiment↔claim reverse links). Together they cover every xref a subagent skipped.
 
 ### Step 6: Generate Initial Ideas (optional)
 
@@ -437,12 +437,20 @@ After all papers are ingested:
    ```bash
    # Rebuild index.md from entity frontmatter (subagents skipped this step)
    python3 tools/research_wiki.py rebuild-index wiki/
+   # Backfill topic seminal_works / SOTA tracker from merged papers
+   # (subagents skipped wiki/topics/*.md updates in INIT MODE)
+   python3 tools/research_wiki.py topic-backfill wiki/
    # Rebuild graph context and open questions
    python3 tools/research_wiki.py rebuild-context-brief wiki/
    python3 tools/research_wiki.py rebuild-open-questions wiki/
    ```
-2. Run lint for a basic health check:
+2. Auto-repair the deterministic xrefs the subagents skipped, then re-run lint
+   for a clean health report:
    ```bash
+   # --fix repairs concept↔paper, claim↔paper, idea↔claim, experiment↔claim
+   # reverse links (the bidirectional rules from CLAUDE.md). Topic xrefs are
+   # NOT in this set — those are handled by `topic-backfill` in step 1.
+   python3 tools/lint.py --wiki-dir wiki/ --fix
    python3 tools/lint.py --wiki-dir wiki/
    ```
 3. Get statistics:
@@ -520,6 +528,7 @@ Then output a summary including:
 - `python3 tools/research_wiki.py add-edge wiki/ ...` — add graph edge
 - `python3 tools/research_wiki.py dedup-edges wiki/` — remove duplicate edges after parallel ingest merge (Step 5, Phase C)
 - `python3 tools/research_wiki.py rebuild-index wiki/` — regenerate index.md from entity frontmatter (Step 7, after all subagents complete)
+- `python3 tools/research_wiki.py topic-backfill wiki/` — append matching papers to topic seminal_works / SOTA tracker (Step 7, repairs the wiki/topics/*.md updates that subagents skipped in INIT MODE)
 - `python3 tools/research_wiki.py rebuild-context-brief wiki/` — rebuild compressed context
 - `python3 tools/research_wiki.py rebuild-open-questions wiki/` — rebuild knowledge gap map
 - `python3 tools/research_wiki.py stats wiki/` — wiki statistics
@@ -531,7 +540,7 @@ Then output a summary including:
 - `python3 tools/fetch_s2.py references <arxiv_id>` — citation-chain expansion (references)
 - `python3 tools/fetch_s2.py citations <arxiv_id>` — citation-chain expansion (citations)
 - `python3 tools/fetch_deepxiv.py search "<topic>" --mode hybrid --limit 10` — DeepXiv semantic search (optional)
-- `python3 tools/lint.py --wiki-dir wiki/` — structural check
+- `python3 tools/lint.py --wiki-dir wiki/ --fix` — structural check + auto-repair (Step 7, repairs concept↔paper, claim↔paper, idea↔claim, experiment↔claim reverse links that subagents skipped)
 - `curl` — download arXiv e-print (tex) or PDF to raw/papers/
 
 ### Skills (via Agent subagent)

--- a/i18n/en/skills/exp-design/SKILL.md
+++ b/i18n/en/skills/exp-design/SKILL.md
@@ -190,7 +190,6 @@ Revise the experiment plan based on Review LLM feedback (add missing experiments
    ```bash
    python3 tools/research_wiki.py slug "<experiment-title>"
    ```
-   Create `wiki/experiments/{slug}.md`:
    Create `wiki/experiments/{slug}.md` following the **CLAUDE.md experiments template exactly** — every field below must be present even if empty, because `/exp-run` later uses `tools/research_wiki.py set-meta` to update them, and `set-meta` refuses to create fields that don't already exist in the frontmatter (it only updates existing keys):
    ```yaml
    ---

--- a/i18n/zh/skills/exp-design/SKILL.md
+++ b/i18n/zh/skills/exp-design/SKILL.md
@@ -190,8 +190,6 @@ mcp__llm-review__chat:
    ```bash
    python3 tools/research_wiki.py slug "<experiment-title>"
    ```
-   创建 `wiki/experiments/{slug}.md`：
-   ```yaml
    创建 `wiki/experiments/{slug}.md`，**严格遵循 CLAUDE.md experiments template** —— 下方所有字段都必须存在（即使为空），因为 `/exp-run` 稍后会用 `tools/research_wiki.py set-meta` 来更新它们，而 `set-meta` 拒绝创建 frontmatter 中不存在的字段（它只更新已存在的 key）：
    ```yaml
    ---


### PR DESCRIPTION
## Summary

Small cleanup PR for the skill spec files. Two real bugs left over from the previous `fix/init-spec-consistency` PR, plus four `setup.sh` catch-up syncs.

### Bugs fixed

- **`i18n/en/skills/exp-design/SKILL.md`** — Step 6 had a duplicated `Create \`wiki/experiments/{slug}.md\`:` line stuck above the new preamble added in 1fc7738. Harmless for rendering but confusing to read.
- **`i18n/zh/skills/exp-design/SKILL.md`** — same duplication plus an orphaned ` ```yaml ` opening fence with no matching close, which structurally breaks markdown rendering of the experiment template block.

### Active-copy sync

The previous PR committed edits to `i18n/en/skills/{init,ideate,exp-design,exp-run}/SKILL.md` and `i18n/zh/...` but did **not** re-run `./setup.sh --lang en` to regenerate the active `.claude/skills/*/SKILL.md` copies. So the active copies at `origin/main` still had the old content. This PR runs setup.sh and commits the refreshed active files so they once again match their i18n sources.

Concretely the catch-up brings these into the active copies:
- `init`: `topic-backfill` wording in the subagent prompt SKIP list and the Enforce-init-mode-skips constraint
- `ideate`: Phase 5 schema alignment (tags, domain, priority, date_resolved, priority computation rule, body sections matching CLAUDE.md template)
- `exp-design`: linked_idea must be filled with the idea slug, linked_papers replaced with origin_gaps→source_papers path, unified 5% baseline-deviation threshold, full experiments template (started / estimated_hours / remote block)
- `exp-run`: explicit Edit-tool procedure for the nested remote: block since set-meta cannot create or write nested fields

## Test plan

- [x] `python -m pytest tests/ -q` — 2327 passed (no behavior change, spec-only cleanup)
- [x] `grep -cE '^[[:space:]]*\\\`\\\`\\\`'` on all modified SKILL.md files shows even fence parity (18, 18, 30, 30, 32, 32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)