### PR TITLE
fix: three small fixes — reset, S2 key check, hallucinated link

### DIFF
--- a/.claude/skills/init/SKILL.md
+++ b/.claude/skills/init/SKILL.md
@@ -91,6 +91,19 @@ This step scans what the user provided, then **selectively expands** via citatio
 
 #### Phase B — Citation-chain expansion (primary discovery method)
 
+**Before calling S2**, check whether the API key is set:
+
+```bash
+python3 -c "
+import sys, os; sys.path.insert(0, 'tools')
+try: import _env
+except Exception: pass
+print('SET' if os.environ.get('SEMANTIC_SCHOLAR_API_KEY', '').strip() else 'UNSET')
+"
+```
+
+If `UNSET`, print a warning: "No Semantic Scholar API key found — citation-chain expansion will work but run 3x slower (3s/request). Run `/setup` to add a key for faster init." Then proceed — fetch_s2.py works unauthenticated.
+
 For each paper in `local_papers` that has an arXiv ID (pick the 3–5 highest-importance ones):
 
 ```bash

--- a/.claude/skills/reset/SKILL.md
+++ b/.claude/skills/reset/SKILL.md
@@ -14,7 +14,7 @@ Manual: `/reset --scope wiki` / `--scope raw` / `--scope log` / `--scope checkpo
 ## Inputs
 
 - `--scope` *(required)*: one of
-  - `wiki` — delete every `*.md` under `wiki/<entity>/` and `wiki/outputs/`, regenerate `wiki/index.md` and empty `wiki/graph/` files. Preserves `.gitkeep`, `wiki/CLAUDE.md`, `wiki/log.md`.
+  - `wiki` — delete every `*.md` under `wiki/<entity>/` and `wiki/outputs/`, plus `wiki/index.md`, `wiki/log.md`, and `wiki/graph/` files. Preserves `.gitkeep` and `wiki/CLAUDE.md`.
   - `raw` — delete every file under `raw/papers/`, `raw/notes/`, `raw/web/` (except `.gitkeep`).
   - `log` — reset `wiki/log.md` to the empty header.
   - `checkpoints` — clear batch state via `research_wiki.py checkpoint-clear`.

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -75,8 +75,10 @@ Present a clear summary to the user, grouped by status:
 ================================
 ✓  ANTHROPIC_API_KEY      — managed by Claude Code (claude login)
 
-Optional keys:
-✗  Semantic Scholar        — not set  (skills work, but slower)
+Recommended:
+✗  Semantic Scholar        — not set  (citation expansion 3x slower — get free key)
+
+Optional:
 ✗  DeepXiv                 — not set  (semantic search unavailable)
 ✗  Review LLM              — not set  (cross-model review unavailable)
 ```
@@ -93,10 +95,10 @@ Always ask for user confirmation before writing to `.env`.
 #### 4a: Semantic Scholar API Key
 
 **Explain**: "Semantic Scholar gives citation data and paper search.
-Used by /ingest, /init, /novelty, /ideate. Free, instant approval.
-Without it, those skills still work but run slower (1 req/3 sec instead of 1/sec)."
+Used by /ingest, /init, /novelty, /ideate. Free to get.
+**Recommended** — without it, /init runs 3x slower and citation-chain expansion is much less effective."
 
-**Guide to get it**: "Go to https://www.semanticscholar.org/product/api and click 'Get API Key'. It's free and approves instantly."
+**Guide to get it**: "Go to https://www.semanticscholar.org/product/api and click 'Get API Key'. It's free."
 
 **Ask**: "Do you have a Semantic Scholar API key? (paste it, or 'skip')"
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## What is ΩmegaWiki?
 
-Andrej Karpathy proposed [LLM-Wiki](https://x.com/karpathy/status/1909372692069236775): an LLM that **builds and maintains a persistent, structured wiki** from your sources — not a throwaway RAG answer, but compounding knowledge that grows smarter with every paper you feed it.
+Andrej Karpathy proposed LLM-Wiki: an LLM that **builds and maintains a persistent, structured wiki** from your sources — not a throwaway RAG answer, but compounding knowledge that grows smarter with every paper you feed it.
 
 **ΩmegaWiki takes that idea and runs the full distance.** It's not just a wiki builder — it's a complete research lifecycle platform: from paper ingestion → knowledge graph → gap detection → idea generation → experiment design → paper writing → peer review response. All driven by 23 Claude Code skills, all centered on one wiki as the single source of truth.
 
@@ -344,7 +344,7 @@ Scan to join the ΩmegaWiki WeChat group / 扫码加入微信交流群
 
 ## Acknowledgments
 
-- **[Andrej Karpathy](https://x.com/karpathy/status/1909372692069236775)** — for the LLM-Wiki concept that inspired this project
+- **Andrej Karpathy** — for the LLM-Wiki concept that inspired this project
 - **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** — the AI agent runtime that powers ΩmegaWiki
 
 ## License
@@ -357,7 +357,7 @@ Scan to join the ΩmegaWiki WeChat group / 扫码加入微信交流群
 
 ### ΩmegaWiki 是什么？
 
-Andrej Karpathy 提出了 [LLM-Wiki](https://x.com/karpathy/status/1909372692069236775) 概念：让 LLM **构建并维护一个持久的、结构化的 wiki**，而不是一次性的 RAG 回答。知识持续积累，每一篇新论文都让整个知识图谱更强。
+Andrej Karpathy 提出了 LLM-Wiki 概念：让 LLM **构建并维护一个持久的、结构化的 wiki**，而不是一次性的 RAG 回答。知识持续积累，每一篇新论文都让整个知识图谱更强。
 
 **ΩmegaWiki 将这个理念完整实现。** 它不仅是 wiki 构建器，更是完整的研究全流程平台：从论文摄入 → 知识图谱 → 缺口检测 → 想法生成 → 实验设计 → 论文写作 → 同行评审回复。23 个 Claude Code Skills 驱动，一个 wiki 作为唯一的知识中枢。
 

--- a/i18n/en/skills/init/SKILL.md
+++ b/i18n/en/skills/init/SKILL.md
@@ -91,6 +91,19 @@ This step scans what the user provided, then **selectively expands** via citatio
 
 #### Phase B — Citation-chain expansion (primary discovery method)
 
+**Before calling S2**, check whether the API key is set:
+
+```bash
+python3 -c "
+import sys, os; sys.path.insert(0, 'tools')
+try: import _env
+except Exception: pass
+print('SET' if os.environ.get('SEMANTIC_SCHOLAR_API_KEY', '').strip() else 'UNSET')
+"
+```
+
+If `UNSET`, print a warning: "No Semantic Scholar API key found — citation-chain expansion will work but run 3x slower (3s/request). Run `/setup` to add a key for faster init." Then proceed — fetch_s2.py works unauthenticated.
+
 For each paper in `local_papers` that has an arXiv ID (pick the 3–5 highest-importance ones):
 
 ```bash

--- a/i18n/en/skills/reset/SKILL.md
+++ b/i18n/en/skills/reset/SKILL.md
@@ -14,7 +14,7 @@ Manual: `/reset --scope wiki` / `--scope raw` / `--scope log` / `--scope checkpo
 ## Inputs
 
 - `--scope` *(required)*: one of
-  - `wiki` — delete every `*.md` under `wiki/<entity>/` and `wiki/outputs/`, regenerate `wiki/index.md` and empty `wiki/graph/` files. Preserves `.gitkeep`, `wiki/CLAUDE.md`, `wiki/log.md`.
+  - `wiki` — delete every `*.md` under `wiki/<entity>/` and `wiki/outputs/`, plus `wiki/index.md`, `wiki/log.md`, and `wiki/graph/` files. Preserves `.gitkeep` and `wiki/CLAUDE.md`.
   - `raw` — delete every file under `raw/papers/`, `raw/notes/`, `raw/web/` (except `.gitkeep`).
   - `log` — reset `wiki/log.md` to the empty header.
   - `checkpoints` — clear batch state via `research_wiki.py checkpoint-clear`.

--- a/i18n/en/skills/setup/SKILL.md
+++ b/i18n/en/skills/setup/SKILL.md
@@ -75,8 +75,10 @@ Present a clear summary to the user, grouped by status:
 ================================
 ✓  ANTHROPIC_API_KEY      — managed by Claude Code (claude login)
 
-Optional keys:
-✗  Semantic Scholar        — not set  (skills work, but slower)
+Recommended:
+✗  Semantic Scholar        — not set  (citation expansion 3x slower — get free key)
+
+Optional:
 ✗  DeepXiv                 — not set  (semantic search unavailable)
 ✗  Review LLM              — not set  (cross-model review unavailable)
 ```
@@ -93,10 +95,10 @@ Always ask for user confirmation before writing to `.env`.
 #### 4a: Semantic Scholar API Key
 
 **Explain**: "Semantic Scholar gives citation data and paper search.
-Used by /ingest, /init, /novelty, /ideate. Free, instant approval.
-Without it, those skills still work but run slower (1 req/3 sec instead of 1/sec)."
+Used by /ingest, /init, /novelty, /ideate. Free to get.
+**Recommended** — without it, /init runs 3x slower and citation-chain expansion is much less effective."
 
-**Guide to get it**: "Go to https://www.semanticscholar.org/product/api and click 'Get API Key'. It's free and approves instantly."
+**Guide to get it**: "Go to https://www.semanticscholar.org/product/api and click 'Get API Key'. It's free."
 
 **Ask**: "Do you have a Semantic Scholar API key? (paste it, or 'skip')"
 

--- a/i18n/zh/skills/init/SKILL.md
+++ b/i18n/zh/skills/init/SKILL.md
@@ -91,6 +91,19 @@ python3 tools/research_wiki.py init wiki/
 
 #### Phase B — 引用链扩展（主要发现方式）
 
+**调用 S2 前**先检查 API key 是否已配置：
+
+```bash
+python3 -c "
+import sys, os; sys.path.insert(0, 'tools')
+try: import _env
+except Exception: pass
+print('SET' if os.environ.get('SEMANTIC_SCHOLAR_API_KEY', '').strip() else 'UNSET')
+"
+```
+
+如果返回 `UNSET`，提示用户："未检测到 Semantic Scholar API key — 引用链扩展仍可运行，但速度慢 3 倍（3 秒/请求）。建议先运行 `/setup` 配置 key 以加速 init。"然后继续执行 — fetch_s2.py 无 key 也可用。
+
 对 `local_papers` 中有 arXiv ID 的论文（选 importance 最高的 3–5 篇）：
 
 ```bash

--- a/i18n/zh/skills/reset/SKILL.md
+++ b/i18n/zh/skills/reset/SKILL.md
@@ -14,7 +14,7 @@ argument-hint: "--scope wiki|raw|log|checkpoints|all"
 ## Inputs
 
 - `--scope`（必填）：取值
-  - `wiki` — 删除 `wiki/<entity>/` 与 `wiki/outputs/` 下所有 `*.md`，重生成 `wiki/index.md` 与 `wiki/graph/` 下的空文件。保留 `.gitkeep`、`wiki/CLAUDE.md`、`wiki/log.md`。
+  - `wiki` — 删除 `wiki/<entity>/` 与 `wiki/outputs/` 下所有 `*.md`，同时删除 `wiki/index.md`、`wiki/log.md` 和 `wiki/graph/` 下的文件。保留 `.gitkeep` 和 `wiki/CLAUDE.md`。
   - `raw` — 删除 `raw/papers/`、`raw/notes/`、`raw/web/` 下所有文件（保留 `.gitkeep`）。
   - `log` — 重置 `wiki/log.md` 为空模板。
   - `checkpoints` — 通过 `research_wiki.py checkpoint-clear` 清除批处理状态。

--- a/i18n/zh/skills/setup/SKILL.md
+++ b/i18n/zh/skills/setup/SKILL.md
@@ -75,8 +75,10 @@ python3 --version
 ================================
 ✓  ANTHROPIC_API_KEY      — 由 Claude Code 管理（claude login）
 
-可选 key：
-✗  Semantic Scholar        — 未配置（skill 可运行，但较慢）
+推荐配置：
+✗  Semantic Scholar        — 未配置（引用链扩展速度慢 3 倍，建议配置免费 key）
+
+可选：
 ✗  DeepXiv                 — 未配置（语义搜索不可用）
 ✗  Review LLM              — 未配置（跨模型 review 不可用）
 ```
@@ -93,11 +95,11 @@ python3 --version
 #### 4a：Semantic Scholar API Key
 
 **解释**："Semantic Scholar 提供论文引用数据和检索功能。
-被 /ingest、/init、/novelty、/ideate 使用。免费，秒批。
-不配置的话，这些 skill 仍可运行，但速度较慢（1请求/3秒，有 key 则 1请求/秒）。"
+被 /ingest、/init、/novelty、/ideate 使用。免费获取。
+**推荐配置** — 不配置的话，/init 速度慢 3 倍，引用链扩展效率大幅下降。"
 
 **引导获取**："访问 https://www.semanticscholar.org/product/api，
-点击 'Get API Key'，免费秒批，无需信用卡。"
+点击 'Get API Key'，免费申请。"
 
 **询问**："您是否有 Semantic Scholar API key？（粘贴，或输入 'skip' 跳过）"
 

--- a/tests/test_reset_wiki.py
+++ b/tests/test_reset_wiki.py
@@ -49,31 +49,34 @@ def test_plan_wiki_lists_all_md(project):
     assert "wiki/concepts/c1.md" in deletes
     assert "wiki/foundations/gradient-descent.md" in deletes
     assert "wiki/outputs/report.md" in deletes
-    # CLAUDE.md and log.md must NOT appear
+    # CLAUDE.md must NOT appear
     assert not any("CLAUDE.md" in f for f in deletes)
-    assert not any("log.md" in f for f in deletes)
+    # Scaffold files (index.md, log.md, graph/) are now deleted, not reset
+    assert "wiki/index.md" in deletes
+    assert "wiki/log.md" in deletes
+    assert "wiki/graph/edges.jsonl" in deletes
 
 
 def test_execute_wiki_deletes_md_keeps_protected_files(project):
     rw.execute(project, ["wiki"])
     assert not (project / "wiki" / "papers" / "p1.md").exists()
     assert not (project / "wiki" / "foundations" / "gradient-descent.md").exists()
+    # Scaffold files deleted (not reset)
+    assert not (project / "wiki" / "index.md").exists()
+    assert not (project / "wiki" / "log.md").exists()
+    assert not (project / "wiki" / "graph" / "edges.jsonl").exists()
     # Protected
     assert (project / "wiki" / "CLAUDE.md").exists()
-    assert (project / "wiki" / "log.md").exists()
     # .gitkeep preserved or recreated
     assert (project / "wiki" / "papers" / ".gitkeep").exists()
     assert (project / "wiki" / "foundations" / ".gitkeep").exists()
-    # index.md regenerated with all 9 entities
-    idx = (project / "wiki" / "index.md").read_text()
-    for entity in rw.ENTITY_DIRS:
-        assert f"{entity}:" in idx
 
 
-def test_execute_wiki_resets_graph(project):
+def test_execute_wiki_deletes_graph(project):
     rw.execute(project, ["wiki"])
-    edges = (project / "wiki" / "graph" / "edges.jsonl").read_text()
-    assert edges == ""
+    assert not (project / "wiki" / "graph" / "edges.jsonl").exists()
+    assert not (project / "wiki" / "graph" / "context_brief.md").exists()
+    assert not (project / "wiki" / "graph" / "open_questions.md").exists()
 
 
 def test_execute_raw_deletes_files_keeps_gitkeep(project):
@@ -94,7 +97,8 @@ def test_execute_all_combines_scopes(project):
     rw.execute(project, ["wiki", "raw", "log"])
     assert not (project / "wiki" / "papers" / "p1.md").exists()
     assert not (project / "raw" / "papers" / "x.pdf").exists()
-    assert (project / "wiki" / "log.md").read_text() == "# OmegaWiki Log\n\n"
+    # log.md deleted by wiki scope, not recreated by log scope
+    assert not (project / "wiki" / "log.md").exists()
     assert (project / "wiki" / "CLAUDE.md").exists()
 
 

--- a/tools/reset_wiki.py
+++ b/tools/reset_wiki.py
@@ -2,9 +2,9 @@
 """Reset wiki state to a clean scaffold (used by /reset skill).
 
 Scopes:
-    wiki         delete all .md content under wiki/<entity>/, regenerate
-                 index.md, regenerate empty graph/ files. Preserves .gitkeep,
-                 wiki/CLAUDE.md, and wiki/log.md.
+    wiki         delete all .md content under wiki/<entity>/, wiki/outputs/,
+                 wiki/index.md, wiki/log.md, and wiki/graph/ files.
+                 Preserves .gitkeep and wiki/CLAUDE.md.
     raw          delete all files under raw/<sub>/ except .gitkeep.
     log          reset wiki/log.md to empty header.
     checkpoints  call `research_wiki.py checkpoint-clear` to drop batch state.
@@ -34,6 +34,7 @@ ALL_SCOPES = ["wiki", "raw", "log", "checkpoints"]
 
 INDEX_TEMPLATE = "# Wiki Index\n\n" + "\n".join(f"{e}:" for e in ENTITY_DIRS) + "\n"
 LOG_TEMPLATE = "# OmegaWiki Log\n\n"
+GRAPH_FILES = ["edges.jsonl", "context_brief.md", "open_questions.md"]
 
 
 def _list_md(directory: Path) -> list[Path]:
@@ -59,17 +60,22 @@ def plan(project_root: Path, scopes: list[str]) -> dict:
                 p["delete_files"].append(str(f.relative_to(project_root)))
         for f in _list_md(wiki / "outputs"):
             p["delete_files"].append(str(f.relative_to(project_root)))
-        p["reset_files"].append("wiki/index.md")
-        p["reset_files"].append("wiki/graph/edges.jsonl")
-        p["reset_files"].append("wiki/graph/context_brief.md")
-        p["reset_files"].append("wiki/graph/open_questions.md")
+        # Scaffold files — deleted, not reset (init recreates them)
+        if (wiki / "index.md").exists():
+            p["delete_files"].append("wiki/index.md")
+        if (wiki / "log.md").exists():
+            p["delete_files"].append("wiki/log.md")
+        for gf in GRAPH_FILES:
+            gf_path = wiki / "graph" / gf
+            if gf_path.exists():
+                p["delete_files"].append(f"wiki/graph/{gf}")
 
     if "raw" in scopes:
         for sub in RAW_SUBDIRS:
             for f in _list_raw(project_root / "raw" / sub):
                 p["delete_files"].append(str(f.relative_to(project_root)))
 
-    if "log" in scopes:
+    if "log" in scopes and "wiki" not in scopes:
         p["reset_files"].append("wiki/log.md")
 
     if "checkpoints" in scopes:
@@ -95,20 +101,19 @@ def execute(project_root: Path, scopes: list[str]) -> dict:
                 keep.parent.mkdir(parents=True, exist_ok=True)
             if not keep.exists():
                 keep.touch()
-        (wiki / "index.md").write_text(INDEX_TEMPLATE, encoding="utf-8")
-        reset += 1
+        # Delete scaffold files (init recreates them from scratch)
+        for scaffold in ["index.md", "log.md"]:
+            sp = wiki / scaffold
+            if sp.exists():
+                sp.unlink()
+                deleted += 1
         graph = wiki / "graph"
-        graph.mkdir(parents=True, exist_ok=True)
-        (graph / "edges.jsonl").write_text("", encoding="utf-8")
-        (graph / "context_brief.md").write_text(
-            "# Query Pack\n\n_Auto-generated compressed context. Do not edit._\n",
-            encoding="utf-8",
-        )
-        (graph / "open_questions.md").write_text(
-            "# Gap Map\n\n_Auto-generated open questions. Do not edit._\n",
-            encoding="utf-8",
-        )
-        reset += 3
+        if graph.exists():
+            for gf in GRAPH_FILES:
+                gfp = graph / gf
+                if gfp.exists():
+                    gfp.unlink()
+                    deleted += 1
 
     if "raw" in scopes:
         for sub in RAW_SUBDIRS:
@@ -121,7 +126,8 @@ def execute(project_root: Path, scopes: list[str]) -> dict:
             if not keep.exists():
                 keep.touch()
 
-    if "log" in scopes:
+    if "log" in scopes and "wiki" not in scopes:
+        # Standalone log scope: reset to empty header
         (wiki / "log.md").write_text(LOG_TEMPLATE, encoding="utf-8")
         reset += 1
 


### PR DESCRIPTION
## Summary

1. **Reset scaffold cleanup**: `reset_wiki.py --scope wiki` now *deletes* `index.md`, `log.md`, and `graph/` files instead of resetting them to templates. Only `wiki/CLAUDE.md` is preserved. Makes `/reset` cleaner for dev iteration — `/init` recreates everything from scratch.

2. **S2 API key check**: `/init` now checks for `SEMANTIC_SCHOLAR_API_KEY` before first S2 call and warns if missing. The tool works unauthenticated but 3x slower. `/setup` now shows S2 under "Recommended" (not mixed with truly optional keys). Removed false "instant approval" claims.

3. **Hallucinated link removed**: Removed three fabricated `x.com/karpathy/status/1909372692069236775` links from README. Text references to Karpathy retained.

## Test plan

- [x] `tests/test_reset_wiki.py` — 8/8 passing
- [x] `tests/test_skill_validation.py` — 77/77 passing
- [x] i18n en + zh source files updated in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)