### PR TITLE
fix(research_wiki): block graph rebuilds inside linked git worktrees

### DIFF
--- a/tests/test_research_wiki.py
+++ b/tests/test_research_wiki.py
@@ -1,6 +1,7 @@
 """Tests for tools/research_wiki.py — Wiki Knowledge Engine."""
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -1676,6 +1677,68 @@ class TestCLI:
             capture_output=True, text=True)
         assert result.returncode == 0
         assert "LoRA" in (wiki / "index.md").read_text()
+
+
+# ── Worktree guard on graph rebuilds (issue #12) ────────────────────────────
+
+class TestRebuildWorktreeGuard:
+    """`rebuild-context-brief` and `rebuild-open-questions` must refuse to run
+    from a linked git worktree — otherwise parallel /init subagents produce
+    add/add merge conflicts on wiki/graph/*.md on Phase B fan-in."""
+
+    TOOL = str(Path(__file__).parent.parent / "tools" / "research_wiki.py")
+
+    def _make_repo_with_worktree(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        env = {
+            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+            "PATH": os.environ.get("PATH", ""),
+        }
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True, env=env)
+        (repo / "seed").write_text("x")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True, env=env)
+        subprocess.run(["git", "commit", "-q", "-m", "seed", "--no-gpg-sign"],
+                       cwd=repo, check=True, env=env)
+        wt = tmp_path / "wt"
+        subprocess.run(
+            ["git", "worktree", "add", "-q", str(wt), "-b", "feat", "main"],
+            cwd=repo, check=True, env=env)
+        return repo, wt, env
+
+    def test_rebuild_context_brief_refuses_in_linked_worktree(self, tmp_path):
+        repo, wt, env = self._make_repo_with_worktree(tmp_path)
+        wiki = wt / "wiki"
+        subprocess.run([sys.executable, self.TOOL, "init", str(wiki)],
+                       cwd=wt, check=True, capture_output=True, env={**os.environ, **env})
+        result = subprocess.run(
+            [sys.executable, self.TOOL, "rebuild-context-brief", str(wiki)],
+            cwd=wt, capture_output=True, text=True, env={**os.environ, **env})
+        assert result.returncode == 2
+        assert "linked git worktree" in result.stderr
+
+    def test_rebuild_open_questions_refuses_in_linked_worktree(self, tmp_path):
+        repo, wt, env = self._make_repo_with_worktree(tmp_path)
+        wiki = wt / "wiki"
+        subprocess.run([sys.executable, self.TOOL, "init", str(wiki)],
+                       cwd=wt, check=True, capture_output=True, env={**os.environ, **env})
+        result = subprocess.run(
+            [sys.executable, self.TOOL, "rebuild-open-questions", str(wiki)],
+            cwd=wt, capture_output=True, text=True, env={**os.environ, **env})
+        assert result.returncode == 2
+        assert "linked git worktree" in result.stderr
+
+    def test_rebuild_context_brief_works_in_primary_worktree(self, tmp_path):
+        repo, wt, env = self._make_repo_with_worktree(tmp_path)
+        wiki = repo / "wiki"
+        subprocess.run([sys.executable, self.TOOL, "init", str(wiki)],
+                       cwd=repo, check=True, capture_output=True, env={**os.environ, **env})
+        result = subprocess.run(
+            [sys.executable, self.TOOL, "rebuild-context-brief", str(wiki)],
+            cwd=repo, capture_output=True, text=True, env={**os.environ, **env})
+        assert result.returncode == 0
+        assert (wiki / "graph" / "context_brief.md").exists()
 
 
 # ── Checkpoint ───────────────────────────────────────────────────────────────

--- a/tools/research_wiki.py
+++ b/tools/research_wiki.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
 import sys
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -287,8 +288,39 @@ def dedup_edges(wiki_root: str) -> None:
 # Query pack generation
 # ---------------------------------------------------------------------------
 
+def _is_linked_worktree() -> bool:
+    # Linked worktrees have distinct --git-dir and --git-common-dir; the primary
+    # checkout has them equal. Used to block graph rebuilds from /init subagents:
+    # their worktree rebuilds collide on merge with the orchestrator's final one.
+    try:
+        git_dir = subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        common_dir = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+    return Path(git_dir).resolve() != Path(common_dir).resolve()
+
+
+def _refuse_in_linked_worktree(cmd: str) -> None:
+    if _is_linked_worktree():
+        print(
+            f"error: {cmd} is not permitted inside a linked git worktree.\n"
+            "Graph rebuilds must run from the primary checkout; the /init "
+            "orchestrator rebuilds once after all subagent merges. See "
+            "init/SKILL.md INIT MODE.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
 def rebuild_context_brief(wiki_root: str, max_chars: int = 8000) -> None:
     """Backward-compatible alias for ``compile_context --for general``."""
+    _refuse_in_linked_worktree("rebuild-context-brief")
     compile_context(wiki_root, "general", max_chars)
 
 
@@ -305,6 +337,7 @@ def rebuild_open_questions(wiki_root: str) -> None:
       - concepts/: ## Open problems section
       - claims/: status == 'proposed' or 'weakly_supported'
     """
+    _refuse_in_linked_worktree("rebuild-open-questions")
     root = Path(wiki_root)
     gaps: list[str] = []
 


### PR DESCRIPTION
## Summary
- `rebuild-context-brief` and `rebuild-open-questions` now refuse to run from a linked git worktree (detected via `git rev-parse --git-dir` vs `--git-common-dir`) and exit 2.
- These commands are full rebuilds, not append-only, so they can't be `merge=union`'d. Parallel `/init` subagents running them in their worktrees produced add/add merge conflicts on Phase B fan-in (issue #12).
- Defense-in-depth: `init/SKILL.md` already tells agents to SKIP these commands in INIT MODE, but that relied on prompt discipline alone. The `/init` orchestrator runs from the primary checkout, so its final Step 7 rebuild is unaffected.

## Changes
- `tools/research_wiki.py` (+33 / -0) — worktree guard
- `tests/test_research_wiki.py` (+63 / -0) — guard tests

## Test plan
- [ ] `pytest tests/test_research_wiki.py` passes
- [ ] Manually invoke `rebuild-context-brief` from a linked worktree → exits 2
- [ ] Manually invoke from primary checkout → runs normally