### PR TITLE
Add 4 wiki toolkit scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,13 +225,66 @@ OmegaWiki/
 │   ├── fetch_s2.py              #   Semantic Scholar API
 │   ├── fetch_deepxiv.py         #   DeepXiv semantic search
 │   ├── fetch_wikipedia.py       #   Wikipedia fetcher (used by /prefill)
-│   └── remote.py                #   SSH ops for remote experiments
+│   ├── remote.py                #   SSH ops for remote experiments
+│   ├── wiki_graph.py            #   Standalone knowledge graph traversal
+│   ├── compile_context.py       #   Purpose-driven context compilation
+│   ├── find_similar.py          #   Token Jaccard dedup search
+│   └── wiki_lint.py             #   Cross-wiki structural lint
 ├── .claude/skills/              # 23 Claude Code skill definitions
 ├── i18n/                        # Bilingual: en/ (canonical) + zh/
 ├── config/                      # Configuration templates
 ├── tests/                       # 2263 tests
 ├── mcp-servers/                 # Cross-model review server
 └── .github/workflows/           # Daily arXiv cron
+```
+
+
+## Standalone Tools
+
+In addition to the main `research_wiki.py` engine and `lint.py` validator, four standalone CLI tools provide focused capabilities:
+
+### wiki_graph.py — Knowledge Graph Traversal
+
+BFS traversal, orphan detection, contradiction discovery, and wikilink seeding for `graph/edges.jsonl`.
+
+```bash
+python3 tools/wiki_graph.py wiki/ seed                          # Extract edges from wikilinks
+python3 tools/wiki_graph.py wiki/ neighbors concepts/attention --depth 2
+python3 tools/wiki_graph.py wiki/ find-contradictions
+python3 tools/wiki_graph.py wiki/ orphans
+python3 tools/wiki_graph.py wiki/ stats
+python3 tools/wiki_graph.py wiki/ add-edge --from concepts/x --to papers/y --type supports
+```
+
+### compile_context.py — Purpose-Driven Context Compilation
+
+Reads `index.md` trigger-to-page mappings and concatenates page content within a token budget. Useful for assembling focused context windows for LLM prompts.
+
+```bash
+python3 tools/compile_context.py wiki/ --list                   # Show available purposes
+python3 tools/compile_context.py wiki/ --for session-close --budget 4000
+```
+
+Purposes are auto-derived from `## By Trigger` / `### <Heading>` sections in your `index.md`.
+
+### find_similar.py — Semantic Dedup Search
+
+Token Jaccard similarity search across wiki pages. Detects near-duplicates before creating new pages.
+
+```bash
+python3 tools/find_similar.py wiki/ "attention mechanism"
+python3 tools/find_similar.py wiki/ "transformer" --type concepts
+python3 tools/find_similar.py wiki/ "failed experiment" --threshold 0.5 --top 10
+```
+
+### wiki_lint.py — Cross-Wiki Structural Lint
+
+Complements `lint.py` (entity-schema checks) with broader structural health checks: orphan pages, broken wikilinks, stale/ghost index entries, oversized pages, and duplicate filenames.
+
+```bash
+python3 tools/wiki_lint.py wiki/                                # Run all checks
+python3 tools/wiki_lint.py wiki/ --fix                          # Auto-fix safe issues
+python3 tools/wiki_lint.py wiki/ --max-lines 300 --json         # Custom threshold, JSON output
 ```
 
 ## Testing

--- a/tools/compile_context.py
+++ b/tools/compile_context.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Context Compilation CLI for ΩmegaWiki.
+
+Parses wiki index.md at runtime to build purpose-to-pages mappings,
+then concatenates page content within a token budget (chars/4 estimate).
+
+The index.md must have a "## By Trigger" section with ### subheadings
+and [[wikilink]] references to pages. Optionally, a "## By Severity"
+section assigns CRITICAL/HIGH/MEDIUM/LOW priority for ordering.
+
+Usage:
+    python3 tools/compile_context.py <wiki_root> --for scene-writing --budget 4000
+    python3 tools/compile_context.py <wiki_root> --for session-close --budget 2000
+    python3 tools/compile_context.py <wiki_root> --list
+
+Python 3.9+, no external dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import re
+import sys
+from pathlib import Path
+
+# Force UTF-8 stdout on Windows
+if sys.stdout.encoding != "utf-8":
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_index(index_path: Path) -> dict:
+    """Parse an index.md and return trigger_map and severity_map.
+
+    Expected structure:
+        ## By Trigger
+        ### <Trigger Name>
+        - [[page-slug]]
+        ...
+        ## By Severity
+        ### CRITICAL (...)
+        - [[page-slug]]
+        ...
+
+    Returns dict with keys 'triggers' and 'severity'.
+    """
+    text = index_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    trigger_map: dict[str, list[str]] = {}
+    severity_map: dict[str, str] = {}
+
+    current_h2 = ""
+    current_h3 = ""
+
+    wikilink_re = re.compile(r"\[\[([^\]]+)\]\]")
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped.startswith("## ") and not stripped.startswith("### "):
+            current_h2 = stripped[3:].strip()
+            current_h3 = ""
+            continue
+
+        if stripped.startswith("### "):
+            current_h3 = stripped[4:].strip()
+            continue
+
+        match = wikilink_re.search(stripped)
+        if not match:
+            continue
+        page_slug = match.group(1)
+
+        if current_h2 == "By Trigger" and current_h3:
+            trigger_map.setdefault(current_h3, [])
+            if page_slug not in trigger_map[current_h3]:
+                trigger_map[current_h3].append(page_slug)
+
+        if current_h2 == "By Severity" and current_h3:
+            severity_map[page_slug] = current_h3.split("(")[0].strip()
+
+    return {"triggers": trigger_map, "severity": severity_map}
+
+
+def resolve_page_path(slug: str, wiki_root: Path) -> Path:
+    """Convert a page slug to a filesystem Path relative to wiki_root."""
+    return wiki_root / (slug + ".md")
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count as chars / 4."""
+    return len(text) // 4
+
+
+SEVERITY_ORDER = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3}
+
+
+def get_severity_rank(slug: str, severity_map: dict) -> int:
+    sev = severity_map.get(slug, "")
+    return SEVERITY_ORDER.get(sev, 99)
+
+
+def slugify_heading(heading: str) -> str:
+    """Convert a trigger heading to a CLI-friendly name.
+
+    'Prose Writing (MANDATORY retrieval)' -> 'prose-writing'
+    'Session Close' -> 'session-close'
+    """
+    base = heading.split("(")[0].strip()
+    return re.sub(r"[^a-z0-9]+", "-", base.lower()).strip("-")
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+def build_purpose_map(trigger_map: dict[str, list[str]]) -> dict[str, str]:
+    """Build bidirectional purpose <-> heading lookup from trigger_map keys."""
+    purpose_to_heading: dict[str, str] = {}
+    for heading in trigger_map:
+        purpose = slugify_heading(heading)
+        purpose_to_heading[purpose] = heading
+    return purpose_to_heading
+
+
+def get_pages_for_purpose(purpose: str, parsed: dict,
+                          purpose_map: dict[str, str]) -> list[str]:
+    heading = purpose_map.get(purpose)
+    if not heading:
+        return []
+    return list(parsed["triggers"].get(heading, []))
+
+
+def compile_context(purpose: str, budget: int, parsed: dict,
+                    purpose_map: dict[str, str], wiki_root: Path) -> str:
+    """Compile context pages for a purpose within a token budget.
+
+    Pages are sorted by severity (CRITICAL first), then truncated if over budget.
+    """
+    slugs = get_pages_for_purpose(purpose, parsed, purpose_map)
+    if not slugs:
+        return f"# No pages found for purpose: {purpose}\n"
+
+    severity_map = parsed["severity"]
+    slugs.sort(key=lambda s: get_severity_rank(s, severity_map))
+
+    sections: list[str] = []
+    tokens_used = 0
+
+    for slug in slugs:
+        page_path = resolve_page_path(slug, wiki_root)
+        if not page_path.exists():
+            section = f"<!-- WARNING: {slug}.md not found -->"
+            section_tokens = estimate_tokens(section)
+        else:
+            content = page_path.read_text(encoding="utf-8")
+            section = content
+            section_tokens = estimate_tokens(content)
+
+        header = f"\n# Source: {slug}\n"
+        separator = "\n---\n"
+        overhead = estimate_tokens(header + separator)
+        total_needed = section_tokens + overhead
+
+        if tokens_used + total_needed > budget:
+            remaining_tokens = budget - tokens_used - overhead
+            if remaining_tokens > 50:
+                remaining_chars = remaining_tokens * 4
+                truncated = section[:remaining_chars]
+                last_nl = truncated.rfind("\n")
+                if last_nl > 0:
+                    truncated = truncated[:last_nl]
+                truncated += "\n\n<!-- TRUNCATED: token budget reached -->"
+                sections.append(separator + header + truncated)
+                tokens_used = budget
+            else:
+                sections.append(
+                    f"\n---\n# SKIPPED: {slug} (and {len(slugs) - len(sections) - 1} more) -- budget exhausted\n"
+                )
+            break
+        else:
+            sections.append(separator + header + section)
+            tokens_used += total_needed
+
+    heading_label = purpose_map.get(purpose, purpose)
+    preamble = (
+        f"# Compiled Context: {purpose} ({heading_label})\n"
+        f"# Budget: {budget} tokens | Used: ~{tokens_used} tokens | "
+        f"Pages: {len([s for s in sections if 'SKIPPED' not in s])}/{len(slugs)}\n"
+    )
+
+    return preamble + "".join(sections) + "\n"
+
+
+def list_purposes(parsed: dict, purpose_map: dict[str, str]) -> str:
+    lines = ["Available purposes:\n"]
+    for purpose in sorted(purpose_map):
+        heading = purpose_map[purpose]
+        page_slugs = parsed["triggers"].get(heading, [])
+        lines.append(f"  {purpose:<30s} ({len(page_slugs)} pages) -- {heading}")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compile wiki context pages for a specific purpose within a token budget."
+    )
+    parser.add_argument("wiki_root", help="Path to the wiki/ directory (must contain index.md)")
+    parser.add_argument(
+        "--for", dest="purpose", type=str,
+        help="Purpose name (auto-derived from index.md headings, e.g. session-close)"
+    )
+    parser.add_argument(
+        "--budget", type=int, default=4000,
+        help="Token budget (estimated as chars/4). Default: 4000"
+    )
+    parser.add_argument(
+        "--list", action="store_true",
+        help="List all available purposes and exit"
+    )
+
+    args = parser.parse_args()
+    wiki_root = Path(args.wiki_root).resolve()
+
+    index_path = wiki_root / "index.md"
+    if not index_path.exists():
+        print(f"ERROR: index.md not found at {index_path}", file=sys.stderr)
+        return 1
+
+    parsed = parse_index(index_path)
+    purpose_map = build_purpose_map(parsed["triggers"])
+
+    if args.list:
+        print(list_purposes(parsed, purpose_map))
+        return 0
+
+    if not args.purpose:
+        parser.print_help()
+        return 1
+
+    if args.purpose not in purpose_map:
+        print(f"ERROR: Unknown purpose '{args.purpose}'", file=sys.stderr)
+        print(f"Available: {', '.join(sorted(purpose_map))}", file=sys.stderr)
+        return 1
+
+    output = compile_context(args.purpose, args.budget, parsed, purpose_map, wiki_root)
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/find_similar.py
+++ b/tools/find_similar.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Semantic dedup tool -- Token Jaccard similarity search across wiki pages.
+
+Finds pages whose title/body are similar to a free-text query, useful for
+detecting near-duplicates before creating new pages and for discovering
+related content across entity types.
+
+Usage:
+    python3 tools/find_similar.py <wiki_root> "attention mechanism"
+    python3 tools/find_similar.py <wiki_root> "transformer architecture" --type concepts
+    python3 tools/find_similar.py <wiki_root> "failed experiment" --threshold 0.5
+
+Python 3.9+, no external dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import re
+import string
+import sys
+from pathlib import Path
+
+from _schemas import ENTITY_DIRS
+
+# Force UTF-8 output on Windows
+if sys.stdout.encoding != "utf-8":
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+if sys.stderr.encoding != "utf-8":
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+THRESHOLD_POTENTIAL = 0.35
+THRESHOLD_LIKELY = 0.65
+
+# English top-100 stopwords (hardcoded, no nltk)
+STOPWORDS: set[str] = {
+    "a", "about", "above", "after", "again", "against", "all", "am", "an",
+    "and", "any", "are", "aren't", "as", "at", "be", "because", "been",
+    "before", "being", "below", "between", "both", "but", "by", "can",
+    "can't", "cannot", "could", "couldn't", "did", "didn't", "do", "does",
+    "doesn't", "doing", "don't", "down", "during", "each", "few", "for",
+    "from", "further", "get", "got", "had", "hadn't", "has", "hasn't",
+    "have", "haven't", "having", "he", "her", "here", "hers", "herself",
+    "him", "himself", "his", "how", "i", "if", "in", "into", "is", "isn't",
+    "it", "its", "itself", "just", "let", "me", "might", "more", "most",
+    "must", "my", "myself", "no", "nor", "not", "now", "of", "off", "on",
+    "once", "only", "or", "other", "our", "ours", "ourselves", "out",
+    "over", "own", "s", "same", "she", "should", "shouldn't", "so", "some",
+    "such", "t", "than", "that", "the", "their", "theirs", "them",
+    "themselves", "then", "there", "these", "they", "this", "those",
+    "through", "to", "too", "under", "until", "up", "very", "was",
+    "wasn't", "we", "were", "weren't", "what", "when", "where", "which",
+    "while", "who", "whom", "why", "will", "with", "won't", "would",
+    "wouldn't", "you", "your", "yours", "yourself", "yourselves",
+}
+
+# ---------------------------------------------------------------------------
+# Tokenisation
+# ---------------------------------------------------------------------------
+
+_PUNCT_TABLE = str.maketrans("", "", string.punctuation)
+
+
+def tokenize(text: str) -> set[str]:
+    """Lowercase, strip punctuation, remove stopwords, return token set."""
+    words = text.lower().translate(_PUNCT_TABLE).split()
+    return {w for w in words if w and w not in STOPWORDS}
+
+
+def jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+# ---------------------------------------------------------------------------
+# Page loader
+# ---------------------------------------------------------------------------
+
+
+def _parse_yaml_frontmatter(content: str) -> dict[str, str]:
+    """Extract simple key: value pairs from YAML frontmatter."""
+    fm: dict[str, str] = {}
+    if not content.startswith("---"):
+        return fm
+    end = content.find("\n---", 3)
+    if end == -1:
+        return fm
+    block = content[3:end]
+    for line in block.splitlines():
+        if ":" in line:
+            key, _, val = line.partition(":")
+            fm[key.strip()] = val.strip()
+    return fm
+
+
+def _first_paragraph(content: str) -> str:
+    """Return first non-frontmatter, non-heading paragraph text."""
+    text = content
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            text = text[end + 4:]
+    lines: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            if lines:
+                break
+            continue
+        if stripped.startswith("#"):
+            if lines:
+                break
+            continue
+        lines.append(stripped)
+    return " ".join(lines)
+
+
+def load_wiki_pages(wiki_root: Path,
+                    entity_filter: str | None = None) -> list[tuple[str, str, str]]:
+    """Walk wiki entity directories, extract title + first paragraph.
+
+    Returns (label, title, body) triples.
+    """
+    entries: list[tuple[str, str, str]] = []
+    dirs_to_scan = [entity_filter] if entity_filter else ENTITY_DIRS
+
+    for subdir_name in dirs_to_scan:
+        subdir = wiki_root / subdir_name
+        if not subdir.is_dir():
+            continue
+        for md_file in sorted(subdir.rglob("*.md")):
+            try:
+                content = md_file.read_text(encoding="utf-8")
+            except Exception:
+                continue
+            fm = _parse_yaml_frontmatter(content)
+            title = fm.get("title", "") or fm.get("name", "")
+            if not title:
+                title = md_file.stem.replace("-", " ").replace("_", " ").title()
+            first_para = _first_paragraph(content)
+            rel = md_file.relative_to(wiki_root)
+            label = str(rel).replace("\\", "/")
+            entries.append((label, title, first_para))
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Search + display
+# ---------------------------------------------------------------------------
+
+
+def score_entry(query_tokens: set[str], title: str, body: str) -> float:
+    """Score an entry against query tokens.
+
+    Uses weighted Jaccard: best of title-only Jaccard and an asymmetric
+    Jaccard against full entry that compensates for length mismatch.
+    """
+    title_tokens = tokenize(title)
+    all_tokens = tokenize(f"{title} {body}")
+
+    s1 = jaccard(query_tokens, title_tokens)
+
+    intersection = len(query_tokens & all_tokens)
+    if not query_tokens or not all_tokens:
+        s2 = 0.0
+    else:
+        excess = max(0, len(all_tokens) - len(query_tokens))
+        denominator = len(query_tokens) + excess * 0.05
+        s2 = intersection / denominator if denominator else 0.0
+
+    return max(s1, s2)
+
+
+def search(query: str, wiki_root: Path, entity_filter: str | None = None,
+           top_n: int = 15, threshold: float = THRESHOLD_POTENTIAL
+           ) -> list[tuple[float, str, str]]:
+    """Return ranked (score, label, snippet) list."""
+    entries = load_wiki_pages(wiki_root, entity_filter)
+    if not entries:
+        print(f"No pages found in {wiki_root}", file=sys.stderr)
+        return []
+    query_tokens = tokenize(query)
+    if not query_tokens:
+        print("ERROR: query produced no tokens after stopword removal", file=sys.stderr)
+        sys.exit(1)
+
+    results: list[tuple[float, str, str]] = []
+    for label, title, body in entries:
+        score = score_entry(query_tokens, title, body)
+        if score >= threshold:
+            snippet = f"{title}"
+            body_start = body[:60].replace("\n", " ").strip()
+            if body_start:
+                snippet += f" -- {body_start}"
+                if len(body) > 60:
+                    snippet += "..."
+            results.append((score, label, snippet))
+
+    results.sort(key=lambda x: x[0], reverse=True)
+    return results[:top_n]
+
+
+def format_results(results: list[tuple[float, str, str]],
+                   likely: float = THRESHOLD_LIKELY) -> str:
+    if not results:
+        return "  No matches above threshold"
+    lines: list[str] = []
+    for score, label, snippet in results:
+        pct = int(score * 100)
+        tag = "[LIKELY DUP]" if score >= likely else "[POTENTIAL] "
+        lines.append(f"  {pct:3d}% {tag} {label} -- \"{snippet}\"")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Find similar wiki pages using Token Jaccard similarity."
+    )
+    parser.add_argument("wiki_root", help="Path to the wiki/ directory")
+    parser.add_argument(
+        "query", nargs="+",
+        help="Free-text query to match against"
+    )
+    parser.add_argument(
+        "--type", default=None, choices=ENTITY_DIRS,
+        help="Restrict search to a single entity directory"
+    )
+    parser.add_argument(
+        "--top", type=int, default=15,
+        help="Max results to show (default: 15)"
+    )
+    parser.add_argument(
+        "--threshold", type=float, default=None,
+        help="Minimum similarity (0.0-1.0). Default: 0.35"
+    )
+    args = parser.parse_args()
+
+    threshold = args.threshold if args.threshold is not None else THRESHOLD_POTENTIAL
+    query_str = " ".join(args.query)
+    wiki_root = Path(args.wiki_root).resolve()
+
+    results = search(query_str, wiki_root, args.type, args.top, threshold)
+    print(format_results(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/wiki_graph.py
+++ b/tools/wiki_graph.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Typed Knowledge Graph Layer for ΩmegaWiki.
+
+CLI tool for managing a JSONL-based knowledge graph over wiki pages.
+Supplements the graph commands in research_wiki.py with standalone
+traversal, seeding, and orphan detection.
+
+Commands:
+    add-edge    Append an edge to edges.jsonl (dedup on from,to,type)
+    neighbors   BFS traversal from a node
+    find-contradictions  Return all contradiction edges
+    orphans     Find wiki pages with zero edges
+    seed        Walk wiki files and extract wikilinks as edges
+    stats       Print edge/node counts
+
+Usage:
+    python3 tools/wiki_graph.py <wiki_root> add-edge --from X --to Y --type T --evidence "reason"
+    python3 tools/wiki_graph.py <wiki_root> neighbors papers/attention --depth 2 --type supports
+    python3 tools/wiki_graph.py <wiki_root> find-contradictions
+    python3 tools/wiki_graph.py <wiki_root> orphans
+    python3 tools/wiki_graph.py <wiki_root> seed
+    python3 tools/wiki_graph.py <wiki_root> stats
+
+Python 3.9+, no external dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import defaultdict, deque
+from datetime import date
+from pathlib import Path
+
+from _schemas import ENTITY_DIRS, VALID_EDGE_TYPES
+
+# ---------------------------------------------------------------------------
+# Edge I/O
+# ---------------------------------------------------------------------------
+
+def _edges_file(wiki_root: Path) -> Path:
+    return wiki_root / "graph" / "edges.jsonl"
+
+
+def load_edges(wiki_root: Path) -> list[dict]:
+    """Load all edges from the JSONL file."""
+    path = _edges_file(wiki_root)
+    edges: list[dict] = []
+    if path.exists():
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    edges.append(json.loads(line))
+    return edges
+
+
+def save_edge(wiki_root: Path, edge: dict) -> None:
+    """Append a single edge to the JSONL file."""
+    path = _edges_file(wiki_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(edge, ensure_ascii=False) + "\n")
+
+
+def edge_key(edge: dict) -> tuple:
+    return (edge["from"], edge["to"], edge["type"])
+
+
+def load_existing_keys(wiki_root: Path) -> set:
+    """Return set of (from, to, type) tuples for dedup."""
+    return {edge_key(e) for e in load_edges(wiki_root)}
+
+
+# ---------------------------------------------------------------------------
+# Slug resolution
+# ---------------------------------------------------------------------------
+
+def resolve_slug(slug: str, wiki_root: Path) -> str | None:
+    """Given a bare slug like 'attention', find its canonical relative path
+    (e.g., 'concepts/attention'). Returns None if not found."""
+    if "/" in slug:
+        candidate = wiki_root / (slug + ".md")
+        if candidate.exists():
+            return slug
+        candidate = wiki_root / slug
+        if candidate.exists():
+            return slug.replace(".md", "")
+        return None
+
+    # Search across entity directories
+    for subdir_name in ENTITY_DIRS:
+        subdir = wiki_root / subdir_name
+        if not subdir.is_dir():
+            continue
+        candidate = subdir / (slug + ".md")
+        if candidate.exists():
+            return f"{subdir_name}/{slug}"
+
+    # Also check any other top-level dirs
+    for subdir in wiki_root.iterdir():
+        if not subdir.is_dir():
+            continue
+        if subdir.name == "graph":
+            continue
+        candidate = subdir / (slug + ".md")
+        if candidate.exists():
+            return f"{subdir.name}/{slug}"
+    return None
+
+
+def file_to_node(filepath: Path, wiki_root: Path) -> str:
+    """Convert a file path to a node identifier like 'concepts/attention'."""
+    rel = filepath.relative_to(wiki_root)
+    return str(rel).replace("\\", "/").replace(".md", "")
+
+
+# ---------------------------------------------------------------------------
+# Wikilink extraction
+# ---------------------------------------------------------------------------
+
+WIKILINK_RE = re.compile(r"\[\[([^\]\|]+?)(?:\|[^\]]+?)?\]\]")
+
+# Frontmatter relationship keys and the edge types they imply
+FRONTMATTER_TYPE_MAP = {
+    "related_entities": "supports",
+    "related_topics": "supports",
+    "related_concepts": "supports",
+    "key_papers": "supports",
+    "source_papers": "supports",
+}
+
+
+def extract_wikilinks_from_file(filepath: Path) -> list[tuple[str, str]]:
+    """Extract (target_slug, edge_type) pairs from a wiki file.
+
+    Parses both YAML frontmatter related_* fields and body [[wikilinks]].
+    """
+    try:
+        text = filepath.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    links: list[tuple[str, str]] = []
+    in_frontmatter = False
+    frontmatter_done = False
+    current_fm_key: str | None = None
+
+    for i, line in enumerate(text.split("\n")):
+        if i == 0 and line.strip() == "---":
+            in_frontmatter = True
+            continue
+        if in_frontmatter and line.strip() == "---":
+            in_frontmatter = False
+            frontmatter_done = True
+            continue
+
+        if in_frontmatter:
+            for fm_key, etype in FRONTMATTER_TYPE_MAP.items():
+                if line.startswith(fm_key + ":"):
+                    current_fm_key = fm_key
+                    for match in WIKILINK_RE.finditer(line):
+                        links.append((match.group(1).strip(), etype))
+                    break
+            else:
+                if current_fm_key and (line.startswith("  ") or line.startswith("- ")):
+                    etype = FRONTMATTER_TYPE_MAP.get(current_fm_key, "supports")
+                    for match in WIKILINK_RE.finditer(line):
+                        links.append((match.group(1).strip(), etype))
+                else:
+                    current_fm_key = None
+        else:
+            for match in WIKILINK_RE.finditer(line):
+                links.append((match.group(1).strip(), "supports"))
+
+    return links
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+def cmd_add_edge(args) -> None:
+    """Add a single edge with dedup."""
+    wiki_root = Path(args.wiki_root).resolve()
+    if args.type not in VALID_EDGE_TYPES:
+        print(f"ERROR: Invalid type '{args.type}'. Valid: {', '.join(sorted(VALID_EDGE_TYPES))}", file=sys.stderr)
+        sys.exit(1)
+
+    edge = {
+        "from": args.from_node,
+        "to": args.to_node,
+        "type": args.type,
+        "evidence": args.evidence or "",
+        "date": date.today().isoformat(),
+    }
+
+    existing = load_existing_keys(wiki_root)
+    key = edge_key(edge)
+    if key in existing:
+        print(f"SKIP (duplicate): {key}")
+        return
+
+    save_edge(wiki_root, edge)
+    print(f"ADDED: {args.from_node} --[{args.type}]--> {args.to_node}")
+
+
+def cmd_neighbors(args) -> None:
+    """BFS traversal from a node."""
+    wiki_root = Path(args.wiki_root).resolve()
+    edges = load_edges(wiki_root)
+    target = args.node
+    depth = args.depth
+    type_filter = args.type
+
+    adj: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+    for e in edges:
+        if type_filter and e["type"] != type_filter:
+            continue
+        adj[e["from"]].append((e["to"], e["type"], "->"))
+        adj[e["to"]].append((e["from"], e["type"], "<-"))
+
+    if target not in adj:
+        resolved = resolve_slug(target.split("/")[-1] if "/" in target else target, wiki_root)
+        if resolved and resolved in adj:
+            target = resolved
+        else:
+            print(f"Node '{target}' not found in graph.")
+            return
+
+    visited = {target}
+    queue: deque[tuple[str, int]] = deque([(target, 0)])
+    results: list[tuple[str, int, str, str]] = []
+
+    while queue:
+        node, d = queue.popleft()
+        if d >= depth:
+            continue
+        for neighbor, etype, direction in adj[node]:
+            if neighbor not in visited:
+                visited.add(neighbor)
+                results.append((neighbor, d + 1, etype, direction))
+                queue.append((neighbor, d + 1))
+
+    if not results:
+        print(f"No neighbors found for '{target}' within depth {depth}.")
+        return
+
+    print(f"Neighbors of '{target}' (depth {depth}):")
+    for node, d, etype, direction in sorted(results, key=lambda x: (x[1], x[0])):
+        print(f"  [d={d}] {node}  ({direction} {etype})")
+
+
+def cmd_find_contradictions(args) -> None:
+    """Return all edges where type=contradicts."""
+    wiki_root = Path(args.wiki_root).resolve()
+    edges = load_edges(wiki_root)
+    contradictions = [e for e in edges if e["type"] == "contradicts"]
+
+    if not contradictions:
+        print("No contradictions found.")
+        return
+
+    print(f"Found {len(contradictions)} contradiction(s):")
+    for e in contradictions:
+        print(f"  {e['from']} <-> {e['to']}: {e.get('evidence', '')}")
+
+
+def cmd_orphans(args) -> None:
+    """Find wiki pages with zero edges."""
+    wiki_root = Path(args.wiki_root).resolve()
+    edges = load_edges(wiki_root)
+    connected = set()
+    for e in edges:
+        connected.add(e["from"])
+        connected.add(e["to"])
+
+    all_pages = set()
+    for subdir_name in ENTITY_DIRS:
+        subdir = wiki_root / subdir_name
+        if not subdir.is_dir():
+            continue
+        for md_file in subdir.rglob("*.md"):
+            node = file_to_node(md_file, wiki_root)
+            all_pages.add(node)
+
+    orphans = sorted(all_pages - connected)
+    if not orphans:
+        print("No orphan pages found -- all pages have at least one edge.")
+        return
+
+    print(f"Found {len(orphans)} orphan page(s) with zero edges:")
+    for o in orphans:
+        print(f"  {o}")
+
+
+def cmd_seed(args) -> None:
+    """Walk wiki files and extract wikilinks as edges."""
+    wiki_root = Path(args.wiki_root).resolve()
+    existing_keys = load_existing_keys(wiki_root)
+    added = 0
+    skipped = 0
+
+    for subdir_name in ENTITY_DIRS:
+        subdir = wiki_root / subdir_name
+        if not subdir.is_dir():
+            continue
+        for md_file in sorted(subdir.rglob("*.md")):
+            from_node = file_to_node(md_file, wiki_root)
+            links = extract_wikilinks_from_file(md_file)
+
+            for target_slug, edge_type in links:
+                resolved = resolve_slug(target_slug, wiki_root)
+                if resolved is None or resolved == from_node:
+                    continue
+
+                edge = {
+                    "from": from_node,
+                    "to": resolved,
+                    "type": edge_type,
+                    "evidence": f"Wikilink in {from_node}",
+                    "date": date.today().isoformat(),
+                }
+
+                key = edge_key(edge)
+                if key in existing_keys:
+                    skipped += 1
+                    continue
+
+                existing_keys.add(key)
+                save_edge(wiki_root, edge)
+                added += 1
+
+    print(f"Seeding complete: {added} edges added, {skipped} duplicates skipped.")
+
+
+def cmd_stats(args) -> None:
+    """Print edge and node counts."""
+    wiki_root = Path(args.wiki_root).resolve()
+    edges = load_edges(wiki_root)
+    nodes: set[str] = set()
+    type_counts: dict[str, int] = defaultdict(int)
+    for e in edges:
+        nodes.add(e["from"])
+        nodes.add(e["to"])
+        type_counts[e["type"]] += 1
+
+    print(f"Total edges: {len(edges)}")
+    print(f"Unique nodes: {len(nodes)}")
+    print("Edges by type:")
+    for t in sorted(type_counts):
+        print(f"  {t}: {type_counts[t]}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Typed Knowledge Graph Layer for ΩmegaWiki"
+    )
+    parser.add_argument("wiki_root", help="Path to the wiki/ directory")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # add-edge
+    p_add = subparsers.add_parser("add-edge", help="Add an edge to the graph")
+    p_add.add_argument("--from", dest="from_node", required=True, help="Source node")
+    p_add.add_argument("--to", dest="to_node", required=True, help="Target node")
+    p_add.add_argument("--type", required=True,
+                       help=f"Edge type: {', '.join(sorted(VALID_EDGE_TYPES))}")
+    p_add.add_argument("--evidence", default="", help="Evidence/reason for edge")
+    p_add.set_defaults(func=cmd_add_edge)
+
+    # neighbors
+    p_nb = subparsers.add_parser("neighbors", help="BFS traversal from a node")
+    p_nb.add_argument("node", help="Starting node (e.g., concepts/attention)")
+    p_nb.add_argument("--depth", type=int, default=1, help="Max traversal depth (default: 1)")
+    p_nb.add_argument("--type", default=None, help="Filter by edge type")
+    p_nb.set_defaults(func=cmd_neighbors)
+
+    # find-contradictions
+    p_fc = subparsers.add_parser("find-contradictions", help="Find all contradiction edges")
+    p_fc.set_defaults(func=cmd_find_contradictions)
+
+    # orphans
+    p_or = subparsers.add_parser("orphans", help="Find wiki pages with zero edges")
+    p_or.set_defaults(func=cmd_orphans)
+
+    # seed
+    p_seed = subparsers.add_parser("seed", help="Seed edges from existing wikilinks")
+    p_seed.set_defaults(func=cmd_seed)
+
+    # stats
+    p_stats = subparsers.add_parser("stats", help="Print graph statistics")
+    p_stats.set_defaults(func=cmd_stats)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/wiki_lint.py
+++ b/tools/wiki_lint.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Extended wiki lint -- structural checks for ΩmegaWiki.
+
+Complements tools/lint.py (entity-schema-aware, frontmatter-focused) with
+broader structural checks that apply to any wiki directory layout:
+orphan pages, broken wikilinks, stale/ghost index entries, oversized pages,
+and duplicate filenames.
+
+Use lint.py for entity-specific schema validation.
+Use wiki_lint.py for cross-wiki structural health.
+
+Checks:
+    1. Orphan pages: pages with zero inbound links
+    2. Broken wikilinks: [[slug]] resolving to no file
+    3. Stale index: page exists on disk but not in index.md
+    4. Ghost index: entry in index.md with no corresponding file
+    5. Oversized pages: page > 500 lines (configurable)
+    6. Duplicate filenames: two pages with same slug in different subdirs
+
+Usage:
+    python3 tools/wiki_lint.py <wiki_root>
+    python3 tools/wiki_lint.py <wiki_root> --fix
+    python3 tools/wiki_lint.py <wiki_root> --max-lines 300
+    python3 tools/wiki_lint.py <wiki_root> --json
+
+Python 3.9+, no external dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json as json_module
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+# Force UTF-8 output on Windows
+if sys.stdout.encoding != "utf-8":
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+if sys.stderr.encoding != "utf-8":
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class Finding:
+    def __init__(self, severity: str, check: str, message: str):
+        self.severity = severity  # ERROR or WARN
+        self.check = check
+        self.message = message
+
+    def __str__(self):
+        return f"[{self.severity}] {self.message}"
+
+    def to_dict(self) -> dict:
+        return {"severity": self.severity, "check": self.check, "message": self.message}
+
+
+def collect_md_files(root: Path) -> List[Path]:
+    """Recursively collect .md files."""
+    return sorted(root.rglob("*.md"))
+
+
+def read_file(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def count_lines(path: Path) -> int:
+    content = read_file(path)
+    if not content:
+        return 0
+    return content.count("\n") + (1 if not content.endswith("\n") else 0)
+
+
+def extract_wikilinks(content: str) -> List[Tuple[str, int]]:
+    """Extract all [[slug]] wikilinks with line numbers."""
+    results = []
+    for i, line in enumerate(content.splitlines(), 1):
+        for m in re.finditer(r'\[\[([^\]]+)\]\]', line):
+            raw = m.group(1)
+            slug = raw.split("|")[0].strip()
+            results.append((slug, i))
+    return results
+
+
+def extract_md_links(content: str) -> List[Tuple[str, int]]:
+    """Extract [text](path.md) markdown links with line numbers."""
+    results = []
+    for i, line in enumerate(content.splitlines(), 1):
+        for m in re.finditer(r'\[([^\]]*)\]\(([^)]+\.md[^)]*)\)', line):
+            results.append((m.group(2), i))
+    return results
+
+
+def build_slug_index(root: Path, all_files: Set[Path]) -> Dict[str, Path]:
+    """Build a slug-to-resolved-path index for fast wikilink resolution."""
+    index: Dict[str, Path] = {}
+    for f in all_files:
+        try:
+            rel = f.relative_to(root.resolve())
+        except ValueError:
+            continue
+        rel_str = str(rel).replace("\\", "/")
+        path_no_ext = rel_str.replace(".md", "")
+        if path_no_ext not in index:
+            index[path_no_ext] = f
+        stem = f.stem
+        if stem not in index:
+            index[stem] = f
+        if stem == "index" and f.parent != root.resolve():
+            parent_rel = str(f.parent.relative_to(root.resolve())).replace("\\", "/")
+            if parent_rel not in index:
+                index[parent_rel] = f
+    return index
+
+
+def resolve_wikilink(slug: str, slug_index: Dict[str, Path]) -> bool:
+    slug_clean = slug.strip().replace("\\", "/")
+    if slug_clean in slug_index:
+        return True
+    slug_stripped = slug_clean.strip("/")
+    if slug_stripped in slug_index:
+        return True
+    bare = slug_stripped.split("/")[-1]
+    if bare in slug_index:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+def check_orphan_pages(root: Path, all_files: Set[Path],
+                       slug_index: Dict[str, Path]) -> List[Finding]:
+    """Check 1: Pages with no inbound links from other pages."""
+    findings = []
+    referenced_files: Set[Path] = set()
+
+    for f in all_files:
+        content = read_file(f)
+        for slug, _ in extract_wikilinks(content):
+            slug_clean = slug.strip().replace("\\", "/")
+            for key in [slug_clean, slug_clean.strip("/"), slug_clean.split("/")[-1]]:
+                if key in slug_index:
+                    referenced_files.add(slug_index[key])
+                    break
+        for link, _ in extract_md_links(content):
+            target = (f.parent / link.split("#")[0]).resolve()
+            if target in all_files:
+                referenced_files.add(target)
+
+    index_file = (root / "index.md").resolve()
+    skip_names = {"readme.md", "log.md", "overview.md", "index.md"}
+
+    for f in all_files:
+        if f.name.lower() in skip_names:
+            continue
+        if f.resolve() == index_file:
+            continue
+        if f.resolve() not in referenced_files:
+            rel = f.relative_to(root)
+            findings.append(Finding("WARN", "orphan-page",
+                                    f"orphan page {rel} (0 inbound links)"))
+    return findings
+
+
+def check_broken_wikilinks(root: Path, all_files: Set[Path],
+                           slug_index: Dict[str, Path]) -> List[Finding]:
+    """Check 2: [[slug]] that resolves to no file."""
+    findings = []
+    for f in all_files:
+        content = read_file(f)
+        rel = f.relative_to(root)
+        for slug, line_no in extract_wikilinks(content):
+            if not resolve_wikilink(slug, slug_index):
+                findings.append(Finding("ERROR", "broken-wikilink",
+                                        f"broken wikilink [[{slug}]] in {rel}:{line_no}"))
+    return findings
+
+
+def check_stale_index(root: Path, all_files: Set[Path],
+                      index_content: str) -> List[Finding]:
+    """Check 3: Page exists on disk but not listed in index.md."""
+    findings = []
+    index_path = (root / "index.md").resolve()
+    index_text = index_content.lower()
+    skip_names = {"readme.md", "log.md", "overview.md", "index.md"}
+
+    for f in all_files:
+        if f.name.lower() in skip_names:
+            continue
+        if f.resolve() == index_path:
+            continue
+
+        rel = f.relative_to(root)
+        rel_str = str(rel).replace("\\", "/")
+        stem = f.stem
+        path_no_ext = rel_str.replace(".md", "")
+
+        referenced = (
+            rel_str.lower() in index_text
+            or path_no_ext.lower() in index_text
+            or f"[[{stem}]]".lower() in index_text
+            or f"[[{path_no_ext}]]".lower() in index_text
+            or f"({rel_str})".lower() in index_text
+            or f"({path_no_ext})".lower() in index_text
+        )
+
+        if not referenced:
+            findings.append(Finding("ERROR", "stale-index",
+                                    f"page {rel} exists on disk but not in index.md"))
+    return findings
+
+
+def check_ghost_index(root: Path, all_files: Set[Path],
+                      index_content: str,
+                      slug_index: Dict[str, Path]) -> List[Finding]:
+    """Check 4: Entry in index.md but no corresponding file."""
+    findings = []
+    index_file = root / "index.md"
+    resolved_files = {f.resolve() for f in all_files}
+
+    for slug, line_no in extract_wikilinks(index_content):
+        if not resolve_wikilink(slug, slug_index):
+            findings.append(Finding("ERROR", "ghost-index",
+                                    f"ghost index entry [[{slug}]] in index.md:{line_no}"))
+
+    for link, line_no in extract_md_links(index_content):
+        target_path = link.split("#")[0]
+        resolved = (index_file.parent / target_path).resolve()
+        if resolved not in resolved_files and not resolved.exists():
+            findings.append(Finding("ERROR", "ghost-index",
+                                    f'ghost index entry "{target_path}" in index.md:{line_no}'))
+    return findings
+
+
+def check_oversized_pages(root: Path, all_files: Set[Path],
+                          max_lines: int) -> List[Finding]:
+    """Check 5: Page > max_lines lines."""
+    findings = []
+    for f in all_files:
+        lines = count_lines(f)
+        if lines > max_lines:
+            rel = f.relative_to(root)
+            findings.append(Finding("WARN", "oversized-page",
+                                    f"oversized page {rel} ({lines} lines, limit {max_lines})"))
+    return findings
+
+
+def check_duplicate_filenames(root: Path, all_files: Set[Path]) -> List[Finding]:
+    """Check 6: Two pages with same slug in different subdirs."""
+    findings = []
+    seen: Dict[str, List[Path]] = {}
+    skip_stems = {"index", "readme", "log", "overview"}
+
+    for f in all_files:
+        stem = f.stem.lower()
+        if stem in skip_stems:
+            continue
+        seen.setdefault(stem, []).append(f)
+
+    for stem, paths in seen.items():
+        if len(paths) > 1:
+            rel_paths = [str(p.relative_to(root)) for p in paths]
+            findings.append(Finding("WARN", "duplicate-filename",
+                                    f"duplicate slug '{stem}' in: {', '.join(rel_paths)}"))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Auto-fix
+# ---------------------------------------------------------------------------
+
+def fix_stale_index(root: Path, stale_findings: List[Finding]) -> None:
+    """Add missing entries to index.md for stale-index findings."""
+    index_path = root / "index.md"
+    content = read_file(index_path)
+
+    additions = []
+    for f in stale_findings:
+        match = re.search(r'page (\S+) exists on disk', f.message)
+        if match:
+            page_path = match.group(1).replace("\\", "/")
+            additions.append(f"\n- [[{page_path.replace('.md', '')}]] -- (auto-added by wiki_lint)")
+
+    if additions:
+        content += "\n\n## Auto-added by wiki_lint (stale-index fix)\n"
+        content += "\n".join(additions) + "\n"
+        index_path.write_text(content, encoding="utf-8")
+        print(f"  [FIX] added {len(additions)} stale entries to index.md")
+
+
+def fix_ghost_index(root: Path, ghost_findings: List[Finding]) -> None:
+    """Comment out ghost index entries."""
+    index_path = root / "index.md"
+    content = read_file(index_path)
+    lines = content.splitlines()
+
+    fixed_count = 0
+    for f in ghost_findings:
+        line_match = re.search(r':(\d+)$', f.message)
+        if line_match:
+            line_no = int(line_match.group(1)) - 1
+            if 0 <= line_no < len(lines):
+                original = lines[line_no]
+                if not original.strip().startswith("<!-- GHOST:"):
+                    lines[line_no] = f"<!-- GHOST: {original.strip()} -->"
+                    fixed_count += 1
+
+    if fixed_count:
+        index_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        print(f"  [FIX] commented out {fixed_count} ghost entries in index.md")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def lint_wiki(root: Path, max_lines: int = 500,
+              fix: bool = False) -> List[Finding]:
+    """Run all checks on a wiki directory."""
+    if not root.exists():
+        return [Finding("ERROR", "missing-directory",
+                        f"wiki directory {root} does not exist")]
+
+    all_files_list = collect_md_files(root)
+    all_files = {f.resolve() for f in all_files_list}
+
+    index_path = root / "index.md"
+    index_content = read_file(index_path) if index_path.exists() else ""
+
+    slug_index = build_slug_index(root, all_files)
+    findings: List[Finding] = []
+
+    findings.extend(check_orphan_pages(root, all_files, slug_index))
+    findings.extend(check_broken_wikilinks(root, all_files, slug_index))
+
+    stale = check_stale_index(root, all_files, index_content)
+    findings.extend(stale)
+
+    ghost = check_ghost_index(root, all_files, index_content, slug_index)
+    findings.extend(ghost)
+
+    findings.extend(check_oversized_pages(root, all_files, max_lines))
+    findings.extend(check_duplicate_filenames(root, all_files))
+
+    if fix:
+        stale_only = [f for f in stale if f.check == "stale-index"]
+        if stale_only:
+            fix_stale_index(root, stale_only)
+        ghost_only = [f for f in ghost if f.check == "ghost-index"]
+        if ghost_only:
+            fix_ghost_index(root, ghost_only)
+
+    return findings
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Structural lint checks for an ΩmegaWiki wiki directory")
+    parser.add_argument("wiki_root", help="Path to the wiki/ directory")
+    parser.add_argument("--fix", action="store_true",
+                        help="Auto-fix safe issues (stale index, ghost entries)")
+    parser.add_argument("--max-lines", type=int, default=500,
+                        help="Max lines per page before warning (default: 500)")
+    parser.add_argument("--json", action="store_true",
+                        help="Output findings as JSON")
+    args = parser.parse_args()
+
+    wiki_root = Path(args.wiki_root).resolve()
+    findings = lint_wiki(wiki_root, args.max_lines, args.fix)
+
+    if args.json:
+        print(json_module.dumps([f.to_dict() for f in findings], indent=2))
+        sys.exit(1 if any(f.severity == "ERROR" for f in findings) else 0)
+
+    if not findings:
+        print("All checks passed. No findings.")
+        sys.exit(0)
+
+    errors = [f for f in findings if f.severity == "ERROR"]
+    warns = [f for f in findings if f.severity == "WARN"]
+
+    for f in sorted(findings, key=lambda x: (0 if x.severity == "ERROR" else 1)):
+        print(f)
+
+    print(f"\n--- Summary: {len(errors)} ERROR(s), {len(warns)} WARN(s) ---")
+    sys.exit(1 if errors else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **wiki_graph.py**: Standalone knowledge graph CLI -- BFS traversal, orphan detection, contradiction discovery, wikilink seeding, and stats for `graph/edges.jsonl`
- **compile_context.py**: Purpose-driven context compilation -- parses `index.md` trigger-to-page mappings and concatenates page content within a configurable token budget
- **find_similar.py**: Token Jaccard similarity search across wiki pages -- detects near-duplicates before page creation
- **wiki_lint.py**: Cross-wiki structural lint (6 checks) -- orphan pages, broken wikilinks, stale/ghost index entries, oversized pages, duplicate filenames

All tools follow existing repo conventions: `wiki_root` as first CLI argument, `from __future__ import annotations`, shared `_schemas.py` constants, zero external dependencies (Python 3.9+ stdlib only). README updated with usage examples and project structure entries.

## Test plan
- [ ] Verify each tool runs with `--help` against an existing wiki directory
- [ ] Run `wiki_graph.py wiki/ stats` on a wiki with edges
- [ ] Run `wiki_lint.py wiki/` and confirm findings match expected state
- [ ] Run `find_similar.py wiki/ "test query"` and verify output format
- [ ] Run `compile_context.py wiki/ --list` on a wiki with a By Trigger index

🤖 Generated with [Claude Code](https://claude.com/claude-code)