### PR TITLE
Use S2 search to guess arxiv-id when filename lacks one

### DIFF
--- a/.claude/skills/ingest/SKILL.md
+++ b/.claude/skills/ingest/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: <local-path-or-arXiv-URL>
 
 ## Inputs
 
-- `source`: local `.tex` / `.pdf` path, a canonical path handed off by `/init` (for example `raw/tmp/...` synthetic or translated `.tex`, or `raw/discovered/...` fetched source dirs / PDFs), or an arXiv URL (e.g. `https://arxiv.org/abs/2106.09685`)
+- `source`: local `.tex` / `.pdf` path, a canonical path handed off by `/init` (for example `raw/tmp/...` synthetic `.tex`, or `raw/discovered/...` fetched source dirs / PDFs), or an arXiv URL (e.g. `https://arxiv.org/abs/2106.09685`)
 
 ## Outputs
 
@@ -399,7 +399,7 @@ Wiki: +1 paper, +{N} claims, +{M} concepts, +{K} edges | Maturity: {level} ({cov
 
 ## Error Handling
 
-- **Source parse failure**: tex fails → PDF parse → vision API → report to user for manual handling. In INIT MODE, synthetic / translated `.tex` under `raw/tmp/` and fetched source dirs / PDFs under `raw/discovered/` are valid inputs and should be consumed as handed off.
+- **Source parse failure**: tex fails → PDF parse → vision API → report to user for manual handling. In INIT MODE, synthetic `.tex` under `raw/tmp/` and fetched source dirs / PDFs under `raw/discovered/` are valid inputs and should be consumed as handed off.
 - **S2 API unavailable**: skip S2 steps (citations backfill, default importance to 3); note in report
 - **DeepXiv API unavailable**: skip DeepXiv enrichment (TLDR, structure verification, social metrics); fall back to S2 + source file parsing
 - **Slug conflict**: if generated slug already exists but content differs, append numeric suffix (e.g. `attention-mechanism-2`)

--- a/.claude/skills/init/SKILL.md
+++ b/.claude/skills/init/SKILL.md
@@ -11,6 +11,7 @@ argument-hint: "[topic] [--no-introduction]"
 
 - `topic` (optional): research direction keywords; omit it when `raw/papers/` already defines the seed set or when notes/web already capture the intent
 - `--no-introduction` (optional): disable external paper discovery; use only user-owned `raw/papers/`, `raw/notes/`, and `raw/web/`
+- parameter guardrail: treat `topic` and `--no-introduction` as user inputs, not agent strategy knobs; do not infer `--no-introduction` from repository state alone. A non-empty `raw/papers/`, empty `raw/notes/` or `raw/web/`, or an omitted `topic` is not by itself a reason to enable local-only mode. Use `--no-introduction` only when the user explicitly asked to disable external discovery.
 - `raw/papers/`: user-owned paper sources (`.tex`, `.pdf`, archives)
 - `raw/notes/`: user-owned notes that express goals, hypotheses, exclusions, and preferred sub-directions
 - `raw/web/`: user-owned saved web pages that express goals, hypotheses, exclusions, and preferred sub-directions
@@ -18,7 +19,7 @@ argument-hint: "[topic] [--no-introduction]"
 ## Outputs
 
 - `wiki/` scaffold via `tools/research_wiki.py init`
-- `raw/tmp/` — `/init`-generated prepared local sources and translated sidecars
+- `raw/tmp/` — `/init`-generated prepared local sources
 - `raw/discovered/` — newly downloaded papers selected by `/init` (only when discovery is enabled)
 - `wiki/Summary/{area}.md`, `wiki/topics/{topic}.md`, provisional `wiki/ideas/{slug}.md`, `wiki/concepts/{slug}.md`, `wiki/claims/{slug}.md`
 - `wiki/papers/*.md` plus paper-derived concepts/claims/people via parallel `/ingest`
@@ -47,12 +48,23 @@ argument-hint: "[topic] [--no-introduction]"
 
 ## Workflow
 
-**Pre-condition**: working directory is the project root containing `wiki/`, `raw/`, `tools/`. Set `WIKI_ROOT=wiki/`.
+**Pre-condition**: working directory is the project root containing `wiki/`, `raw/`, `tools/`. Set `WIKI_ROOT=wiki/`. Resolve `PYTHON_BIN` once and reuse it for every Python command during `/init` so the workflow stays on the same interpreter that `setup.sh` populated:
+
+```bash
+if [ -x .venv/bin/python ]; then
+  PYTHON_BIN=.venv/bin/python
+elif [ -x .venv/Scripts/python.exe ]; then
+  PYTHON_BIN=.venv/Scripts/python.exe
+else
+  PYTHON_BIN=python3
+fi
+export PYTHON_BIN
+```
 
 ### Step 1: Initialize wiki structure
 
 ```bash
-python3 tools/research_wiki.py init wiki/
+"$PYTHON_BIN" tools/research_wiki.py init wiki/
 ```
 
 Create the standard wiki directories, `graph/`, `outputs/`, `index.md`, and `log.md`. Do not add a second init log entry here.
@@ -60,26 +72,27 @@ Create the standard wiki directories, `graph/`, `outputs/`, `index.md`, and `log
 ### Step 2: Prepare local inputs into `raw/tmp/`
 
 ```bash
-python3 tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json
+"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json
 ```
 
 - decode local PDFs into synthetic `.tex` under `raw/tmp/` when possible
-- write translated notes/web sidecars under `raw/tmp/` when translation succeeds
+- for PDFs that lack an embedded arXiv ID, attempt title-based recovery via Semantic Scholar search; when an arXiv ID is recovered successfully, prefer the fetched raw TeX source from arXiv (`raw/tmp/papers/...-arxiv-src/`) over the synthetic `.tex`
+- keep notes/web on their original source paths; `/init` reads them directly during planning
 - set each local paper's `canonical_ingest_path` to a prepared `raw/tmp/` path when available; otherwise fall back to the original `raw/papers/...` path
-- record warnings for failed decode / translation rather than aborting `/init`
+- record warnings for failed decode / arXiv source fetch rather than aborting `/init`
 - save the manifest to `.checkpoints/init-prepare.json`
 
 ### Step 3: Build the discovery plan, trim it, and write the final source manifest
 
 ```bash
-python3 tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json
+"$PYTHON_BIN" tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json
 ```
 
 - `mode=seeded` when the prepare manifest contains at least one parseable local paper; otherwise `mode=bootstrap`
 - `plan` must read `.checkpoints/init-prepare.json` instead of rescanning `raw/`
-- `raw/notes/` and `raw/web/` signals are read from translated `raw/tmp/` sidecars when present
-- if multiple local copies of the same paper exist, prefer better local sources in this order: translated/prepared `.tex` > original local `.tex` > archive-extracted source `.tex` > PDF-derived synthetic `.tex` > raw `.pdf`
-- if Chinese note content is detected, preserve a planner warning that curated Chinese support is planned for later and current note/web extraction may perform worse
+- `raw/notes/` and `raw/web/` signals are read directly from the original source files
+- if multiple local copies of the same paper exist, prefer better local sources in this order: original local `.tex` > archive-extracted source `.tex` or fetched arXiv source directory > PDF-derived synthetic `.tex` > raw `.pdf`
+- if Chinese note or web content is detected, preserve a planner warning that extraction/ranking may be less reliable and treat provisional outputs as lower-confidence
 - when `topic` is omitted in seeded mode, derive discovery and ranking cues from local paper titles/abstracts plus notes/web signals instead of refusing to plan
 - if seeded discovery adds no external papers, proceed with the user-owned paper set instead of treating that as a fatal planner error
 - when both `topic` and notes/web keywords are absent, bootstrap discovery has no query to search with, so it must surface that as a planner error instead of issuing an empty search
@@ -97,27 +110,35 @@ Planner policy:
 - survey/benchmark/overview bonus = 15
 - citation/centrality = 15
 - prefer a survey if one is available
-- allow at most one older canonical anchor slot
+- allow at most one older canonical anchor slot, and only in bootstrap or very roomy seeded cases
+- in seeded mode with limited introduced capacity, do not reserve an older anchor up front; freshness should dominate and older external non-survey papers must not pile up via citation advantage
 - otherwise freshness wins close decisions
 - seeded mode computes anchor bonus from user papers first, then notes/web priorities
 - bootstrap mode searches first, then expands citations/references from the strongest initial candidates
 
 LLM trim policy:
 
-- trim the over-picked shortlist to a final **8-10** papers total
-- keep all parseable user-owned papers by default
+- read `.checkpoints/init-plan.json` and explicitly trim the over-picked `shortlist` to a final **8-10** papers total before `fetch`
+- do not skip the trim step even if the shortlist already looks reasonable
+- keep all parseable user-owned papers by default, then use the remaining slots for introduced papers
 - if the user already provided more than 10 parseable papers, add no new papers
-- prefer one survey/overview when available, one canonical older anchor at most, and fresh representatives across distinct clusters
+- prefer one survey/overview when available, at most one older canonical anchor when it is actually useful, and fresh representatives across distinct clusters
+- when the user already supplied a substantial seed set, freshness should dominate and older canonical papers should be further deprioritized
+- "`at most one` older canonical anchor" is a ceiling, not a requirement
+- before `fetch`, emit an explicit final selection artifact in the workflow/response that includes: `shortlist_count`, `final_count`, and the exact final `candidate_id` list in shortlist order
+- if `final_count` is outside **8-10**, stop and revise the final selection before `fetch`, unless `--no-introduction` is active or the user already supplied more than 10 parseable papers
+- call `fetch` only with the exact final selected `candidate_id`s; never forward the whole shortlist implicitly or pass all shortlist IDs by default
 
 If `--no-introduction` is present:
 
+- only use this branch when the user explicitly requested local-only behavior
 - final paper set = all parseable user papers from `.checkpoints/init-prepare.json`
 - still run `fetch` with zero external IDs so it writes `.checkpoints/init-sources.json`
 
 Otherwise run:
 
 ```bash
-python3 tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id> --id <candidate-id>
+"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id> --id <candidate-id>
 ```
 
 - external papers downloaded by `/init` go to `raw/discovered/`, never `raw/papers/`
@@ -174,7 +195,7 @@ fi
 
 ```bash
 STASH_REF=$(git stash list | head -1 | cut -d: -f1)
-python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session stash_ref "$STASH_REF"
+"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session stash_ref "$STASH_REF"
 ```
 
 - capture the current branch before worktree fan-out; `/init` worktree mode must run from a named branch, not detached HEAD:
@@ -185,10 +206,10 @@ if [ -z "$BASE_BRANCH" ]; then
   echo "/init worktree mode requires a named branch; switch to or create one before continuing." >&2
   exit 1
 fi
-python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_branch "$BASE_BRANCH"
+"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_branch "$BASE_BRANCH"
 ```
 
-- save selected paper IDs and planner mode into checkpoint metadata
+- save final selected paper IDs (post-trim, not the over-picked shortlist) and planner mode into checkpoint metadata
 - verify `.gitattributes` contains `merge=union` for `wiki/log.md`, `wiki/graph/edges.jsonl`, and `wiki/index.md`
 - commit the scaffold:
 
@@ -196,7 +217,7 @@ python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_branc
 git add wiki/ raw/papers/ raw/tmp/ raw/discovered/ .checkpoints/init-prepare.json .checkpoints/init-plan.json .checkpoints/init-sources.json
 git commit -m "init: scaffold before parallel ingest" --no-gpg-sign
 BASE_COMMIT=$(git rev-parse HEAD)
-python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_commit "$BASE_COMMIT"
+"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_commit "$BASE_COMMIT"
 ```
 
 ### Step 5: Parallel paper ingest with worktree isolation
@@ -251,11 +272,11 @@ git switch "$BASE_BRANCH"
 git merge --no-ff "$WT_BRANCH" --no-edit
 git worktree remove "$WT_PATH"
 git branch -d "$WT_BRANCH"
-python3 tools/research_wiki.py dedup-edges wiki/
-python3 tools/research_wiki.py rebuild-index wiki/
-python3 tools/research_wiki.py rebuild-context-brief wiki/
-python3 tools/research_wiki.py rebuild-open-questions wiki/
-python3 tools/lint.py wiki/ --fix
+"$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/
+"$PYTHON_BIN" tools/lint.py wiki/ --fix
 ```
 
 ### Step 6: Final report and cleanup
@@ -297,9 +318,10 @@ Also note explicitly:
 
 - **No parseable paper in `raw/papers/`**: enter bootstrap mode
 - **`raw/notes/` and `raw/web/` empty**: skip provisional seeding, continue
-- **PDF decode or translation fails during prepare**: keep the local source, record the warning in `.checkpoints/init-prepare.json`, and fall back to the original path if needed
-- **Chinese content is detected in `raw/notes/`**: keep going, but preserve a planner warning that curated Chinese support is planned for later and current note/web extraction may be degraded
+- **PDF decode fails during prepare**: keep the local source, record the warning in `.checkpoints/init-prepare.json`, and fall back to the original path if needed
+- **Chinese content is detected in `raw/notes/` or `raw/web/`**: keep going, but preserve a planner warning that note/web extraction and ranking may be less reliable and treat rankings plus provisional pages as lower-confidence
 - **S2 or DeepXiv unavailable**: planner falls back to the remaining sources; preserve the warning in the checkpointed plan and note degraded discovery in the report
+- **arXiv ID recovery or TeX source fetch failure for a local PDF**: record a warning in `.checkpoints/init-prepare.json`, fall back to synthetic `.tex` or the original PDF path, and continue
 - **External fetch fails for one paper**: keep the remaining final set and report the failed download
 - **Single paper ingest fails**: record it via checkpoint, skip it, continue the rest, and list it in the report
 - **Current checkout is detached HEAD**: stop before worktree fan-out and ask the user to switch to or create a named branch first
@@ -310,18 +332,18 @@ Also note explicitly:
 
 ### Tools (via Bash)
 
-- `python3 tools/research_wiki.py init wiki/`
-- `python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session <key> <value>`
-- `python3 tools/research_wiki.py checkpoint-save/load/clear wiki/ init-session ...`
-- `python3 tools/research_wiki.py dedup-edges wiki/`
-- `python3 tools/research_wiki.py rebuild-index wiki/`
-- `python3 tools/research_wiki.py rebuild-context-brief wiki/`
-- `python3 tools/research_wiki.py rebuild-open-questions wiki/`
-- `python3 tools/research_wiki.py log wiki/ "<message>"`
-- `python3 tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json`
-- `python3 tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json`
-- `python3 tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id>`
-- `python3 tools/lint.py wiki/ --fix`
+- `"$PYTHON_BIN" tools/research_wiki.py init wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session <key> <value>`
+- `"$PYTHON_BIN" tools/research_wiki.py checkpoint-save/load/clear wiki/ init-session ...`
+- `"$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py log wiki/ "<message>"`
+- `"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json`
+- `"$PYTHON_BIN" tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json`
+- `"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id>`
+- `"$PYTHON_BIN" tools/lint.py wiki/ --fix`
 
 ### Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ Standard log line:
 ## Constraints
 
 - **`raw/papers/`, `raw/notes/`, `raw/web/` are user-owned**: treat them as authoritative inputs. `/init` and `/daily-arxiv` may add externally fetched papers only under `raw/discovered/`, and only `/init` may add generated prepared local sidecars under `raw/tmp/` (additions only — never overwrite an existing user-owned file). `/edit` may add raw sources only when the user explicitly asked for it. All other skills, tools, and `/init` subagents running `/ingest` in INIT MODE treat `raw/` as strictly read-only.
+- **User-facing skill parameters are user-owned**: flags and values shown in a skill's `argument-hint` belong to the user's command, not to agent strategy. Do not invent, flip, or drop those parameters from repository state alone. If the user omitted a parameter, only use a default or derived value when that skill explicitly documents omission behavior; otherwise leave it unset or ask the user. Internal derived settings that are not user-facing parameters may still be inferred by the skill.
 - **INIT MODE handoff is manifest-driven**: when `/init` writes `.checkpoints/init-sources.json`, that manifest becomes the single source of truth for ingest order and canonical source paths. Prepared local inputs should point to `raw/tmp/`; introduced external papers should point to `raw/discovered/`.
 - **graph/ is auto-generated**: never manually edit files in `graph/` — only via `tools/research_wiki.py`.
 - **Bidirectional links**: always write the reverse link when writing a forward link.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ claude login
 chmod +x setup.sh && ./setup.sh        # Linux / macOS
 # Windows (PowerShell):
 #   powershell -ExecutionPolicy Bypass -File .\setup.ps1
+# setup creates .venv for OmegaWiki
+# the script does not keep your shell activated, but /init will use .venv automatically
 
 # 4. Put your own papers in raw/papers/ (.tex or .pdf)
 #    Optional: add intent notes to raw/notes/ and saved pages to raw/web/
@@ -408,6 +410,8 @@ claude login
 chmod +x setup.sh && ./setup.sh --lang zh        # Linux / macOS
 # Windows (PowerShell):
 #   powershell -ExecutionPolicy Bypass -File .\setup.ps1 -Lang zh
+# setup 会为 OmegaWiki 创建 .venv
+# 脚本不会把你当前 shell 永久激活，但 /init 会自动使用 .venv
 
 # 把你自己的论文放入 raw/papers/（.tex 或 .pdf）
 # 可选：把意图笔记放入 raw/notes/，网页存档放入 raw/web/

--- a/docs/runtime-directory-structure.en.md
+++ b/docs/runtime-directory-structure.en.md
@@ -25,7 +25,7 @@ wiki/
 raw/
 ├── papers/            ← user-owned .tex / .pdf sources
 ├── discovered/        ← externally fetched papers from /init and /daily-arxiv
-├── tmp/               ← /init-generated prepared local sources (synthetic / translated sidecars)
+├── tmp/               ← /init-generated prepared local sources (synthetic tex, fetched source dirs)
 ├── notes/             ← user-owned .md notes
 └── web/               ← user-owned HTML / Markdown
 

--- a/docs/runtime-directory-structure.zh.md
+++ b/docs/runtime-directory-structure.zh.md
@@ -25,7 +25,7 @@ wiki/
 raw/
 ├── papers/            ← 用户自有 .tex / .pdf 来源
 ├── discovered/        ← /init 与 /daily-arxiv 抓取的外部论文
-├── tmp/               ← /init 生成的本地预处理来源（合成 / 翻译 sidecar）
+├── tmp/               ← /init 生成的本地预处理来源（合成 tex、抓取到的源码目录）
 ├── notes/             ← 用户自有 .md 笔记
 └── web/               ← 用户自有 HTML / Markdown
 

--- a/i18n/en/CLAUDE.md
+++ b/i18n/en/CLAUDE.md
@@ -108,6 +108,7 @@ Standard log line:
 ## Constraints
 
 - **`raw/papers/`, `raw/notes/`, `raw/web/` are user-owned**: treat them as authoritative inputs. `/init` and `/daily-arxiv` may add externally fetched papers only under `raw/discovered/`, and only `/init` may add generated prepared local sidecars under `raw/tmp/` (additions only — never overwrite an existing user-owned file). `/edit` may add raw sources only when the user explicitly asked for it. All other skills, tools, and `/init` subagents running `/ingest` in INIT MODE treat `raw/` as strictly read-only.
+- **User-facing skill parameters are user-owned**: flags and values shown in a skill's `argument-hint` belong to the user's command, not to agent strategy. Do not invent, flip, or drop those parameters from repository state alone. If the user omitted a parameter, only use a default or derived value when that skill explicitly documents omission behavior; otherwise leave it unset or ask the user. Internal derived settings that are not user-facing parameters may still be inferred by the skill.
 - **INIT MODE handoff is manifest-driven**: when `/init` writes `.checkpoints/init-sources.json`, that manifest becomes the single source of truth for ingest order and canonical source paths. Prepared local inputs should point to `raw/tmp/`; introduced external papers should point to `raw/discovered/`.
 - **graph/ is auto-generated**: never manually edit files in `graph/` — only via `tools/research_wiki.py`.
 - **Bidirectional links**: always write the reverse link when writing a forward link.

--- a/i18n/en/skills/ingest/SKILL.md
+++ b/i18n/en/skills/ingest/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: <local-path-or-arXiv-URL>
 
 ## Inputs
 
-- `source`: local `.tex` / `.pdf` path, a canonical path handed off by `/init` (for example `raw/tmp/...` synthetic or translated `.tex`, or `raw/discovered/...` fetched source dirs / PDFs), or an arXiv URL (e.g. `https://arxiv.org/abs/2106.09685`)
+- `source`: local `.tex` / `.pdf` path, a canonical path handed off by `/init` (for example `raw/tmp/...` synthetic `.tex`, or `raw/discovered/...` fetched source dirs / PDFs), or an arXiv URL (e.g. `https://arxiv.org/abs/2106.09685`)
 
 ## Outputs
 
@@ -399,7 +399,7 @@ Wiki: +1 paper, +{N} claims, +{M} concepts, +{K} edges | Maturity: {level} ({cov
 
 ## Error Handling
 
-- **Source parse failure**: tex fails → PDF parse → vision API → report to user for manual handling. In INIT MODE, synthetic / translated `.tex` under `raw/tmp/` and fetched source dirs / PDFs under `raw/discovered/` are valid inputs and should be consumed as handed off.
+- **Source parse failure**: tex fails → PDF parse → vision API → report to user for manual handling. In INIT MODE, synthetic `.tex` under `raw/tmp/` and fetched source dirs / PDFs under `raw/discovered/` are valid inputs and should be consumed as handed off.
 - **S2 API unavailable**: skip S2 steps (citations backfill, default importance to 3); note in report
 - **DeepXiv API unavailable**: skip DeepXiv enrichment (TLDR, structure verification, social metrics); fall back to S2 + source file parsing
 - **Slug conflict**: if generated slug already exists but content differs, append numeric suffix (e.g. `attention-mechanism-2`)

--- a/i18n/en/skills/init/SKILL.md
+++ b/i18n/en/skills/init/SKILL.md
@@ -11,6 +11,7 @@ argument-hint: "[topic] [--no-introduction]"
 
 - `topic` (optional): research direction keywords; omit it when `raw/papers/` already defines the seed set or when notes/web already capture the intent
 - `--no-introduction` (optional): disable external paper discovery; use only user-owned `raw/papers/`, `raw/notes/`, and `raw/web/`
+- parameter guardrail: treat `topic` and `--no-introduction` as user inputs, not agent strategy knobs; do not infer `--no-introduction` from repository state alone. A non-empty `raw/papers/`, empty `raw/notes/` or `raw/web/`, or an omitted `topic` is not by itself a reason to enable local-only mode. Use `--no-introduction` only when the user explicitly asked to disable external discovery.
 - `raw/papers/`: user-owned paper sources (`.tex`, `.pdf`, archives)
 - `raw/notes/`: user-owned notes that express goals, hypotheses, exclusions, and preferred sub-directions
 - `raw/web/`: user-owned saved web pages that express goals, hypotheses, exclusions, and preferred sub-directions
@@ -18,7 +19,7 @@ argument-hint: "[topic] [--no-introduction]"
 ## Outputs
 
 - `wiki/` scaffold via `tools/research_wiki.py init`
-- `raw/tmp/` — `/init`-generated prepared local sources and translated sidecars
+- `raw/tmp/` — `/init`-generated prepared local sources
 - `raw/discovered/` — newly downloaded papers selected by `/init` (only when discovery is enabled)
 - `wiki/Summary/{area}.md`, `wiki/topics/{topic}.md`, provisional `wiki/ideas/{slug}.md`, `wiki/concepts/{slug}.md`, `wiki/claims/{slug}.md`
 - `wiki/papers/*.md` plus paper-derived concepts/claims/people via parallel `/ingest`
@@ -47,12 +48,23 @@ argument-hint: "[topic] [--no-introduction]"
 
 ## Workflow
 
-**Pre-condition**: working directory is the project root containing `wiki/`, `raw/`, `tools/`. Set `WIKI_ROOT=wiki/`.
+**Pre-condition**: working directory is the project root containing `wiki/`, `raw/`, `tools/`. Set `WIKI_ROOT=wiki/`. Resolve `PYTHON_BIN` once and reuse it for every Python command during `/init` so the workflow stays on the same interpreter that `setup.sh` populated:
+
+```bash
+if [ -x .venv/bin/python ]; then
+  PYTHON_BIN=.venv/bin/python
+elif [ -x .venv/Scripts/python.exe ]; then
+  PYTHON_BIN=.venv/Scripts/python.exe
+else
+  PYTHON_BIN=python3
+fi
+export PYTHON_BIN
+```
 
 ### Step 1: Initialize wiki structure
 
 ```bash
-python3 tools/research_wiki.py init wiki/
+"$PYTHON_BIN" tools/research_wiki.py init wiki/
 ```
 
 Create the standard wiki directories, `graph/`, `outputs/`, `index.md`, and `log.md`. Do not add a second init log entry here.
@@ -60,26 +72,27 @@ Create the standard wiki directories, `graph/`, `outputs/`, `index.md`, and `log
 ### Step 2: Prepare local inputs into `raw/tmp/`
 
 ```bash
-python3 tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json
+"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json
 ```
 
 - decode local PDFs into synthetic `.tex` under `raw/tmp/` when possible
-- write translated notes/web sidecars under `raw/tmp/` when translation succeeds
+- for PDFs that lack an embedded arXiv ID, attempt title-based recovery via Semantic Scholar search; when an arXiv ID is recovered successfully, prefer the fetched raw TeX source from arXiv (`raw/tmp/papers/...-arxiv-src/`) over the synthetic `.tex`
+- keep notes/web on their original source paths; `/init` reads them directly during planning
 - set each local paper's `canonical_ingest_path` to a prepared `raw/tmp/` path when available; otherwise fall back to the original `raw/papers/...` path
-- record warnings for failed decode / translation rather than aborting `/init`
+- record warnings for failed decode / arXiv source fetch rather than aborting `/init`
 - save the manifest to `.checkpoints/init-prepare.json`
 
 ### Step 3: Build the discovery plan, trim it, and write the final source manifest
 
 ```bash
-python3 tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json
+"$PYTHON_BIN" tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json
 ```
 
 - `mode=seeded` when the prepare manifest contains at least one parseable local paper; otherwise `mode=bootstrap`
 - `plan` must read `.checkpoints/init-prepare.json` instead of rescanning `raw/`
-- `raw/notes/` and `raw/web/` signals are read from translated `raw/tmp/` sidecars when present
-- if multiple local copies of the same paper exist, prefer better local sources in this order: translated/prepared `.tex` > original local `.tex` > archive-extracted source `.tex` > PDF-derived synthetic `.tex` > raw `.pdf`
-- if Chinese note content is detected, preserve a planner warning that curated Chinese support is planned for later and current note/web extraction may perform worse
+- `raw/notes/` and `raw/web/` signals are read directly from the original source files
+- if multiple local copies of the same paper exist, prefer better local sources in this order: original local `.tex` > archive-extracted source `.tex` or fetched arXiv source directory > PDF-derived synthetic `.tex` > raw `.pdf`
+- if Chinese note or web content is detected, preserve a planner warning that extraction/ranking may be less reliable and treat provisional outputs as lower-confidence
 - when `topic` is omitted in seeded mode, derive discovery and ranking cues from local paper titles/abstracts plus notes/web signals instead of refusing to plan
 - if seeded discovery adds no external papers, proceed with the user-owned paper set instead of treating that as a fatal planner error
 - when both `topic` and notes/web keywords are absent, bootstrap discovery has no query to search with, so it must surface that as a planner error instead of issuing an empty search
@@ -97,27 +110,35 @@ Planner policy:
 - survey/benchmark/overview bonus = 15
 - citation/centrality = 15
 - prefer a survey if one is available
-- allow at most one older canonical anchor slot
+- allow at most one older canonical anchor slot, and only in bootstrap or very roomy seeded cases
+- in seeded mode with limited introduced capacity, do not reserve an older anchor up front; freshness should dominate and older external non-survey papers must not pile up via citation advantage
 - otherwise freshness wins close decisions
 - seeded mode computes anchor bonus from user papers first, then notes/web priorities
 - bootstrap mode searches first, then expands citations/references from the strongest initial candidates
 
 LLM trim policy:
 
-- trim the over-picked shortlist to a final **8-10** papers total
-- keep all parseable user-owned papers by default
+- read `.checkpoints/init-plan.json` and explicitly trim the over-picked `shortlist` to a final **8-10** papers total before `fetch`
+- do not skip the trim step even if the shortlist already looks reasonable
+- keep all parseable user-owned papers by default, then use the remaining slots for introduced papers
 - if the user already provided more than 10 parseable papers, add no new papers
-- prefer one survey/overview when available, one canonical older anchor at most, and fresh representatives across distinct clusters
+- prefer one survey/overview when available, at most one older canonical anchor when it is actually useful, and fresh representatives across distinct clusters
+- when the user already supplied a substantial seed set, freshness should dominate and older canonical papers should be further deprioritized
+- "`at most one` older canonical anchor" is a ceiling, not a requirement
+- before `fetch`, emit an explicit final selection artifact in the workflow/response that includes: `shortlist_count`, `final_count`, and the exact final `candidate_id` list in shortlist order
+- if `final_count` is outside **8-10**, stop and revise the final selection before `fetch`, unless `--no-introduction` is active or the user already supplied more than 10 parseable papers
+- call `fetch` only with the exact final selected `candidate_id`s; never forward the whole shortlist implicitly or pass all shortlist IDs by default
 
 If `--no-introduction` is present:
 
+- only use this branch when the user explicitly requested local-only behavior
 - final paper set = all parseable user papers from `.checkpoints/init-prepare.json`
 - still run `fetch` with zero external IDs so it writes `.checkpoints/init-sources.json`
 
 Otherwise run:
 
 ```bash
-python3 tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id> --id <candidate-id>
+"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id> --id <candidate-id>
 ```
 
 - external papers downloaded by `/init` go to `raw/discovered/`, never `raw/papers/`
@@ -174,7 +195,7 @@ fi
 
 ```bash
 STASH_REF=$(git stash list | head -1 | cut -d: -f1)
-python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session stash_ref "$STASH_REF"
+"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session stash_ref "$STASH_REF"
 ```
 
 - capture the current branch before worktree fan-out; `/init` worktree mode must run from a named branch, not detached HEAD:
@@ -185,10 +206,10 @@ if [ -z "$BASE_BRANCH" ]; then
   echo "/init worktree mode requires a named branch; switch to or create one before continuing." >&2
   exit 1
 fi
-python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_branch "$BASE_BRANCH"
+"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_branch "$BASE_BRANCH"
 ```
 
-- save selected paper IDs and planner mode into checkpoint metadata
+- save final selected paper IDs (post-trim, not the over-picked shortlist) and planner mode into checkpoint metadata
 - verify `.gitattributes` contains `merge=union` for `wiki/log.md`, `wiki/graph/edges.jsonl`, and `wiki/index.md`
 - commit the scaffold:
 
@@ -196,7 +217,7 @@ python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_branc
 git add wiki/ raw/papers/ raw/tmp/ raw/discovered/ .checkpoints/init-prepare.json .checkpoints/init-plan.json .checkpoints/init-sources.json
 git commit -m "init: scaffold before parallel ingest" --no-gpg-sign
 BASE_COMMIT=$(git rev-parse HEAD)
-python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_commit "$BASE_COMMIT"
+"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_commit "$BASE_COMMIT"
 ```
 
 ### Step 5: Parallel paper ingest with worktree isolation
@@ -251,11 +272,11 @@ git switch "$BASE_BRANCH"
 git merge --no-ff "$WT_BRANCH" --no-edit
 git worktree remove "$WT_PATH"
 git branch -d "$WT_BRANCH"
-python3 tools/research_wiki.py dedup-edges wiki/
-python3 tools/research_wiki.py rebuild-index wiki/
-python3 tools/research_wiki.py rebuild-context-brief wiki/
-python3 tools/research_wiki.py rebuild-open-questions wiki/
-python3 tools/lint.py wiki/ --fix
+"$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/
+"$PYTHON_BIN" tools/lint.py wiki/ --fix
 ```
 
 ### Step 6: Final report and cleanup
@@ -297,9 +318,10 @@ Also note explicitly:
 
 - **No parseable paper in `raw/papers/`**: enter bootstrap mode
 - **`raw/notes/` and `raw/web/` empty**: skip provisional seeding, continue
-- **PDF decode or translation fails during prepare**: keep the local source, record the warning in `.checkpoints/init-prepare.json`, and fall back to the original path if needed
-- **Chinese content is detected in `raw/notes/`**: keep going, but preserve a planner warning that curated Chinese support is planned for later and current note/web extraction may be degraded
+- **PDF decode fails during prepare**: keep the local source, record the warning in `.checkpoints/init-prepare.json`, and fall back to the original path if needed
+- **Chinese content is detected in `raw/notes/` or `raw/web/`**: keep going, but preserve a planner warning that note/web extraction and ranking may be less reliable and treat rankings plus provisional pages as lower-confidence
 - **S2 or DeepXiv unavailable**: planner falls back to the remaining sources; preserve the warning in the checkpointed plan and note degraded discovery in the report
+- **arXiv ID recovery or TeX source fetch failure for a local PDF**: record a warning in `.checkpoints/init-prepare.json`, fall back to synthetic `.tex` or the original PDF path, and continue
 - **External fetch fails for one paper**: keep the remaining final set and report the failed download
 - **Single paper ingest fails**: record it via checkpoint, skip it, continue the rest, and list it in the report
 - **Current checkout is detached HEAD**: stop before worktree fan-out and ask the user to switch to or create a named branch first
@@ -310,18 +332,18 @@ Also note explicitly:
 
 ### Tools (via Bash)
 
-- `python3 tools/research_wiki.py init wiki/`
-- `python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session <key> <value>`
-- `python3 tools/research_wiki.py checkpoint-save/load/clear wiki/ init-session ...`
-- `python3 tools/research_wiki.py dedup-edges wiki/`
-- `python3 tools/research_wiki.py rebuild-index wiki/`
-- `python3 tools/research_wiki.py rebuild-context-brief wiki/`
-- `python3 tools/research_wiki.py rebuild-open-questions wiki/`
-- `python3 tools/research_wiki.py log wiki/ "<message>"`
-- `python3 tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json`
-- `python3 tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json`
-- `python3 tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id>`
-- `python3 tools/lint.py wiki/ --fix`
+- `"$PYTHON_BIN" tools/research_wiki.py init wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session <key> <value>`
+- `"$PYTHON_BIN" tools/research_wiki.py checkpoint-save/load/clear wiki/ init-session ...`
+- `"$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py log wiki/ "<message>"`
+- `"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json`
+- `"$PYTHON_BIN" tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json`
+- `"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id>`
+- `"$PYTHON_BIN" tools/lint.py wiki/ --fix`
 
 ### Skills
 

--- a/i18n/zh/CLAUDE.md
+++ b/i18n/zh/CLAUDE.md
@@ -104,6 +104,7 @@
 ## 约束
 
 - **`raw/papers/`、`raw/notes/`、`raw/web/` 归用户所有**：把它们当作权威输入。`/init` 与 `/daily-arxiv` 只能把外部抓取论文追加到 `raw/discovered/`，并且只有 `/init` 能把本地来源的预处理 sidecar 写到 `raw/tmp/`（只增不改，绝不覆盖用户自有文件）。`/edit` 仅在用户明确要求时才允许新增 raw 来源。除此之外，所有 skill、tool，以及 `/init` 在 INIT MODE 下 fan-out 的 `/ingest` 子代理都必须把 `raw/` 视为严格只读。
+- **skill 的用户可见参数归用户所有**：skill 的 `argument-hint` 中列出的 flag 与取值属于用户命令，而不是 agent 可自行决定的策略开关。不得仅根据仓库状态擅自补出、切换或删除这些参数。若用户未提供某个参数，只有在该 skill 明确写出省略时的默认或推导规则时，才可使用该默认或推导值；否则应保持未设置，必要时询问用户。不是用户可见参数的内部派生设置，skill 仍可自行推断。
 - **INIT MODE 交接由 manifest 驱动**：当 `/init` 写出 `.checkpoints/init-sources.json` 后，该 manifest 就是 ingest 顺序与规范来源路径的唯一真相来源。预处理后的本地输入应指向 `raw/tmp/`；外部引入论文应指向 `raw/discovered/`。
 - **graph/ 自动生成**：不得手动编辑 `graph/` 下的文件，仅通过 `tools/research_wiki.py` 维护。
 - **双向链接**：写正向链接时同步写反向链接。

--- a/i18n/zh/skills/ingest/SKILL.md
+++ b/i18n/zh/skills/ingest/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: <local-path-or-arXiv-URL>
 
 ## Inputs
 
-- `source`：本地 `.tex` / `.pdf` 路径、`/init` 交接的规范来源路径（例如 `raw/tmp/...` 下的合成/翻译 `.tex`，或 `raw/discovered/...` 下抓取到的源码目录 / PDF），或 arXiv URL（如 `https://arxiv.org/abs/2106.09685`）
+- `source`：本地 `.tex` / `.pdf` 路径、`/init` 交接的规范来源路径（例如 `raw/tmp/...` 下的合成 `.tex`，或 `raw/discovered/...` 下抓取到的源码目录 / PDF），或 arXiv URL（如 `https://arxiv.org/abs/2106.09685`）
 
 ## Outputs
 
@@ -399,7 +399,7 @@ Wiki: +1 paper, +{N} claims, +{M} concepts, +{K} edges | Maturity: {level} ({cov
 
 ## Error Handling
 
-- **来源解析失败**：tex 失败 → PDF 解析 → vision API → 报告用户手动处理。INIT MODE 下，`raw/tmp/` 中的合成 / 翻译 `.tex` 与 `raw/discovered/` 中的抓取源码目录 / PDF 都是合法输入，应按交接路径直接消费。
+- **来源解析失败**：tex 失败 → PDF 解析 → vision API → 报告用户手动处理。INIT MODE 下，`raw/tmp/` 中的合成 `.tex` 与 `raw/discovered/` 中的抓取源码目录 / PDF 都是合法输入，应按交接路径直接消费。
 - **S2 API 不可用**：跳过 S2 相关步骤（citations 回填、importance 使用默认值 3），在报告中注明
 - **DeepXiv API 不可用**：跳过 DeepXiv 增强步骤（TLDR、结构验证、社交指标），仅依赖 S2 + 源文件解析
 - **slug 冲突**：若生成的 slug 已存在但内容不同，追加数字后缀（如 `attention-mechanism-2`）

--- a/i18n/zh/skills/init/SKILL.md
+++ b/i18n/zh/skills/init/SKILL.md
@@ -11,6 +11,7 @@ argument-hint: "[topic] [--no-introduction]"
 
 - `topic`（可选）：研究方向关键词；如果 `raw/papers/` 已经给出了 seed set，或 notes/web 已经表达了意图，就可以省略
 - `--no-introduction`（可选）：禁用外部找论文；只使用用户自有的 `raw/papers/`、`raw/notes/`、`raw/web/`
+- 参数护栏：把 `topic` 与 `--no-introduction` 视为用户输入，而不是 agent 自行决定的策略开关；不得仅根据仓库状态推断 `--no-introduction`。`raw/papers/` 非空、`raw/notes/` 或 `raw/web/` 为空、或用户省略 `topic`，都不能单独成为启用 local-only 模式的理由。只有当用户明确要求禁用外部发现时，才可使用 `--no-introduction`。
 - `raw/papers/`：用户自有论文来源（`.tex`、`.pdf`、压缩包）
 - `raw/notes/`：用户笔记
 - `raw/web/`：用户提供的网页存档
@@ -18,7 +19,7 @@ argument-hint: "[topic] [--no-introduction]"
 ## Outputs
 
 - 通过 `tools/research_wiki.py init` 建立 `wiki/` scaffold
-- `raw/tmp/` — `/init` 生成的本地 prepared 来源与翻译 sidecar
+- `raw/tmp/` — `/init` 生成的本地 prepared 来源
 - `raw/discovered/` — `/init` 选中的外部论文（在 `--no-introduction` 时关闭）
 - `wiki/Summary/{area}.md`、`wiki/topics/{topic}.md`、provisional `wiki/ideas/{slug}.md`、`wiki/concepts/{slug}.md`、`wiki/claims/{slug}.md`
 - 通过并行 `/ingest` 创建的 `wiki/papers/*.md` 与论文驱动的 concepts / claims / people
@@ -47,12 +48,23 @@ argument-hint: "[topic] [--no-introduction]"
 
 ## Workflow
 
-**前置条件**：当前目录为项目根，且包含 `wiki/`、`raw/`、`tools/`。设 `WIKI_ROOT=wiki/`。
+**前置条件**：当前目录为项目根，且包含 `wiki/`、`raw/`、`tools/`。设 `WIKI_ROOT=wiki/`。先解析一次 `PYTHON_BIN`，并在整个 `/init` 流程里复用它，确保运行时使用与 `setup.sh` 安装依赖时相同的解释器：
+
+```bash
+if [ -x .venv/bin/python ]; then
+  PYTHON_BIN=.venv/bin/python
+elif [ -x .venv/Scripts/python.exe ]; then
+  PYTHON_BIN=.venv/Scripts/python.exe
+else
+  PYTHON_BIN=python3
+fi
+export PYTHON_BIN
+```
 
 ### Step 1: 初始化 wiki 结构
 
 ```bash
-python3 tools/research_wiki.py init wiki/
+"$PYTHON_BIN" tools/research_wiki.py init wiki/
 ```
 
 创建标准目录、`graph/`、`outputs/`、`index.md` 与 `log.md`。这里不要重复写第二条 init 日志。
@@ -60,26 +72,27 @@ python3 tools/research_wiki.py init wiki/
 ### Step 2: 先把本地输入 prepare 到 `raw/tmp/`
 
 ```bash
-python3 tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json
+"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json
 ```
 
 - 本地 PDF 能 decode 时，先转成 `raw/tmp/` 下的 synthetic `.tex`
-- notes / web 翻译成功时，把英文 sidecar 写到 `raw/tmp/`
+- 对于不含嵌入 arXiv ID 的 PDF，尝试通过 Semantic Scholar 按标题搜索恢复 arXiv ID；恢复成功后，优先使用从 arXiv 抓取的原始 TeX 源码（`raw/tmp/papers/...-arxiv-src/`），而非 synthetic `.tex`
+- notes / web 保持原始来源路径，`/init` 在 planning 阶段直接读取
 - 本地论文若存在 usable 的 prepared `.tex`，其 `canonical_ingest_path` 必须指向 `raw/tmp/`
-- decode / translation 失败时记录 warning，而不是中止 `/init`
+- decode / arXiv 源码抓取失败时记录 warning，而不是中止 `/init`
 - 输出 manifest 到 `.checkpoints/init-prepare.json`
 
 ### Step 3: 基于 prepared 输入生成 plan、裁剪 shortlist，并写出最终 source manifest
 
 ```bash
-python3 tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json
+"$PYTHON_BIN" tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json
 ```
 
 - `mode=seeded` 取决于 `.checkpoints/init-prepare.json` 中是否存在可解析本地论文；否则为 `bootstrap`
 - `plan` 必须读取 prepare manifest，而不是重新扫描 `raw/`
-- notes/web 的用户信号若存在英文 sidecar，应优先读取 `raw/tmp/`
-- 如果同一篇本地论文出现多个副本，优先级必须明确：翻译/预处理后的 `.tex` > 原始本地 `.tex` > archive 解出的源码 `.tex` > 由 PDF 生成的 synthetic `.tex` > 原始 `.pdf`
-- 若检测到中文 notes 内容，要保留 planner warning：中文精细支持会在后续版本补上；当前 note/web 提取效果可能会降级
+- notes/web 的用户信号直接从原始来源文件读取
+- 如果同一篇本地论文出现多个副本，优先级必须明确：原始本地 `.tex` > archive 解出的源码 `.tex` 或抓取到的 arXiv 源码目录 > 由 PDF 生成的 synthetic `.tex` > 原始 `.pdf`
+- 若检测到中文 notes 或 web 内容，要保留 planner warning：当前 note/web 提取与排序对中文输入的可靠性可能更低，provisional 输出也应视为较低置信度
 - seeded 模式下如果省略 `topic`，要从本地论文标题/摘要以及 notes/web 信号里提取 discovery 与 ranking 线索，而不是直接拒绝初始化
 - 如果 seeded discovery 最终没有新增任何外部论文，也要继续用用户自带论文集往下走，而不是把它当成 fatal planner error
 - 如果 `topic` 与 notes/web 关键词都缺失，bootstrap discovery 就没有可搜索的 query；此时应把它记为 planner error，而不是发起空搜索
@@ -97,27 +110,35 @@ planner 评分策略：
 - survey/benchmark/overview bonus = 15
 - citation/centrality = 15
 - 有 survey 就优先保留
-- 最多保留一个偏旧 canonical anchor
+- 最多保留一个偏旧 canonical anchor，而且只应在 bootstrap 或 seeded 且最终新增容量非常宽裕时考虑
+- 在 seeded 模式且可新增论文空间有限时，不要预留偏旧 anchor；此时应让 freshness 主导，并防止偏旧的外部非 survey 论文仅凭 citation 优势堆积进入 shortlist
 - 其余近分时 freshness 优先
 - seeded 模式先看用户论文连接，再看 notes/web 偏好
 - bootstrap 模式先 search，再从最强初始候选做 citation/reference 扩展
 
 LLM 裁剪策略：
 
-- 把 over-pick 的 shortlist 裁到最终 **8-10** 篇
-- 默认保留所有可解析的用户论文
+- 在 `fetch` 前读取 `.checkpoints/init-plan.json`，并把 over-pick 的 `shortlist` 明确裁成最终 **8-10** 篇
+- 即使 shortlist 看起来已经“差不多”，也不得跳过裁剪步骤
+- 默认保留所有可解析的用户论文，再用剩余名额选择 introduced 论文
 - 若用户已提供超过 10 篇可解析论文，则不再新增外部论文
-- 优先保留 survey/overview、至多一篇偏旧 canonical anchor，以及来自不同 cluster 的近期代表作
+- 优先保留 survey/overview、在确有帮助时至多一篇偏旧 canonical anchor，以及来自不同 cluster 的近期代表作
+- 当用户已经提供较充足的 seed set 时，应优先 freshness，并进一步降低偏旧 canonical 论文的优先级
+- “至多一篇” 是上限，不代表必须保留一篇偏旧 canonical anchor
+- 在 `fetch` 前，必须在工作流/响应中给出一个明确的最终选择结果，至少包含：`shortlist_count`、`final_count`，以及按 shortlist 顺序排列的最终 `candidate_id` 列表
+- 若 `final_count` 不在 **8-10** 范围内，则必须先停止并修正最终选择，再执行 `fetch`；`--no-introduction` 或“用户已提供超过 10 篇可解析论文”这两种已说明例外除外
+- `fetch` 只能接收最终选中的那组 `candidate_id`；禁止把整个 shortlist 默认原样转发，或默认把所有 shortlist ID 都传进去
 
 若传入 `--no-introduction`：
 
+- 只有在用户明确要求只使用本地论文时，才走这一分支
 - 最终论文集 = `.checkpoints/init-prepare.json` 中所有可解析本地论文
 - 仍然要执行 `fetch`（不给外部 ID），以写出 `.checkpoints/init-sources.json`
 
 否则运行：
 
 ```bash
-python3 tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id> --id <candidate-id>
+"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id> --id <candidate-id>
 ```
 
 - `/init` 下载的论文只允许写入 `raw/discovered/`，绝不写入 `raw/papers/`
@@ -174,7 +195,7 @@ fi
 
 ```bash
 STASH_REF=$(git stash list | head -1 | cut -d: -f1)
-python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session stash_ref "$STASH_REF"
+"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session stash_ref "$STASH_REF"
 ```
 
 - 在 worktree fan-out 前先记录当前 branch；`/init` 的 worktree 模式必须运行在一个有名字的 branch 上，不能处于 detached HEAD：
@@ -185,10 +206,10 @@ if [ -z "$BASE_BRANCH" ]; then
   echo "/init 的 worktree 模式要求当前位于一个命名分支；请先切换到或创建分支。" >&2
   exit 1
 fi
-python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_branch "$BASE_BRANCH"
+"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_branch "$BASE_BRANCH"
 ```
 
-- 同时把 selected paper IDs 与 planner mode 写入 checkpoint metadata
+- 同时把最终选中的 paper IDs（post-trim 后的结果，不是 over-pick 的 shortlist）与 planner mode 写入 checkpoint metadata
 - 验证 `.gitattributes` 对 `wiki/log.md`、`wiki/graph/edges.jsonl`、`wiki/index.md` 使用了 `merge=union`
 - commit scaffold：
 
@@ -196,7 +217,7 @@ python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_branc
 git add wiki/ raw/papers/ raw/tmp/ raw/discovered/ .checkpoints/init-prepare.json .checkpoints/init-plan.json .checkpoints/init-sources.json
 git commit -m "init: scaffold before parallel ingest" --no-gpg-sign
 BASE_COMMIT=$(git rev-parse HEAD)
-python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_commit "$BASE_COMMIT"
+"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_commit "$BASE_COMMIT"
 ```
 
 ### Step 5: 通过 worktree 隔离并行 ingest 论文
@@ -251,11 +272,11 @@ git switch "$BASE_BRANCH"
 git merge --no-ff "$WT_BRANCH" --no-edit
 git worktree remove "$WT_PATH"
 git branch -d "$WT_BRANCH"
-python3 tools/research_wiki.py dedup-edges wiki/
-python3 tools/research_wiki.py rebuild-index wiki/
-python3 tools/research_wiki.py rebuild-context-brief wiki/
-python3 tools/research_wiki.py rebuild-open-questions wiki/
-python3 tools/lint.py wiki/ --fix
+"$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/
+"$PYTHON_BIN" tools/lint.py wiki/ --fix
 ```
 
 ### Step 6: 最终报告与清理
@@ -297,9 +318,10 @@ python3 tools/lint.py wiki/ --fix
 
 - **`raw/papers/` 无可解析论文**：自动切换到 bootstrap 模式
 - **`raw/notes/` 与 `raw/web/` 为空**：跳过 provisional seeding，继续
-- **prepare 阶段的 PDF decode 或 translation 失败**：把 warning 记入 `.checkpoints/init-prepare.json`，必要时回退到原始路径
-- **`raw/notes/` 中检测到中文内容**：继续执行，但要保留 planner warning，明确说明中文精细支持会在后续版本补上，当前 note/web 提取效果可能降级
+- **prepare 阶段的 PDF decode 失败**：把 warning 记入 `.checkpoints/init-prepare.json`，必要时回退到原始路径
+- **`raw/notes/` 或 `raw/web/` 中检测到中文内容**：继续执行，但要保留 planner warning，说明当前 note/web 提取与排序对中文输入的可靠性可能更低，并把 rankings 与 provisional 页面视为较低置信度
 - **S2 或 DeepXiv 不可用**：planner 使用剩余来源并继续执行；把 warning 保留在 checkpoint plan 中，并在最终报告里注明 discovery 降级
+- **本地 PDF 的 arXiv ID 恢复或 TeX 源码抓取失败**：把 warning 记入 `.checkpoints/init-prepare.json`，回退到 synthetic `.tex` 或原始 PDF 路径，然后继续
 - **某篇外部论文下载失败**：保留其余最终论文集，报告失败项
 - **单篇 ingest 失败**：写 checkpoint，跳过该篇，继续其他论文，并在最终报告中列出
 - **当前 checkout 处于 detached HEAD**：在 worktree fan-out 前停止，并要求用户先切换到或创建一个命名分支
@@ -310,18 +332,18 @@ python3 tools/lint.py wiki/ --fix
 
 ### Tools (via Bash)
 
-- `python3 tools/research_wiki.py init wiki/`
-- `python3 tools/research_wiki.py checkpoint-set-meta wiki/ init-session <key> <value>`
-- `python3 tools/research_wiki.py checkpoint-save/load/clear wiki/ init-session ...`
-- `python3 tools/research_wiki.py dedup-edges wiki/`
-- `python3 tools/research_wiki.py rebuild-index wiki/`
-- `python3 tools/research_wiki.py rebuild-context-brief wiki/`
-- `python3 tools/research_wiki.py rebuild-open-questions wiki/`
-- `python3 tools/research_wiki.py log wiki/ "<message>"`
-- `python3 tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json`
-- `python3 tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json`
-- `python3 tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id>`
-- `python3 tools/lint.py wiki/ --fix`
+- `"$PYTHON_BIN" tools/research_wiki.py init wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session <key> <value>`
+- `"$PYTHON_BIN" tools/research_wiki.py checkpoint-save/load/clear wiki/ init-session ...`
+- `"$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py log wiki/ "<message>"`
+- `"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json`
+- `"$PYTHON_BIN" tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json`
+- `"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id>`
+- `"$PYTHON_BIN" tools/lint.py wiki/ --fix`
 
 ### Skills
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 PyMuPDF>=1.23.0
 feedparser>=6.0.0
 requests>=2.28.0
-anthropic>=0.20.0
 markdownify>=0.11.0
 chardet>=5.0.0
 deepxiv-sdk>=0.2.0

--- a/setup.ps1
+++ b/setup.ps1
@@ -97,39 +97,29 @@ Write-Info "Setting up Python environment..."
 
 Push-Location $ProjectRoot
 try {
-    $UsingExisting = $false
-    if ($env:VIRTUAL_ENV) {
-        Write-Ok "Using active venv: $env:VIRTUAL_ENV"
-        $UsingExisting = $true
-    } elseif ($env:CONDA_DEFAULT_ENV -and $env:CONDA_DEFAULT_ENV -ne "base") {
-        Write-Ok "Using active conda env: $env:CONDA_DEFAULT_ENV"
-        $UsingExisting = $true
-    } else {
-        if (Test-Path ".venv") {
-            Write-Warn2 ".venv already exists, using it"
-        } else {
-            & $PythonCmd -m venv .venv
-            if ($LASTEXITCODE -ne 0) { throw "venv creation failed" }
-            Write-Ok "Created .venv"
-        }
+    if ($env:VIRTUAL_ENV -or ($env:CONDA_DEFAULT_ENV -and $env:CONDA_DEFAULT_ENV -ne "base")) {
+        Write-Warn2 "Active environment detected; setup always installs OmegaWiki into .venv"
     }
 
-    # Resolve the python interpreter to use for installs + verification
-    if ($UsingExisting) {
-        $VenvPython = $PythonCmd
+    if (Test-Path ".venv") {
+        Write-Warn2 ".venv already exists, using it"
     } else {
-        $VenvPython = Join-Path $ProjectRoot ".venv\Scripts\python.exe"
-        if (-not (Test-Path $VenvPython)) {
-            Write-Fail "Expected $VenvPython but it does not exist"
-            exit 1
-        }
-        Write-Ok "Using .venv\Scripts\python.exe"
+        & $PythonCmd -m venv .venv
+        if ($LASTEXITCODE -ne 0) { throw "venv creation failed" }
+        Write-Ok "Created .venv"
     }
 
-    Write-Info "Installing dependencies..."
+    $VenvPython = Join-Path $ProjectRoot ".venv\Scripts\python.exe"
+    if (-not (Test-Path $VenvPython)) {
+        Write-Fail "Expected $VenvPython but it does not exist"
+        exit 1
+    }
+    Write-Ok "Using .venv\Scripts\python.exe"
+
+    Write-Info "Installing dependencies into .venv..."
     & $VenvPython -m pip install -r requirements.txt -q
     if ($LASTEXITCODE -ne 0) { throw "pip install failed" }
-    Write-Ok "Dependencies installed"
+    Write-Ok "Dependencies installed into .venv"
 
     # -- Step 3: Configuration files ---------------------------------------
     Write-Host ""
@@ -177,27 +167,61 @@ try {
     Write-Host ""
     Write-Info "Verifying installation..."
 
-    $errors = 0
-    $checks = @(
-        @{ name = "fetch_arxiv";    import = "from fetch_arxiv import fetch_recent" },
-        @{ name = "fetch_s2";       import = "from fetch_s2 import search" },
-        @{ name = "fetch_deepxiv";  import = "from fetch_deepxiv import search" },
-        @{ name = "research_wiki";  import = "from research_wiki import slugify" },
-        @{ name = "lint";           import = "from lint import check_missing_fields" }
-    )
-    Push-Location "tools"
-    try {
-        foreach ($c in $checks) {
-            & $VenvPython -c $c.import 2>$null
+    $script:VerificationErrors = 0
+    $script:VerificationWarnings = 0
+
+    function Invoke-PythonCheck {
+        param(
+            [string]$Label,
+            [string]$Code,
+            [string]$WorkingDirectory = $ProjectRoot,
+            [switch]$WarningOnly
+        )
+
+        Push-Location $WorkingDirectory
+        try {
+            & $VenvPython -c $Code 2>$null | Out-Null
             if ($LASTEXITCODE -eq 0) {
-                Write-Ok ("tools/{0}.py" -f $c.name)
+                Write-Ok $Label
+            } elseif ($WarningOnly) {
+                Write-Warn2 $Label
+                $script:VerificationWarnings++
             } else {
-                Write-Fail ("tools/{0}.py import error" -f $c.name)
-                $errors++
+                Write-Fail $Label
+                $script:VerificationErrors++
             }
+        } finally {
+            Pop-Location
         }
-    } finally {
-        Pop-Location
+    }
+
+    Invoke-PythonCheck -Label "PyMuPDF (fitz)" -Code "import fitz"
+    Invoke-PythonCheck -Label "requests" -Code "import requests"
+    Invoke-PythonCheck -Label "feedparser" -Code "import feedparser"
+
+    $toolChecks = @(
+        @{ name = "tools/init_discovery.py"; import = "from init_discovery import prepare_inputs" },
+        @{ name = "tools/fetch_s2.py";       import = "from fetch_s2 import search" },
+        @{ name = "tools/fetch_arxiv.py";    import = "from fetch_arxiv import fetch_recent" },
+        @{ name = "tools/research_wiki.py";  import = "from research_wiki import slugify" },
+        @{ name = "tools/lint.py";           import = "from lint import check_missing_fields" }
+    )
+    foreach ($c in $toolChecks) {
+        Invoke-PythonCheck -Label $c.name -Code $c.import -WorkingDirectory (Join-Path $ProjectRoot "tools")
+    }
+
+    & $VenvPython -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        & $VenvPython -c "import deepxiv_sdk" 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Ok "deepxiv-sdk (optional)"
+        } else {
+            Write-Warn2 "deepxiv-sdk unavailable; DeepXiv features will degrade but setup can continue"
+            $script:VerificationWarnings++
+        }
+    } else {
+        Write-Warn2 "Python < 3.10 detected inside .venv; deepxiv-sdk may be unavailable, so DeepXiv features may degrade"
+        $script:VerificationWarnings++
     }
 } finally {
     Pop-Location
@@ -206,10 +230,12 @@ try {
 # -- Done ------------------------------------------------------------------
 Write-Host ""
 Write-Host "============================================"
-if ($errors -eq 0) {
+if ($script:VerificationErrors -eq 0 -and $script:VerificationWarnings -eq 0) {
     Write-Host "  Setup complete!" -ForegroundColor Green
+} elseif ($script:VerificationErrors -eq 0) {
+    Write-Host "  Setup complete with $script:VerificationWarnings warning(s)" -ForegroundColor Yellow
 } else {
-    Write-Host "  Setup complete with $errors warning(s)" -ForegroundColor Yellow
+    Write-Host "  Setup complete with $script:VerificationErrors error(s) and $script:VerificationWarnings warning(s)" -ForegroundColor Yellow
 }
 Write-Host "============================================"
 Write-Host ""
@@ -218,8 +244,10 @@ Write-Host ""
 Write-Host "  1. Authenticate Claude Code (if not already):"
 Write-Host "       claude login"
 Write-Host ""
-Write-Host "  2. Activate the venv in your shell (optional, for manual tool use):"
+Write-Host "  2. Activate the venv in your shell only if you want to run Python tools manually:"
 Write-Host "       .\.venv\Scripts\Activate.ps1"
+Write-Host "       setup.ps1 does not activate your current shell permanently."
+Write-Host "       /init will use .venv automatically when it exists."
 Write-Host ""
 Write-Host "  3. Start Claude Code:"
 Write-Host "       claude"

--- a/setup.sh
+++ b/setup.sh
@@ -48,9 +48,11 @@ for i in "${!_ARGS[@]}"; do
     --lang)   LANG_CODE="${_ARGS[$((i+1))]}" ;;
   esac
 done
+PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
 [[ "$LANG_CODE" == "en" || "$LANG_CODE" == "zh" ]] || { fail "Unknown lang: $LANG_CODE (use 'en' or 'zh')"; exit 1; }
-I18N_DIR="$(cd "$(dirname "$0")" && pwd)/i18n/$LANG_CODE"
+I18N_DIR="$PROJECT_ROOT/i18n/$LANG_CODE"
 [ -d "$I18N_DIR" ] || { fail "i18n/$LANG_CODE not found — run from the project root"; exit 1; }
+cd "$PROJECT_ROOT"
 
 echo ""
 echo "============================================"
@@ -64,6 +66,7 @@ info "Checking prerequisites..."
 
 # Python
 if command -v python3 &>/dev/null; then
+    PYTHON_CMD="python3"
     PY_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
     PY_MAJOR=$(echo "$PY_VERSION" | cut -d. -f1)
     PY_MINOR=$(echo "$PY_VERSION" | cut -d. -f2)
@@ -79,10 +82,10 @@ else
 fi
 
 # pip
-if python3 -m pip --version &>/dev/null; then
+if "$PYTHON_CMD" -m pip --version &>/dev/null; then
     ok "pip available"
 else
-    fail "pip not found. Install with: python3 -m ensurepip"
+    fail "pip not found. Install with: $PYTHON_CMD -m ensurepip"
     exit 1
 fi
 
@@ -109,29 +112,27 @@ fi
 echo ""
 info "Setting up Python environment..."
 
-# Detect if user is already in a virtual environment (venv or conda)
-if [ -n "$VIRTUAL_ENV" ]; then
-    ok "Using active venv: $VIRTUAL_ENV"
-    USING_VENV="$VIRTUAL_ENV"
-elif [ -n "$CONDA_DEFAULT_ENV" ] && [ "$CONDA_DEFAULT_ENV" != "base" ]; then
-    ok "Using active conda env: $CONDA_DEFAULT_ENV"
-    USING_VENV="conda:$CONDA_DEFAULT_ENV"
-else
-    # No active env — create .venv
-    if [ -d ".venv" ]; then
-        warn ".venv already exists, using it"
-    else
-        python3 -m venv .venv
-        ok "Created .venv"
-    fi
-    source .venv/bin/activate
-    ok "Activated .venv"
-    USING_VENV=".venv"
+if [ -n "$VIRTUAL_ENV" ] || { [ -n "$CONDA_DEFAULT_ENV" ] && [ "$CONDA_DEFAULT_ENV" != "base" ]; }; then
+    warn "Active environment detected; setup always installs OmegaWiki into .venv"
 fi
 
-info "Installing dependencies..."
-pip install -r requirements.txt -q
-ok "Dependencies installed"
+if [ -d ".venv" ]; then
+    warn ".venv already exists, using it"
+else
+    "$PYTHON_CMD" -m venv .venv
+    ok "Created .venv"
+fi
+
+VENV_PYTHON=".venv/bin/python"
+if [ ! -x "$VENV_PYTHON" ]; then
+    fail "Expected $VENV_PYTHON but it does not exist"
+    exit 1
+fi
+ok "Using $VENV_PYTHON"
+
+info "Installing dependencies into .venv..."
+"$VENV_PYTHON" -m pip install -r requirements.txt -q
+ok "Dependencies installed into .venv"
 
 # ── Step 3: Configuration files ─────────────────────────────────────────
 
@@ -184,32 +185,65 @@ echo ""
 info "Verifying installation..."
 
 ERRORS=0
+WARNINGS=0
 
-# Check tools import (run from tools/ so _env.py resolves correctly)
-for tool_check in \
-    "fetch_arxiv:from fetch_arxiv import fetch_recent" \
-    "fetch_s2:from fetch_s2 import search" \
-    "fetch_deepxiv:from fetch_deepxiv import search" \
-    "research_wiki:from research_wiki import slugify" \
-    "lint:from lint import check_missing_fields"; do
-    tool_name="${tool_check%%:*}"
-    tool_import="${tool_check#*:}"
-    if (cd tools && python3 -c "$tool_import") 2>/dev/null; then
-        ok "tools/${tool_name}.py"
+check_python_snippet() {
+    local label="$1"
+    local snippet="$2"
+    if "$VENV_PYTHON" -c "$snippet" >/dev/null 2>&1; then
+        ok "$label"
     else
-        fail "tools/${tool_name}.py import error"
+        fail "$label missing"
         ERRORS=$((ERRORS+1))
     fi
-done
+}
+
+check_tool_import() {
+    local label="$1"
+    local import_stmt="$2"
+    if (cd tools && "$VENV_PYTHON" -c "$import_stmt") >/dev/null 2>&1; then
+        ok "$label"
+    else
+        fail "$label import error"
+        ERRORS=$((ERRORS+1))
+    fi
+}
+
+# Check real runtime dependencies first.
+check_python_snippet "PyMuPDF (fitz)" "import fitz"
+check_python_snippet "requests" "import requests"
+check_python_snippet "feedparser" "import feedparser"
+
+# Then check the current-stage tools with the same interpreter.
+check_tool_import "tools/init_discovery.py" "from init_discovery import prepare_inputs"
+check_tool_import "tools/fetch_s2.py" "from fetch_s2 import search"
+check_tool_import "tools/fetch_arxiv.py" "from fetch_arxiv import fetch_recent"
+check_tool_import "tools/research_wiki.py" "from research_wiki import slugify"
+check_tool_import "tools/lint.py" "from lint import check_missing_fields"
+
+# DeepXiv is optional; surface it as a warning-only diagnostic.
+if "$VENV_PYTHON" -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" >/dev/null 2>&1; then
+    if "$VENV_PYTHON" -c "import deepxiv_sdk" >/dev/null 2>&1; then
+        ok "deepxiv-sdk (optional)"
+    else
+        warn "deepxiv-sdk unavailable; DeepXiv features will degrade but setup can continue"
+        WARNINGS=$((WARNINGS+1))
+    fi
+else
+    warn "Python < 3.10 detected inside .venv; deepxiv-sdk may be unavailable, so DeepXiv features may degrade"
+    WARNINGS=$((WARNINGS+1))
+fi
 
 # ── Done ────────────────────────────────────────────────────────────────
 
 echo ""
 echo "============================================"
-if [ $ERRORS -eq 0 ]; then
+if [ $ERRORS -eq 0 ] && [ $WARNINGS -eq 0 ]; then
     echo -e "  ${GREEN}Setup complete!${NC}"
+elif [ $ERRORS -eq 0 ]; then
+    echo -e "  ${YELLOW}Setup complete with $WARNINGS warning(s)${NC}"
 else
-    echo -e "  ${YELLOW}Setup complete with $ERRORS warning(s)${NC}"
+    echo -e "  ${YELLOW}Setup complete with $ERRORS error(s) and $WARNINGS warning(s)${NC}"
 fi
 echo "============================================"
 echo ""
@@ -218,15 +252,20 @@ echo ""
 echo "  1. Authenticate Claude Code (if not already):"
 echo "     claude login"
 echo ""
-echo "  2. Start Claude Code:"
+echo "  2. Optional: activate .venv for manual Python tool use:"
+echo "     source .venv/bin/activate"
+echo "     setup.sh does not activate your current shell permanently."
+echo "     /init will use .venv/bin/python automatically when it exists."
+echo ""
+echo "  3. Start Claude Code:"
 echo "     claude"
 echo ""
-echo "  3. Complete API key configuration (guided):"
+echo "  4. Complete API key configuration (guided):"
 echo "     /setup"
 echo "     Claude Code will walk you through Semantic Scholar,"
 echo "     DeepXiv, and Review LLM — skip any you don't have yet."
 echo ""
-echo "  4. Then initialize your wiki:"
+echo "  5. Then initialize your wiki:"
 echo "     /init [your-research-topic]"
 echo ""
 echo "  For more, see README.md"

--- a/tests/test_init_discovery.py
+++ b/tests/test_init_discovery.py
@@ -34,6 +34,34 @@ def _s2_paper(
     }
 
 
+def _shortlist_candidate(
+    candidate_id: str,
+    title: str,
+    *,
+    year: int,
+    citation_count: int,
+    total_score: float,
+    cluster: str,
+    user_owned: bool = False,
+    is_survey: bool = False,
+    deepxiv_relevance_score: float = 0.0,
+) -> dict:
+    return {
+        "candidate_id": candidate_id,
+        "title": title,
+        "abstract": title,
+        "year": year,
+        "citation_count": citation_count,
+        "source_channels": ["search_s2"],
+        "anchor_sources": [],
+        "deepxiv_relevance_score": deepxiv_relevance_score,
+        "user_owned": user_owned,
+        "cluster": cluster,
+        "is_survey": is_survey,
+        "total_score": total_score,
+    }
+
+
 @pytest.fixture
 def raw_root(tmp_path):
     raw = tmp_path / "raw"
@@ -50,6 +78,7 @@ def test_prepare_pdf_emits_canonical_tmp_tex(raw_root, monkeypatch):
         "_extract_pdf_text",
         lambda _path: ("Adapter Tuning for LLMs\nAbstract\nImproves multilingual transfer.", []),
     )
+    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [])
 
     manifest = disc.prepare_inputs(raw_root)
 
@@ -57,6 +86,8 @@ def test_prepare_pdf_emits_canonical_tmp_tex(raw_root, monkeypatch):
     assert entry["prepared_path"].startswith("raw/tmp/papers/")
     assert entry["canonical_ingest_path"] == entry["prepared_path"]
     assert entry["ingest_format"] == "tex"
+    assert "translated_to_english" not in entry
+    assert "original_language" not in entry
     assert (raw_root.parent / entry["canonical_ingest_path"]).exists()
 
 
@@ -71,6 +102,7 @@ def test_prepare_prefers_local_tex_over_pdf_for_same_paper(raw_root, monkeypatch
         "_extract_pdf_text",
         lambda _path: ("Adapter Tuning for LLMs\nAbstract\npdf version", []),
     )
+    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [])
 
     manifest = disc.prepare_inputs(raw_root)
     paper_entries = [item for item in manifest["entries"] if item["source_kind"] == "paper"]
@@ -78,25 +110,29 @@ def test_prepare_prefers_local_tex_over_pdf_for_same_paper(raw_root, monkeypatch
     assert len(paper_entries) == 1
     assert paper_entries[0]["source_path"] == "raw/papers/paper.tex"
     assert paper_entries[0]["canonical_ingest_path"] == "raw/papers/paper.tex"
+    assert "translated_to_english" not in paper_entries[0]
+    assert "original_language" not in paper_entries[0]
     assert any("duplicate local source skipped" in warning for warning in paper_entries[0]["warnings"])
 
 
-def test_prepare_translates_notes_into_tmp_sidecar(raw_root, monkeypatch):
+def test_prepare_notes_keep_original_paths(raw_root):
     (raw_root / "notes" / "focus.md").write_text("我们想研究多语言 adapter tuning。", encoding="utf-8")
-    monkeypatch.setattr(
-        disc,
-        "_translate_to_english",
-        lambda text, _label: ("We want to study multilingual adapter tuning.", ["translated"]),
-    )
 
     manifest = disc.prepare_inputs(raw_root)
     entry = next(item for item in manifest["entries"] if item["source_kind"] == "notes")
 
-    assert entry["translated_to_english"] is True
-    assert entry["prepared_path"].startswith("raw/tmp/notes/")
+    assert entry["source_path"] == "raw/notes/focus.md"
+    assert entry["prepared_path"] is None
+    assert entry["canonical_ingest_path"] == "raw/notes/focus.md"
+    assert entry["canonical_read_path"] == "raw/notes/focus.md"
+    assert "translated_to_english" not in entry
+    assert "original_language" not in entry
     notes_web = disc.scan_notes_web(raw_root, prepared_manifest=manifest)
-    assert "multilingual" in notes_web["keywords"]
+    assert notes_web["files"][0]["canonical_path"] == "raw/notes/focus.md"
+    assert "translated_to_english" not in notes_web["files"][0]
+    assert "original_language" not in notes_web["files"][0]
     assert "adapter" in notes_web["keywords"]
+    assert "tuning" in notes_web["keywords"]
 
 
 def test_plan_warns_when_chinese_notes_are_detected(raw_root, monkeypatch):
@@ -108,10 +144,15 @@ def test_plan_warns_when_chinese_notes_are_detected(raw_root, monkeypatch):
 
     plan = disc.build_plan("adapter tuning", raw_root, raw_root.parent / "wiki")
 
-    assert plan["notes_web"]["chinese_note_count"] == 1
+    assert "chinese_note_count" not in plan["notes_web"]
+    assert "chinese_web_count" not in plan["notes_web"]
+    assert "untranslated_chinese_count" not in plan["notes_web"]
+    assert all("translated_to_english" not in item for item in plan["notes_web"]["files"])
+    assert all("original_language" not in item for item in plan["notes_web"]["files"])
     assert any(
         warning["source"] == "notes_web_chinese"
-        and "Curated Chinese support is planned" in warning["message"]
+        and "lower-confidence" in warning["message"]
+        and "planned for a later release" not in warning["message"]
         for warning in plan["warnings"]
     )
 
@@ -206,10 +247,10 @@ def test_plan_uses_prepared_manifest_canonical_paths(raw_root, monkeypatch):
         "_extract_pdf_text",
         lambda _path: ("Adapter Tuning for LLMs\nAbstract\nImproves multilingual transfer.", []),
     )
+    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [])
     manifest = disc.prepare_inputs(raw_root)
     monkeypatch.setattr(disc, "s2_citations", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(disc, "s2_references", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(disc, "deepxiv_search", lambda *_args, **_kwargs: [])
 
     plan = disc.build_plan("adapter tuning", raw_root, raw_root.parent / "wiki", prepared_manifest=manifest)
@@ -477,57 +518,253 @@ def test_exclusion_terms_penalize_candidate():
     assert excluded["score_components"]["exclusion_penalty"] < 0
 
 
-def test_freshness_beats_multiple_old_papers_after_anchor_slot():
+def test_bootstrap_keeps_one_old_anchor_without_piling():
     candidates = [
-        {
-            "candidate_id": "old-1",
-            "title": "Canonical Old Adapter Paper",
-            "abstract": "adapter tuning",
-            "year": disc.CURRENT_YEAR - 8,
-            "citation_count": 5000,
-            "source_channels": ["search_s2"],
-            "anchor_sources": [],
-            "deepxiv_relevance_score": 0.6,
-            "user_owned": False,
-            "cluster": "adapter",
-            "is_survey": False,
-            "total_score": 80.0,
-        },
-        {
-            "candidate_id": "old-2",
-            "title": "Another Old Adapter Paper",
-            "abstract": "adapter tuning",
-            "year": disc.CURRENT_YEAR - 7,
-            "citation_count": 4200,
-            "source_channels": ["search_s2"],
-            "anchor_sources": [],
-            "deepxiv_relevance_score": 0.58,
-            "user_owned": False,
-            "cluster": "adapter",
-            "is_survey": False,
-            "total_score": 79.0,
-        },
-        {
-            "candidate_id": "fresh-1",
-            "title": "Fresh Adapter Benchmark",
-            "abstract": "adapter benchmark",
-            "year": disc.CURRENT_YEAR,
-            "citation_count": 80,
-            "source_channels": ["search_s2"],
-            "anchor_sources": [],
-            "deepxiv_relevance_score": 0.8,
-            "user_owned": False,
-            "cluster": "benchmark",
-            "is_survey": False,
-            "total_score": 74.0,
-        },
+        _shortlist_candidate(
+            "old-1",
+            "Canonical Old Adapter Paper",
+            year=disc.CURRENT_YEAR - 8,
+            citation_count=5000,
+            total_score=80.0,
+            cluster="adapter",
+            deepxiv_relevance_score=0.6,
+        ),
+        _shortlist_candidate(
+            "old-2",
+            "Another Old Adapter Paper",
+            year=disc.CURRENT_YEAR - 7,
+            citation_count=4200,
+            total_score=79.0,
+            cluster="adapter-2",
+            deepxiv_relevance_score=0.58,
+        ),
+        _shortlist_candidate(
+            "fresh-1",
+            "Fresh Adapter Benchmark",
+            year=disc.CURRENT_YEAR,
+            citation_count=80,
+            total_score=74.0,
+            cluster="benchmark",
+            deepxiv_relevance_score=0.8,
+        ),
     ]
 
     shortlist = disc._select_shortlist(candidates, "bootstrap", 0, True)
     old_selected = [item for item in shortlist if item["candidate_id"].startswith("old")]
 
-    assert len(old_selected) <= 1
+    assert [item["candidate_id"] for item in old_selected] == ["old-1"]
     assert any(item["candidate_id"] == "fresh-1" for item in shortlist)
+
+
+def test_seeded_with_little_room_prefers_fresh_papers_before_old_anchor():
+    local_candidates = [
+        _shortlist_candidate(
+            f"local-{idx}",
+            f"Local Seed {idx}",
+            year=disc.CURRENT_YEAR,
+            citation_count=0,
+            total_score=100.0 - idx,
+            cluster=f"local-{idx}",
+            user_owned=True,
+        )
+        for idx in range(8)
+    ]
+    external_candidates = [
+        _shortlist_candidate(
+            "old-1",
+            "Canonical Old Adapter Paper",
+            year=disc.CURRENT_YEAR - 8,
+            citation_count=5000,
+            total_score=92.0,
+            cluster="old-a",
+        ),
+        _shortlist_candidate(
+            "old-2",
+            "Another Old Adapter Paper",
+            year=disc.CURRENT_YEAR - 7,
+            citation_count=4200,
+            total_score=90.0,
+            cluster="old-b",
+        ),
+        _shortlist_candidate(
+            "fresh-1",
+            "Fresh Adapter Benchmark",
+            year=disc.CURRENT_YEAR,
+            citation_count=150,
+            total_score=86.0,
+            cluster="fresh-a",
+        ),
+        _shortlist_candidate(
+            "fresh-2",
+            "Fresh Routing Method",
+            year=disc.CURRENT_YEAR - 1,
+            citation_count=120,
+            total_score=85.0,
+            cluster="fresh-b",
+        ),
+        _shortlist_candidate(
+            "fresh-3",
+            "Fresh Mixture Method",
+            year=disc.CURRENT_YEAR - 1,
+            citation_count=110,
+            total_score=84.0,
+            cluster="fresh-c",
+        ),
+    ]
+
+    shortlist = disc._select_shortlist(local_candidates + external_candidates, "seeded", 8, True)
+    introduced_ids = [item["candidate_id"] for item in shortlist if not item["user_owned"]]
+    old_selected = [candidate_id for candidate_id in introduced_ids if candidate_id.startswith("old")]
+
+    assert introduced_ids[:3] == ["fresh-1", "fresh-2", "fresh-3"]
+    assert old_selected == ["old-1"]
+
+
+def test_seeded_with_little_room_caps_old_external_papers_at_one():
+    local_candidates = [
+        _shortlist_candidate(
+            f"local-{idx}",
+            f"Local Seed {idx}",
+            year=disc.CURRENT_YEAR,
+            citation_count=0,
+            total_score=100.0 - idx,
+            cluster=f"local-{idx}",
+            user_owned=True,
+        )
+        for idx in range(8)
+    ]
+    external_candidates = [
+        _shortlist_candidate(
+            "old-1",
+            "Canonical Old Adapter Paper",
+            year=disc.CURRENT_YEAR - 9,
+            citation_count=7000,
+            total_score=96.0,
+            cluster="old-a",
+        ),
+        _shortlist_candidate(
+            "old-2",
+            "Classic Old Routing Paper",
+            year=disc.CURRENT_YEAR - 8,
+            citation_count=6500,
+            total_score=95.0,
+            cluster="old-b",
+        ),
+        _shortlist_candidate(
+            "old-3",
+            "Historic Old Prompting Paper",
+            year=disc.CURRENT_YEAR - 7,
+            citation_count=6000,
+            total_score=94.0,
+            cluster="old-c",
+        ),
+        _shortlist_candidate(
+            "fresh-1",
+            "Fresh Adapter Benchmark",
+            year=disc.CURRENT_YEAR,
+            citation_count=60,
+            total_score=70.0,
+            cluster="fresh-a",
+        ),
+        _shortlist_candidate(
+            "fresh-2",
+            "Fresh Routing Method",
+            year=disc.CURRENT_YEAR - 1,
+            citation_count=55,
+            total_score=69.0,
+            cluster="fresh-b",
+        ),
+        _shortlist_candidate(
+            "fresh-3",
+            "Fresh Mixture Method",
+            year=disc.CURRENT_YEAR - 1,
+            citation_count=50,
+            total_score=68.0,
+            cluster="fresh-c",
+        ),
+        _shortlist_candidate(
+            "fresh-4",
+            "Fresh Retrieval Method",
+            year=disc.CURRENT_YEAR - 1,
+            citation_count=45,
+            total_score=67.0,
+            cluster="fresh-d",
+        ),
+    ]
+
+    shortlist = disc._select_shortlist(local_candidates + external_candidates, "seeded", 8, True)
+    old_selected = [
+        item["candidate_id"]
+        for item in shortlist
+        if not item["user_owned"] and item["candidate_id"].startswith("old")
+    ]
+
+    assert old_selected == ["old-1"]
+
+
+def test_roomy_seeded_mode_can_still_keep_one_old_anchor():
+    local_candidates = [
+        _shortlist_candidate(
+            f"local-{idx}",
+            f"Local Seed {idx}",
+            year=disc.CURRENT_YEAR,
+            citation_count=0,
+            total_score=100.0 - idx,
+            cluster=f"local-{idx}",
+            user_owned=True,
+        )
+        for idx in range(4)
+    ]
+    external_candidates = [
+        _shortlist_candidate(
+            "old-1",
+            "Canonical Old Adapter Paper",
+            year=disc.CURRENT_YEAR - 8,
+            citation_count=5000,
+            total_score=85.0,
+            cluster="old-a",
+        ),
+        _shortlist_candidate(
+            "old-2",
+            "Classic Old Routing Paper",
+            year=disc.CURRENT_YEAR - 7,
+            citation_count=4500,
+            total_score=82.0,
+            cluster="old-b",
+        ),
+        _shortlist_candidate(
+            "fresh-1",
+            "Fresh Adapter Benchmark",
+            year=disc.CURRENT_YEAR,
+            citation_count=120,
+            total_score=84.0,
+            cluster="fresh-a",
+        ),
+        _shortlist_candidate(
+            "fresh-2",
+            "Fresh Routing Method",
+            year=disc.CURRENT_YEAR - 1,
+            citation_count=110,
+            total_score=83.0,
+            cluster="fresh-b",
+        ),
+        _shortlist_candidate(
+            "fresh-3",
+            "Fresh Mixture Method",
+            year=disc.CURRENT_YEAR - 1,
+            citation_count=95,
+            total_score=80.0,
+            cluster="fresh-c",
+        ),
+    ]
+
+    shortlist = disc._select_shortlist(local_candidates + external_candidates, "seeded", 4, True)
+    introduced_ids = [item["candidate_id"] for item in shortlist if not item["user_owned"]]
+    old_selected = [candidate_id for candidate_id in introduced_ids if candidate_id.startswith("old")]
+
+    assert "old-1" in introduced_ids
+    assert old_selected == ["old-1"]
+    assert "fresh-1" in introduced_ids
 
 
 def test_diversity_penalty_improves_early_cluster_mix():
@@ -674,6 +911,7 @@ def test_fetch_skips_prepared_local_duplicate_and_writes_source_manifest(raw_roo
         "_extract_pdf_text",
         lambda _path: ("Fetched Paper\nAbstract\nAdapter tuning setup.", []),
     )
+    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [])
     prepare_manifest = disc.prepare_inputs(raw_root)
     prepare_json = tmp_path / "prepare.json"
     prepare_json.write_text(json.dumps(prepare_manifest), encoding="utf-8")
@@ -723,6 +961,7 @@ def test_fetch_writes_mixed_source_manifest_from_tmp_and_discovered(raw_root, mo
         "_extract_pdf_text",
         lambda _path: ("Seed Paper\nAbstract\nLocal adapter seed.", []),
     )
+    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [])
     prepare_manifest = disc.prepare_inputs(raw_root)
     prepare_json = tmp_path / "prepare.json"
     prepare_json.write_text(json.dumps(prepare_manifest), encoding="utf-8")
@@ -798,3 +1037,356 @@ def test_download_to_discovered_writes_under_raw_discovered(raw_root, monkeypatc
     assert result["status"] == "downloaded_pdf"
     assert Path(result["canonical_ingest_path"]).parent == raw_root / "discovered"
     assert Path(result["canonical_ingest_path"]).exists()
+
+
+def test_prepare_pdf_recovers_arxiv_id_by_title(raw_root, monkeypatch):
+    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        disc,
+        "_extract_pdf_text",
+        lambda _path: ("Adapter Tuning for LLMs\nAbstract\nImproves multilingual transfer.", []),
+    )
+
+    def _fake_s2_search(query, limit=5):
+        if "adapter tuning" in query.lower():
+            return [
+                {
+                    "title": "Adapter Tuning for LLMs",
+                    "abstract": "Improves multilingual transfer.",
+                    "authors": [{"name": "Author"}],
+                    "year": 2024,
+                    "citationCount": 50,
+                    "venue": "TestConf",
+                    "externalIds": {"ArXiv": "2401.00001"},
+                    "url": "https://arxiv.org/abs/2401.00001",
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(disc, "s2_search", _fake_s2_search)
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{Adapter Tuning for LLMs}\n"
+            "\\begin{abstract}\nImproves multilingual transfer.\n\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(disc, "_download_arxiv_source", _fake_download)
+
+    manifest = disc.prepare_inputs(raw_root)
+    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
+
+    assert entry["arxiv_id"] == "2401.00001"
+    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
+    assert entry["ingest_format"] == "directory"
+    assert (raw_root.parent / entry["canonical_ingest_path"]).exists()
+
+
+def test_prepare_pdf_prefers_arxiv_tex_over_synthetic(raw_root, monkeypatch):
+    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        disc,
+        "_extract_pdf_text",
+        lambda _path: ("Adapter Tuning for LLMs\nAbstract\nSome content.", []),
+    )
+    monkeypatch.setattr(
+        disc,
+        "s2_search",
+        lambda query, limit=5: [
+            {
+                "title": "Adapter Tuning for LLMs",
+                "externalIds": {"ArXiv": "2401.00002"},
+            }
+        ],
+    )
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text("\\title{Adapter Tuning for LLMs}\n", encoding="utf-8")
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(disc, "_download_arxiv_source", _fake_download)
+
+    manifest = disc.prepare_inputs(raw_root)
+    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
+
+    assert entry["original_format"] == "pdf"
+    assert entry["ingest_format"] == "directory"
+    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
+    assert "recovered arXiv ID" in entry["warnings"][0]
+
+
+def test_prepare_pdf_falls_back_to_synthetic_when_tex_unavailable(raw_root, monkeypatch):
+    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        disc,
+        "_extract_pdf_text",
+        lambda _path: ("Adapter Tuning for LLMs\nAbstract\nSome content.", []),
+    )
+    monkeypatch.setattr(
+        disc,
+        "s2_search",
+        lambda query, limit=5: [
+            {
+                "title": "Adapter Tuning for LLMs",
+                "externalIds": {"ArXiv": "2401.00003"},
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        disc,
+        "_download_arxiv_source",
+        lambda _arxiv_id, _dest: {"success": False, "format": "", "error": "no source tarball"},
+    )
+
+    manifest = disc.prepare_inputs(raw_root)
+    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
+
+    assert entry["arxiv_id"] == "2401.00003"
+    assert entry["canonical_ingest_path"].endswith(".tex")
+    assert entry["ingest_format"] == "tex"
+    assert any("TeX source download failed" in w for w in entry["warnings"])
+
+
+def test_prepare_pdf_arxiv_recovery_warns_on_api_failure(raw_root, monkeypatch):
+    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        disc,
+        "_extract_pdf_text",
+        lambda _path: ("Adapter Tuning for LLMs\nAbstract\nSome content.", []),
+    )
+    monkeypatch.setattr(
+        disc,
+        "s2_search",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("network down")),
+    )
+
+    manifest = disc.prepare_inputs(raw_root)
+    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
+
+    assert entry["usable"] is True
+    assert entry["canonical_ingest_path"].endswith(".tex")
+    assert entry["arxiv_id"] == ""
+
+
+def test_prepare_pdf_skips_title_search_when_arxiv_id_in_text(raw_root, monkeypatch):
+    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        disc,
+        "_extract_pdf_text",
+        lambda _path: (
+            "arXiv:2401.00004\nAdapter Tuning for LLMs\nAbstract\nSome content.",
+            [],
+        ),
+    )
+
+    calls = []
+
+    def _spy_s2_search(query, limit=5):
+        calls.append(query)
+        return []
+
+    monkeypatch.setattr(disc, "s2_search", _spy_s2_search)
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{Adapter Tuning for LLMs}\n"
+            "\\begin{abstract}\nSome content.\n\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(disc, "_download_arxiv_source", _fake_download)
+
+    manifest = disc.prepare_inputs(raw_root)
+    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
+
+    assert entry["arxiv_id"] == "2401.00004"
+    assert not calls  # s2_search should not have been called
+
+
+def test_guess_title_skips_conference_header():
+    text = "Published as a conference paper at ICLR 2023\nReal Paper Title Here\nAbstract\nSome content."
+    assert disc._guess_title_from_text(text, "fallback") == "Real Paper Title Here"
+
+
+def test_guess_title_skips_arxiv_line():
+    text = "arXiv:2401.00001 [cs.CL]\nActual Paper Title\nAbstract\nContent."
+    assert disc._guess_title_from_text(text, "fallback") == "Actual Paper Title"
+
+
+def test_extract_arxiv_id_from_pdf_metadata(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "meta.pdf"
+    pdf_path.write_bytes(b"%PDF")
+
+    class FakeDoc:
+        def __init__(self, metadata):
+            self.metadata = metadata
+        def close(self):
+            pass
+
+    class FakeFitz:
+        @staticmethod
+        def open(path):
+            return FakeDoc({"subject": "See arXiv:2106.09685", "keywords": "", "title": ""})
+
+    monkeypatch.setattr(disc, "HAS_PYMUPDF", True)
+    monkeypatch.setattr(disc, "fitz", FakeFitz())
+
+    result = disc._extract_arxiv_id_from_pdf_metadata(pdf_path)
+    assert result == "2106.09685"
+
+
+def test_extract_arxiv_id_from_pdf_metadata_tries_all_fields(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "meta.pdf"
+    pdf_path.write_bytes(b"%PDF")
+
+    class FakeDoc:
+        def __init__(self, metadata):
+            self.metadata = metadata
+        def close(self):
+            pass
+
+    class FakeFitz:
+        @staticmethod
+        def open(path):
+            return FakeDoc({"subject": "", "keywords": "", "title": "Paper on arXiv:2107.00001"})
+
+    monkeypatch.setattr(disc, "HAS_PYMUPDF", True)
+    monkeypatch.setattr(disc, "fitz", FakeFitz())
+
+    result = disc._extract_arxiv_id_from_pdf_metadata(pdf_path)
+    assert result == "2107.00001"
+
+
+def test_extract_arxiv_source_metadata_reads_title_and_abstract(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "main.tex").write_text(
+        "\\title{Adapter Tuning for LLMs}\n"
+        "\\begin{abstract}\nImproves multilingual transfer.\n\\end{abstract}\n",
+        encoding="utf-8",
+    )
+    result = disc._extract_arxiv_source_metadata(source_dir)
+    assert result["source_title"] == "Adapter Tuning for LLMs"
+    assert result["source_abstract"] == "Improves multilingual transfer."
+
+
+def test_extract_arxiv_source_metadata_handles_missing_title_tex(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "main.tex").write_text(
+        "\\section{Body}\nNo title here.\n",
+        encoding="utf-8",
+    )
+    result = disc._extract_arxiv_source_metadata(source_dir)
+    assert result == {"source_title": "", "source_abstract": ""}
+
+
+def test_prepare_pdf_refreshes_metadata_from_accepted_arxiv_source(raw_root, monkeypatch):
+    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        disc,
+        "_extract_pdf_text",
+        lambda _path: (
+            "Adapter Tuning\n"
+            "Abstract\n"
+            "We study efficient multilingual transfer for large language models with low-rank adapters "
+            "and parameter-efficient finetuning.",
+            [],
+        ),
+    )
+    monkeypatch.setattr(
+        disc,
+        "s2_search",
+        lambda query, limit=5: [
+            {
+                "title": "Adapter Tuning for Large Language Models",
+                "externalIds": {"ArXiv": "2401.00005"},
+            }
+        ],
+    )
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{Adapter Tuning for Large Language Models}\n"
+            "\\begin{abstract}\n"
+            "We study efficient multilingual transfer for large language models with low-rank adapters "
+            "and parameter-efficient finetuning.\n"
+            "\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(disc, "_download_arxiv_source", _fake_download)
+
+    manifest = disc.prepare_inputs(raw_root)
+    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
+
+    assert entry["title"] == "Adapter Tuning for Large Language Models"
+    assert entry["candidate_id"] == f"local:{disc.slugify('Adapter Tuning for Large Language Models')}"
+    assert entry["abstract_excerpt"].startswith("We study efficient multilingual transfer")
+    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
+
+
+def test_prepare_pdf_keeps_fetched_source_with_weak_local_abstract(raw_root, monkeypatch):
+    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        disc,
+        "_extract_pdf_text",
+        lambda _path: ("Adapter Tuning\nAbstract\nBrief note.", []),
+    )
+    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [
+        {"title": "Adapter Tuning for Large Language Models", "externalIds": {"ArXiv": "2401.00001"}}
+    ])
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{Adapter Tuning for Large Language Models}\n"
+            "\\begin{abstract}\nWe study efficient multilingual transfer for large language models.\n\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(disc, "_download_arxiv_source", _fake_download)
+
+    manifest = disc.prepare_inputs(raw_root)
+    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
+
+    assert entry["arxiv_id"] == "2401.00001"
+    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
+    assert entry["ingest_format"] == "directory"
+    assert any("using fetched TeX source" in w for w in entry["warnings"])
+
+
+def test_prepare_pdf_keeps_fetched_source_without_source_metadata(raw_root, monkeypatch):
+    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        disc,
+        "_extract_pdf_text",
+        lambda _path: ("Adapter Tuning\nAbstract\nBrief note.", []),
+    )
+    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [
+        {"title": "Adapter Tuning for Large Language Models", "externalIds": {"ArXiv": "2401.00006"}}
+    ])
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text("\\section{Body}\nNo title metadata.\n", encoding="utf-8")
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(disc, "_download_arxiv_source", _fake_download)
+
+    manifest = disc.prepare_inputs(raw_root)
+    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
+
+    assert entry["arxiv_id"] == "2401.00006"
+    assert entry["title"] == "Adapter Tuning"
+    assert entry["abstract_excerpt"] == "Brief note."
+    assert entry["canonical_ingest_path"].endswith("-arxiv-src")

--- a/tests/test_skill_init.py
+++ b/tests/test_skill_init.py
@@ -7,6 +7,8 @@ import pytest
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SKILL_PATH = PROJECT_ROOT / ".claude" / "skills" / "init" / "SKILL.md"
 CLAUDE_MD = PROJECT_ROOT / "CLAUDE.md"
+I18N_EN_CLAUDE_MD = PROJECT_ROOT / "i18n" / "en" / "CLAUDE.md"
+I18N_ZH_CLAUDE_MD = PROJECT_ROOT / "i18n" / "zh" / "CLAUDE.md"
 
 
 @pytest.fixture(scope="module")
@@ -17,6 +19,16 @@ def skill_content():
 @pytest.fixture(scope="module")
 def claude_content():
     return CLAUDE_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def i18n_en_claude_content():
+    return I18N_EN_CLAUDE_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def i18n_zh_claude_content():
+    return I18N_ZH_CLAUDE_MD.read_text(encoding="utf-8")
 
 
 class TestSkillStructure:
@@ -44,6 +56,11 @@ class TestSkillStructure:
 class TestPublicContract:
     def test_supports_no_introduction(self, skill_content):
         assert "--no-introduction" in skill_content
+
+    def test_no_introduction_is_user_controlled(self, skill_content):
+        lowered = skill_content.lower()
+        assert "do not infer `--no-introduction` from repository state alone" in lowered
+        assert "user explicitly asked to disable external discovery" in lowered
 
     def test_mentions_raw_discovered(self, skill_content):
         assert "raw/discovered/" in skill_content
@@ -75,19 +92,26 @@ class TestPublicContract:
 
     def test_mentions_degraded_chinese_notes_warning(self, skill_content):
         lowered = skill_content.lower()
-        assert "curated chinese support is planned" in lowered or "中文精细支持会在后续版本补上" in skill_content
+        assert "lower-confidence" in lowered or "较低置信度" in skill_content
         assert "raw/notes/" in skill_content
 
 
 class TestWorkflow:
+    def test_prefers_repo_python_bin(self, skill_content):
+        assert "PYTHON_BIN" in skill_content
+        assert ".venv/bin/python" in skill_content
+        assert ".venv/Scripts/python.exe" in skill_content
+
     def test_step1_init(self, skill_content):
         assert "### Step 1" in skill_content
         assert "research_wiki.py init" in skill_content
+        assert '"$PYTHON_BIN" tools/research_wiki.py init wiki/' in skill_content
 
     def test_step2_prepare(self, skill_content):
         assert "### Step 2" in skill_content
         assert "init_discovery.py prepare" in skill_content
         assert ".checkpoints/init-prepare.json" in skill_content
+        assert '"$PYTHON_BIN" tools/init_discovery.py prepare' in skill_content
 
     def test_step3_discovery_plan_and_fetch(self, skill_content):
         assert "### Step 3" in skill_content
@@ -96,6 +120,25 @@ class TestWorkflow:
         assert "init_discovery.py fetch" in skill_content
         assert ".checkpoints/init-sources.json" in skill_content
         assert "8-10" in skill_content
+        assert '"$PYTHON_BIN" tools/init_discovery.py plan' in skill_content
+        assert '"$PYTHON_BIN" tools/init_discovery.py fetch' in skill_content
+
+    def test_step3_requires_explicit_final_selection_before_fetch(self, skill_content):
+        assert "read `.checkpoints/init-plan.json`" in skill_content
+        assert "before `fetch`" in skill_content
+        assert "final selection artifact" in skill_content
+        assert "`candidate_id`" in skill_content
+
+    def test_step3_requires_revise_before_fetch_when_count_is_wrong(self, skill_content):
+        lowered = skill_content.lower()
+        assert "stop and revise the final selection before `fetch`" in lowered
+        assert "`--no-introduction`" in skill_content
+        assert "more than 10 parseable papers" in skill_content
+
+    def test_step3_distinguishes_shortlist_from_final_set(self, skill_content):
+        assert "over-picked `shortlist`" in skill_content
+        assert "final **8-10** papers total" in skill_content
+        assert "never forward the whole shortlist implicitly" in skill_content
 
     def test_step4_scaffold_pages(self, skill_content):
         assert "### Step 4" in skill_content
@@ -117,6 +160,10 @@ class TestWorkflow:
         assert "base_branch" in skill_content
         assert "git rev-parse HEAD" in skill_content
         assert "base_commit" in skill_content
+
+    def test_step4_5_checkpoint_ids_are_post_trim(self, skill_content):
+        assert "post-trim" in skill_content
+        assert "not the over-picked shortlist" in skill_content
 
     def test_step5_parallel_ingest(self, skill_content):
         assert "### Step 5" in skill_content
@@ -198,3 +245,17 @@ class TestClaudemdConsistency:
 
     def test_claude_mentions_raw_tmp(self, claude_content):
         assert "raw/tmp/" in claude_content
+
+    def test_claude_declares_user_owned_skill_parameters(self, claude_content):
+        lowered = claude_content.lower()
+        assert "user-facing skill parameters are user-owned" in lowered
+        assert "argument-hint" in claude_content
+
+    def test_i18n_en_claude_declares_user_owned_skill_parameters(self, i18n_en_claude_content):
+        lowered = i18n_en_claude_content.lower()
+        assert "user-facing skill parameters are user-owned" in lowered
+        assert "argument-hint" in i18n_en_claude_content
+
+    def test_i18n_zh_claude_declares_user_owned_skill_parameters(self, i18n_zh_claude_content):
+        assert "用户可见参数归用户所有" in i18n_zh_claude_content
+        assert "argument-hint" in i18n_zh_claude_content

--- a/tests/test_skill_setup.py
+++ b/tests/test_skill_setup.py
@@ -5,7 +5,7 @@ Validates:
 - Required SKILL.md sections are present (language-agnostic)
 - Referenced files exist (config/setup-guide.md, .env.example)
 - setup-guide.md covers all four configurable keys
-- setup.sh no longer contains interactive API key prompts
+- setup scripts keep dependency installation deterministic
 """
 
 from pathlib import Path
@@ -19,6 +19,8 @@ ACTIVE_SKILL = PROJECT_ROOT / ".claude" / "skills" / "setup" / "SKILL.md"
 SETUP_GUIDE = PROJECT_ROOT / "config" / "setup-guide.md"
 ENV_EXAMPLE = PROJECT_ROOT / "config" / ".env.example"
 SETUP_SH = PROJECT_ROOT / "setup.sh"
+SETUP_PS1 = PROJECT_ROOT / "setup.ps1"
+README_MD = PROJECT_ROOT / "README.md"
 
 
 # ── File existence ─────────────────────────────────────────────────────────
@@ -37,6 +39,10 @@ def test_setup_guide_exists():
 
 def test_env_example_exists():
     assert ENV_EXAMPLE.exists(), f"config/.env.example not found at {ENV_EXAMPLE}"
+
+
+def test_setup_ps1_exists():
+    assert SETUP_PS1.exists(), f"setup.ps1 not found at {SETUP_PS1}"
 
 
 # ── SKILL.md required sections ─────────────────────────────────────────────
@@ -189,6 +195,51 @@ def test_setup_sh_references_setup_skill():
     content = SETUP_SH.read_text(encoding="utf-8")
     assert "/setup" in content, \
         "setup.sh 'Next steps' should reference the /setup skill"
+
+
+def test_setup_sh_uses_project_venv_for_installs():
+    content = SETUP_SH.read_text(encoding="utf-8")
+    assert ".venv/bin/python" in content, "setup.sh should resolve the project .venv python"
+    assert "-m pip install -r requirements.txt" in content, "setup.sh should install with the resolved python"
+
+
+def test_setup_ps1_uses_project_venv_for_installs():
+    content = SETUP_PS1.read_text(encoding="utf-8")
+    assert ".venv\\Scripts\\python.exe" in content, "setup.ps1 should resolve the project .venv python"
+    assert "-m pip install -r requirements.txt" in content, "setup.ps1 should install with the resolved python"
+
+
+def test_setup_sh_verifies_runtime_dependencies():
+    content = SETUP_SH.read_text(encoding="utf-8")
+    assert "import fitz" in content, "setup.sh should verify PyMuPDF availability"
+    assert "import requests" in content, "setup.sh should verify requests availability"
+    assert "import feedparser" in content, "setup.sh should verify feedparser availability"
+    assert "deepxiv-sdk" in content, "setup.sh should surface DeepXiv diagnostics"
+
+
+def test_setup_ps1_verifies_runtime_dependencies():
+    content = SETUP_PS1.read_text(encoding="utf-8")
+    assert "import fitz" in content, "setup.ps1 should verify PyMuPDF availability"
+    assert "import requests" in content, "setup.ps1 should verify requests availability"
+    assert "import feedparser" in content, "setup.ps1 should verify feedparser availability"
+    assert "deepxiv-sdk" in content, "setup.ps1 should surface DeepXiv diagnostics"
+
+
+def test_setup_scripts_note_non_persistent_activation():
+    sh_content = SETUP_SH.read_text(encoding="utf-8")
+    ps1_content = SETUP_PS1.read_text(encoding="utf-8")
+    assert "does not activate your current shell permanently" in sh_content
+    assert "/init will use .venv/bin/python automatically" in sh_content
+    assert "does not activate your current shell permanently" in ps1_content
+    assert "/init will use .venv automatically" in ps1_content
+
+
+def test_readme_mentions_setup_venv_behavior():
+    content = README_MD.read_text(encoding="utf-8")
+    assert "setup creates .venv for OmegaWiki" in content
+    assert "/init will use .venv automatically" in content
+    assert "setup 会为 OmegaWiki 创建 .venv" in content
+    assert "/init 会自动使用 .venv" in content
 
 
 # ── Active skill file (after setup.sh --lang sync) ────────────────────────

--- a/tools/init_discovery.py
+++ b/tools/init_discovery.py
@@ -41,14 +41,6 @@ except ImportError:
     fitz = None
     HAS_PYMUPDF = False
 
-try:
-    from anthropic import Anthropic
-
-    HAS_ANTHROPIC = True
-except ImportError:
-    Anthropic = None
-    HAS_ANTHROPIC = False
-
 STOP_WORDS = {
     "a", "an", "and", "are", "as", "at", "be", "by", "for", "from",
     "has", "have", "in", "into", "is", "it", "of", "on", "or", "that",
@@ -82,6 +74,8 @@ PREPARE_TEXT_SUFFIXES = {".md", ".txt", ".html", ".htm", ".tex"}
 SHORTLIST_TARGET = 12
 FINAL_TARGET_RANGE = [8, 10]
 CURRENT_YEAR = datetime.now(timezone.utc).year
+OLDER_PAPER_YEARS = 4
+ROOMY_INTRODUCED_CAPACITY = 6
 RANKING_WEIGHTS = {
     "relevance": 30,
     "freshness": 20,
@@ -91,7 +85,6 @@ RANKING_WEIGHTS = {
 }
 EXCLUSION_PENALTY = 12
 MAX_SOURCE_ARCHIVE_BYTES = 250_000_000
-TRANSLATION_MODEL = os.environ.get("OMEGAWIKI_TRANSLATION_MODEL", "claude-3-5-haiku-latest")
 
 
 def _paper_entry_match_key(entry: dict[str, Any]) -> tuple[str, str]:
@@ -99,19 +92,17 @@ def _paper_entry_match_key(entry: dict[str, Any]) -> tuple[str, str]:
 
 
 def _paper_entry_preference(entry: dict[str, Any]) -> tuple[int, int, int]:
-    canonical_path = str(entry.get("canonical_ingest_path") or "")
     original_format = str(entry.get("original_format") or "")
     ingest_format = str(entry.get("ingest_format") or "")
-    translated = bool(entry.get("translated_to_english"))
     abstract_len = len(str(entry.get("abstract_excerpt") or ""))
     has_arxiv = 1 if entry.get("arxiv_id") else 0
 
-    if translated and canonical_path.endswith(".tex"):
-        rank = 5
-    elif original_format == "tex" and ingest_format == "tex":
+    if original_format == "tex" and ingest_format == "tex":
         rank = 4
     elif original_format in {"archive", "directory"} and ingest_format in {"tex", "directory"}:
         rank = 3
+    elif original_format == "pdf" and ingest_format == "directory":
+        rank = 3  # fetched arXiv source for a PDF — equivalent to archive
     elif original_format == "pdf" and ingest_format == "tex":
         rank = 2
     elif ingest_format == "pdf":
@@ -174,6 +165,135 @@ def _extract_arxiv_id(text: str) -> str:
     return match.group(0) if match else ""
 
 
+def _recover_arxiv_id_by_title(title: str) -> str:
+    """Try to recover an arXiv ID by searching Semantic Scholar with the paper title.
+
+    Returns the bare arXiv ID (e.g. '2106.09685') or an empty string on failure.
+    """
+    if not title or len(title) < 8:
+        return ""
+    try:
+        results = s2_search(title, limit=5)
+    except Exception:
+        return ""
+    normalized_title = _normalize_text(title)
+    title_tokens = set(_tokenize(normalized_title))
+    for result in results:
+        result_title = _normalize_text(str(result.get("title") or ""))
+        if not result_title:
+            continue
+        arxiv_id = (result.get("externalIds") or {}).get("ArXiv", "")
+        if not arxiv_id:
+            continue
+        # Exact normalized match
+        if result_title == normalized_title:
+            return str(arxiv_id)
+        # High token-overlap match (at least 80% of tokens in common)
+        result_tokens = set(_tokenize(result_title))
+        if result_tokens and title_tokens:
+            overlap = len(result_tokens & title_tokens)
+            min_len = min(len(result_tokens), len(title_tokens))
+            if min_len > 0 and overlap / min_len >= 0.8:
+                return str(arxiv_id)
+    return ""
+
+
+def _download_arxiv_source(arxiv_id: str, dest_dir: Path) -> dict[str, Any]:
+    """Download arXiv TeX source tarball and extract to dest_dir.
+
+    Returns a dict with keys:
+        success (bool), format (str), error (str | None).
+    """
+    headers = {"User-Agent": "OmegaWiki-init-discovery/1.0"}
+    try:
+        src_resp = requests.get(f"https://arxiv.org/e-print/{arxiv_id}", timeout=30, headers=headers)
+        if src_resp.ok and src_resp.content:
+            with NamedTemporaryFile(suffix=".tar", delete=False) as tmp:
+                tmp.write(src_resp.content)
+                tmp_path = Path(tmp.name)
+            try:
+                dest_dir.mkdir(parents=True, exist_ok=True)
+                _safe_extract_tar(tmp_path, dest_dir)
+                if not any(path.is_file() for path in dest_dir.rglob("*")):
+                    raise ValueError("source archive extracted no files")
+                return {"success": True, "format": "directory", "error": None}
+            except (tarfile.TarError, OSError, ValueError) as exc:
+                shutil.rmtree(dest_dir, ignore_errors=True)
+                return {"success": False, "format": "", "error": str(exc)}
+            finally:
+                tmp_path.unlink(missing_ok=True)
+    except requests.RequestException as exc:
+        return {"success": False, "format": "", "error": str(exc)}
+    return {"success": False, "format": "", "error": "empty response"}
+
+
+def _extract_arxiv_id_from_pdf_metadata(path: Path) -> str:
+    """Try to extract an arXiv ID from the PDF document info dict (metadata)."""
+    if not HAS_PYMUPDF:
+        return ""
+    try:
+        doc = fitz.open(path)
+        meta = doc.metadata or {}
+        doc.close()
+        for key in ("subject", "keywords", "title"):
+            text = str(meta.get(key) or "")
+            arxiv_id = _extract_arxiv_id(text)
+            if arxiv_id:
+                return arxiv_id
+    except Exception:
+        pass
+    return ""
+
+
+def _extract_arxiv_source_metadata(source_dir: Path) -> dict[str, str]:
+    """Extract title/abstract metadata from a fetched arXiv source dir."""
+    tex_files = sorted(source_dir.rglob("*.tex"))
+    if not tex_files:
+        return {"source_title": "", "source_abstract": ""}
+
+    # Find the .tex file that contains a title command — this is usually the main/master file.
+    # Conference templates use \icmltitle{}, \cvprtitle{}, \neuripstitle{}, etc.
+    source_text = ""
+    for tf in tex_files:
+        text = _read_text(tf, limit=15000)
+        if text and re.search(r"\\[a-z]*title[a-z]*\{", text, re.IGNORECASE):
+            source_text = text
+            break
+    if not source_text:
+        return {"source_title": "", "source_abstract": ""}
+
+    # Extract title from source (handle \title{}, \icmltitle{}, \icmltitlerunning{}, etc.)
+    source_title = ""
+    title_match = re.search(r"\\[a-z]*title[a-z]*\{", source_text, re.IGNORECASE)
+    if title_match:
+        start = title_match.end()
+        depth = 1
+        chars = []
+        idx = start
+        while idx < len(source_text) and depth > 0:
+            ch = source_text[idx]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+            if depth > 0:
+                chars.append(ch)
+            idx += 1
+        raw_title = "".join(chars)
+        source_title = re.sub(r"\s+", " ", raw_title).strip()
+
+    # Extract abstract from source
+    source_abstract = ""
+    m = re.search(r"\\begin\{abstract\}(.+?)\\end\{abstract\}", source_text, re.DOTALL | re.IGNORECASE)
+    if m:
+        source_abstract = re.sub(r"\s+", " ", m.group(1)).strip()
+
+    return {
+        "source_title": source_title,
+        "source_abstract": source_abstract,
+    }
+
+
 def _guess_title_from_tex(text: str, fallback: str) -> str:
     match = re.search(r"\\title\{(.+?)\}", text, re.DOTALL)
     if match:
@@ -183,13 +303,44 @@ def _guess_title_from_tex(text: str, fallback: str) -> str:
     return fallback
 
 
+# Common PDF header/footer lines that should not be mistaken for paper titles.
+_NON_TITLE_PATTERNS = (
+    "published as a",
+    "proceedings of",
+    "conference",
+    "arxiv preprint",
+    "arxiv:",
+    "copyright",
+    "all rights reserved",
+    "https://",
+    "http://",
+    "doi:",
+    "ieee",
+    "acm",
+    "springer",
+    "elsevier",
+)
+
+
+def _is_likely_title(line: str) -> bool:
+    lower = line.lower()
+    if lower in {"abstract", "introduction", "contents", "references"}:
+        return False
+    for pat in _NON_TITLE_PATTERNS:
+        if pat in lower:
+            return False
+    # Skip lines that look like venue + year (e.g. "ICLR 2023")
+    if re.search(r"\b20\d{2}\b", line) and len(line) < 50:
+        return False
+    return True
+
+
 def _guess_title_from_text(text: str, fallback: str) -> str:
     for raw_line in text.splitlines():
         line = raw_line.strip().strip("#").strip()
         if len(line) < 8:
             continue
-        lower = line.lower()
-        if lower in {"abstract", "introduction", "contents"}:
+        if not _is_likely_title(line):
             continue
         return re.sub(r"\s+", " ", line)[:200]
     return fallback
@@ -347,47 +498,6 @@ def _extract_pdf_text(path: Path) -> tuple[str, list[str]]:
         return "", warnings
 
 
-def _translate_to_english(text: str, source_label: str = "") -> tuple[str, list[str]]:
-    if not text.strip():
-        return text, []
-    if _detect_language(text) != "zh":
-        return text, []
-    warnings: list[str] = []
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
-    if not HAS_ANTHROPIC or not api_key:
-        warnings.append(f"translation unavailable for {source_label or 'content'}; keeping original text")
-        return text, warnings
-    try:
-        client = Anthropic(api_key=api_key)
-        message = client.messages.create(
-            model=TRANSLATION_MODEL,
-            max_tokens=4096,
-            temperature=0,
-            system=(
-                "Translate Chinese research content into concise, faithful English. "
-                "Preserve technical terminology and structure. Return only the translated text."
-            ),
-            messages=[
-                {
-                    "role": "user",
-                    "content": text[:120000],
-                }
-            ],
-        )
-        chunks = []
-        for block in message.content:
-            if getattr(block, "type", "") == "text":
-                chunks.append(block.text)
-        translated = "\n".join(chunks).strip()
-        if not translated:
-            warnings.append(f"translation returned empty output for {source_label or 'content'}")
-            return text, warnings
-        return translated, warnings
-    except Exception as exc:
-        warnings.append(f"translation failed for {source_label or 'content'}: {exc}")
-        return text, warnings
-
-
 def _build_synthetic_tex(title: str, text: str) -> str:
     abstract = _extract_abstract_excerpt(text, limit=1500)
     body = re.sub(r"\s+\n", "\n", text).strip()
@@ -423,34 +533,18 @@ def _prepare_text_entry(path: Path, raw_root: Path, kind: str) -> dict[str, Any]
     if not text.strip():
         return None
     source_rel = _relative_to_project(path, raw_root)
-    language = _detect_language(text)
-    translated_text = text
-    warnings: list[str] = []
-    prepared_path = ""
-    translated = False
-    if language == "zh":
-        translated_text, translate_warnings = _translate_to_english(text, source_rel)
-        warnings.extend(translate_warnings)
-        translated = translated_text != text
-        if translated:
-            tmp_path = raw_root / "tmp" / kind / f"{_path_slug(path.relative_to(raw_root))}.md"
-            _write_text(tmp_path, translated_text)
-            prepared_path = _relative_to_project(tmp_path, raw_root)
-    title = _guess_title_from_text(translated_text, path.stem)
-    canonical_rel = prepared_path or source_rel
+    title = _guess_title_from_text(text, path.stem)
     return {
         "entry_id": f"{kind}:{_path_slug(path.relative_to(raw_root))}",
         "source_kind": kind,
         "source_path": source_rel,
-        "prepared_path": prepared_path or None,
-        "canonical_ingest_path": canonical_rel,
-        "canonical_read_path": canonical_rel,
+        "prepared_path": None,
+        "canonical_ingest_path": source_rel,
+        "canonical_read_path": source_rel,
         "original_format": path.suffix.lower().lstrip(".") or "text",
-        "original_language": language,
-        "translated_to_english": translated,
         "title": title,
-        "abstract_excerpt": _extract_abstract_excerpt(translated_text, limit=400),
-        "warnings": warnings,
+        "abstract_excerpt": _extract_abstract_excerpt(text, limit=400),
+        "warnings": [],
         "usable": True,
     }
 
@@ -463,10 +557,8 @@ def _prepare_paper_entry(path: Path, raw_root: Path) -> dict[str, Any]:
     prepared_path = ""
     canonical_path = ""
     resolved_source_path = source_rel
-    translated = False
     title = _guess_local_title(path) if path.is_file() else (path.stem.replace("_", " ").replace("-", " ").strip() or "Untitled")
     abstract_excerpt = ""
-    language = "unknown"
     arxiv_id = ""
     usable = True
 
@@ -499,8 +591,6 @@ def _prepare_paper_entry(path: Path, raw_root: Path) -> dict[str, Any]:
             "canonical_ingest_path": source_rel,
             "original_format": original_format,
             "ingest_format": _ingest_format_from_path(source_rel),
-            "original_language": "unknown",
-            "translated_to_english": False,
             "title": title,
             "abstract_excerpt": "",
             "arxiv_id": "",
@@ -514,18 +604,44 @@ def _prepare_paper_entry(path: Path, raw_root: Path) -> dict[str, Any]:
         text, pdf_warnings = _extract_pdf_text(candidate_path)
         warnings.extend(pdf_warnings)
         if text:
-            language = _detect_language(text)
-            if language == "zh":
-                translated_text, translate_warnings = _translate_to_english(text, source_rel)
-                warnings.extend(translate_warnings)
-                translated = translated_text != text
-                text = translated_text
             title = _guess_title_from_text(text, _guess_local_title(candidate_path))
             abstract_excerpt = _extract_abstract_excerpt(text)
-            out_path = raw_root / "tmp" / "papers" / f"{_path_slug(path.relative_to(raw_root))}.tex"
-            _write_text(out_path, _build_synthetic_tex(title, text))
-            prepared_path = _relative_to_project(out_path, raw_root)
-            canonical_path = prepared_path
+            # Look up arXiv ID in order: filename -> metadata -> page-0 text -> S2 title search
+            arxiv_id = _extract_arxiv_id(path.name)
+            if not arxiv_id:
+                arxiv_id = _extract_arxiv_id_from_pdf_metadata(candidate_path)
+            if not arxiv_id:
+                arxiv_id = _extract_arxiv_id(text[:1000])
+            if not arxiv_id:
+                arxiv_id = _recover_arxiv_id_by_title(title)
+            if arxiv_id:
+                source_dir = raw_root / "tmp" / "papers" / f"{_path_slug(path.relative_to(raw_root))}-arxiv-src"
+                dl_result = _download_arxiv_source(arxiv_id, source_dir)
+                if dl_result["success"]:
+                    source_meta = _extract_arxiv_source_metadata(source_dir)
+                    if source_meta["source_title"]:
+                        title = source_meta["source_title"]
+                    if source_meta["source_abstract"]:
+                        abstract_excerpt = source_meta["source_abstract"][:1200]
+                    prepared_path = _relative_to_project(source_dir, raw_root)
+                    canonical_path = prepared_path
+                    warnings.append(
+                        f"recovered arXiv ID {arxiv_id}; using fetched TeX source"
+                    )
+                else:
+                    out_path = raw_root / "tmp" / "papers" / f"{_path_slug(path.relative_to(raw_root))}.tex"
+                    _write_text(out_path, _build_synthetic_tex(title, text))
+                    prepared_path = _relative_to_project(out_path, raw_root)
+                    canonical_path = prepared_path
+                    warnings.append(
+                        f"recovered arXiv ID {arxiv_id} but TeX source download failed; "
+                        f"falling back to synthetic tex ({dl_result.get('error', 'unknown error')})"
+                    )
+            else:
+                out_path = raw_root / "tmp" / "papers" / f"{_path_slug(path.relative_to(raw_root))}.tex"
+                _write_text(out_path, _build_synthetic_tex(title, text))
+                prepared_path = _relative_to_project(out_path, raw_root)
+                canonical_path = prepared_path
         else:
             title = _guess_local_title(candidate_path)
             canonical_path = resolved_source_path
@@ -534,21 +650,7 @@ def _prepare_paper_entry(path: Path, raw_root: Path) -> dict[str, Any]:
         title = _guess_local_title(candidate_path)
         arxiv_id = _extract_arxiv_id(f"{candidate_path.name} {title} {text[:2000]}")
         abstract_excerpt = _extract_abstract_excerpt(text)
-        language = _detect_language(text)
-        if language == "zh":
-            translated_text, translate_warnings = _translate_to_english(text, source_rel)
-            warnings.extend(translate_warnings)
-            translated = translated_text != text
-            if translated:
-                out_path = raw_root / "tmp" / "papers" / f"{_path_slug(path.relative_to(raw_root))}.tex"
-                title = _guess_title_from_text(translated_text, title)
-                _write_text(out_path, _build_synthetic_tex(title, translated_text))
-                prepared_path = _relative_to_project(out_path, raw_root)
-                canonical_path = prepared_path
-            else:
-                canonical_path = resolved_source_path
-        else:
-            canonical_path = resolved_source_path
+        canonical_path = resolved_source_path
 
     if not arxiv_id:
         arxiv_id = _extract_arxiv_id(f"{path.name} {title} {abstract_excerpt}")
@@ -563,8 +665,6 @@ def _prepare_paper_entry(path: Path, raw_root: Path) -> dict[str, Any]:
         "canonical_ingest_path": canonical_path,
         "original_format": original_format or candidate_path.suffix.lower().lstrip(".") or "file",
         "ingest_format": _ingest_format_from_path(canonical_path),
-        "original_language": language,
-        "translated_to_english": translated,
         "title": title,
         "abstract_excerpt": abstract_excerpt,
         "arxiv_id": arxiv_id,
@@ -576,8 +676,7 @@ def _prepare_paper_entry(path: Path, raw_root: Path) -> dict[str, Any]:
 def prepare_inputs(raw_root: Path) -> dict[str, Any]:
     raw_root = raw_root.resolve()
     tmp_root = raw_root / "tmp"
-    for sub in ("papers", "notes", "web"):
-        (tmp_root / sub).mkdir(parents=True, exist_ok=True)
+    (tmp_root / "papers").mkdir(parents=True, exist_ok=True)
     paper_entries: list[dict[str, Any]] = []
     other_entries: list[dict[str, Any]] = []
 
@@ -723,65 +822,52 @@ def scan_local_papers(raw_root: Path, prepared_manifest: dict[str, Any] | None =
     return results
 
 
-def scan_notes_web(raw_root: Path, prepared_manifest: dict[str, Any] | None = None) -> dict[str, Any]:
-    files: list[dict[str, Any]] = []
-    combined_text = ""
-    chinese_note_count = 0
-    chinese_web_count = 0
-    untranslated_chinese_count = 0
+def _iter_notes_web_sources(raw_root: Path, prepared_manifest: dict[str, Any] | None = None) -> list[dict[str, str]]:
+    sources: list[dict[str, str]] = []
     if prepared_manifest:
         for entry in prepared_manifest.get("entries", []):
             if entry.get("source_kind") not in {"notes", "web"} or not entry.get("usable", True):
                 continue
-            canonical_rel = entry.get("prepared_path") or entry["source_path"]
-            text = _read_text(_resolve_project_path(raw_root, canonical_rel), limit=120000)
-            if not text.strip():
+            source_path = str(entry.get("source_path") or "")
+            if not source_path:
                 continue
-            original_language = str(entry.get("original_language") or "")
-            translated = bool(entry.get("translated_to_english"))
-            if original_language == "zh":
-                if entry["source_kind"] == "notes":
-                    chinese_note_count += 1
-                else:
-                    chinese_web_count += 1
-                if not translated:
-                    untranslated_chinese_count += 1
-            files.append({
-                "path": entry["source_path"],
-                "canonical_path": canonical_rel,
-                "kind": entry["source_kind"],
-                "keywords": _top_terms(text, limit=8),
-                "translated_to_english": translated,
-                "original_language": original_language or _detect_language(text),
+            sources.append({
+                "path": source_path,
+                "canonical_path": source_path,
+                "kind": str(entry["source_kind"]),
             })
-            combined_text += "\n" + text
-    else:
-        for sub in ("notes", "web"):
-            base = raw_root / sub
-            if not base.exists():
+        return sources
+
+    for sub in ("notes", "web"):
+        base = raw_root / sub
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*")):
+            if path.is_dir() or path.name == ".gitkeep" or path.suffix.lower() not in TEXT_SUFFIXES:
                 continue
-            for path in sorted(base.rglob("*")):
-                if path.is_dir() or path.name == ".gitkeep" or path.suffix.lower() not in TEXT_SUFFIXES:
-                    continue
-                text = _read_text(path)
-                if not text.strip():
-                    continue
-                language = _detect_language(text)
-                if language == "zh":
-                    if sub == "notes":
-                        chinese_note_count += 1
-                    else:
-                        chinese_web_count += 1
-                    untranslated_chinese_count += 1
-                files.append({
-                    "path": str(path.relative_to(raw_root.parent)),
-                    "canonical_path": str(path.relative_to(raw_root.parent)),
-                    "kind": sub,
-                    "keywords": _top_terms(text, limit=8),
-                    "translated_to_english": False,
-                    "original_language": language,
-                })
-                combined_text += "\n" + text
+            rel_path = str(path.relative_to(raw_root.parent))
+            sources.append({
+                "path": rel_path,
+                "canonical_path": rel_path,
+                "kind": sub,
+            })
+    return sources
+
+
+def scan_notes_web(raw_root: Path, prepared_manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    files: list[dict[str, Any]] = []
+    combined_text = ""
+    for item in _iter_notes_web_sources(raw_root, prepared_manifest):
+        text = _read_text(_resolve_project_path(raw_root, item["canonical_path"]), limit=120000)
+        if not text.strip():
+            continue
+        files.append({
+            "path": item["path"],
+            "canonical_path": item["canonical_path"],
+            "kind": item["kind"],
+            "keywords": _top_terms(text, limit=8),
+        })
+        combined_text += "\n" + text
 
     sentences = _split_sentences(combined_text)
     exclusions = [s for s in sentences if any(p in s.lower() for p in EXCLUSION_PATTERNS)]
@@ -794,10 +880,15 @@ def scan_notes_web(raw_root: Path, prepared_manifest: dict[str, Any] | None = No
         "exclusions": exclusions[:8],
         "assertions": assertions,
         "ideas": ideas,
-        "chinese_note_count": chinese_note_count,
-        "chinese_web_count": chinese_web_count,
-        "untranslated_chinese_count": untranslated_chinese_count,
     }
+
+
+def _notes_web_contains_chinese(raw_root: Path, prepared_manifest: dict[str, Any] | None = None) -> bool:
+    for item in _iter_notes_web_sources(raw_root, prepared_manifest):
+        text = _read_text(_resolve_project_path(raw_root, item["canonical_path"]), limit=120000)
+        if text.strip() and _detect_language(text) == "zh":
+            return True
+    return False
 
 
 def _title_key(title: str) -> str:
@@ -922,6 +1013,24 @@ def _freshness_score(year: int | None) -> float:
     if age <= 8:
         return 0.4
     return 0.15
+
+
+def _is_older_paper(candidate: dict[str, Any]) -> bool:
+    year = candidate.get("year")
+    if not year:
+        return False
+    try:
+        return CURRENT_YEAR - int(year) >= OLDER_PAPER_YEARS
+    except (TypeError, ValueError):
+        return False
+
+
+def _is_older_external_non_survey(candidate: dict[str, Any]) -> bool:
+    return (
+        not candidate.get("user_owned")
+        and not candidate.get("is_survey")
+        and _is_older_paper(candidate)
+    )
 
 
 def _survey_score(title: str, abstract: str) -> float:
@@ -1065,6 +1174,9 @@ def _select_shortlist(
     shortlist = list(protected)
     target = SHORTLIST_TARGET if mode == "bootstrap" else max(10, min(SHORTLIST_TARGET, local_count + 4))
     target = max(target, len(shortlist))
+    introduced_capacity = max(FINAL_TARGET_RANGE[1] - local_count, 0)
+    allow_old_anchor_promotion = mode == "bootstrap" or introduced_capacity >= ROOMY_INTRODUCED_CAPACITY
+    scarce_seeded_mode = mode != "bootstrap" and introduced_capacity < ROOMY_INTRODUCED_CAPACITY
 
     survey_pool = [c for c in candidates if c.get("is_survey") and c["candidate_id"] not in protected_ids]
     if survey_pool and len(shortlist) < target:
@@ -1075,11 +1187,9 @@ def _select_shortlist(
     older_candidates = [
         c
         for c in candidates
-        if c["candidate_id"] not in protected_ids
-        and c.get("year")
-        and CURRENT_YEAR - int(c["year"]) >= 4
+        if c["candidate_id"] not in protected_ids and _is_older_external_non_survey(c)
     ]
-    if older_candidates and len(shortlist) < target:
+    if allow_old_anchor_promotion and older_candidates and len(shortlist) < target:
         older = max(older_candidates, key=lambda c: (c["citation_count"], c["total_score"]))
         shortlist.append(older)
         protected_ids.add(older["candidate_id"])
@@ -1088,6 +1198,7 @@ def _select_shortlist(
     cluster_counts: defaultdict[str, int] = defaultdict(int)
     for item in shortlist:
         cluster_counts[item["cluster"]] += 1
+    older_external_selected = sum(1 for item in shortlist if _is_older_external_non_survey(item))
 
     for candidate in candidates:
         if candidate["candidate_id"] in protected_ids:
@@ -1095,7 +1206,7 @@ def _select_shortlist(
         if len(shortlist) >= target:
             break
         old_penalty = 0.0
-        if candidate.get("year") and CURRENT_YEAR - int(candidate["year"]) >= 4 and anchor_added:
+        if _is_older_external_non_survey(candidate) and (anchor_added or scarce_seeded_mode):
             old_penalty = 12.0
         diversity_penalty = 12.0 * cluster_counts[candidate["cluster"]]
         penalized_score = candidate["total_score"] - diversity_penalty - old_penalty
@@ -1110,11 +1221,13 @@ def _select_shortlist(
     for candidate in remaining:
         if len(shortlist) >= target:
             break
-        if anchor_added and candidate.get("year") and CURRENT_YEAR - int(candidate["year"]) >= 4:
+        if _is_older_external_non_survey(candidate) and older_external_selected >= 1:
             continue
         shortlist.append(candidate)
         protected_ids.add(candidate["candidate_id"])
         cluster_counts[candidate["cluster"]] += 1
+        if _is_older_external_non_survey(candidate):
+            older_external_selected += 1
 
     return shortlist
 
@@ -1300,13 +1413,14 @@ def build_plan(
             "semantic_scholar",
             "SEMANTIC_SCHOLAR_API_KEY is unset; Semantic Scholar discovery will run with the slower public rate limit.",
         )
-    if notes_web.get("chinese_note_count", 0) > 0:
+    if _notes_web_contains_chinese(raw_root, prepared_manifest=prepared_manifest):
         _record_issue(
             warnings,
             "notes_web_chinese",
             (
-                "Chinese note content detected. Curated Chinese support is planned for a later release; "
-                "current note/web extraction and ranking may perform worse, so treat rankings and provisional pages as lower-confidence."
+                "Chinese note or web content detected. Current note/web extraction and ranking may be "
+                "less reliable for Chinese-heavy inputs, so treat rankings and provisional pages as "
+                "lower-confidence."
             ),
         )
 
@@ -1382,32 +1496,19 @@ def _download_source(candidate: dict[str, Any], raw_root: Path) -> dict[str, Any
     if not arxiv_id:
         return {"candidate_id": candidate["candidate_id"], "status": "skipped_no_arxiv", "path": ""}
 
-    headers = {"User-Agent": "OmegaWiki-init-discovery/1.0"}
-    try:
-        src_resp = requests.get(f"https://arxiv.org/e-print/{arxiv_id}", timeout=30, headers=headers)
-        if src_resp.ok and src_resp.content:
-            with NamedTemporaryFile(suffix=".tar", delete=False) as tmp:
-                tmp.write(src_resp.content)
-                tmp_path = Path(tmp.name)
-            try:
-                dest_dir.mkdir(parents=True, exist_ok=True)
-                _safe_extract_tar(tmp_path, dest_dir)
-                if not any(path.is_file() for path in dest_dir.rglob("*")):
-                    raise ValueError("source archive extracted no files")
-                return {
-                    "candidate_id": candidate["candidate_id"],
-                    "status": "downloaded_source",
-                    "path": str(dest_dir),
-                    "canonical_ingest_path": str(dest_dir),
-                    "ingest_format": "directory",
-                }
-            except (tarfile.TarError, OSError, ValueError):
-                shutil.rmtree(dest_dir, ignore_errors=True)
-            finally:
-                tmp_path.unlink(missing_ok=True)
-    except requests.RequestException:
-        pass
+    # Try TeX source first
+    source_result = _download_arxiv_source(arxiv_id, dest_dir)
+    if source_result["success"]:
+        return {
+            "candidate_id": candidate["candidate_id"],
+            "status": "downloaded_source",
+            "path": str(dest_dir),
+            "canonical_ingest_path": str(dest_dir),
+            "ingest_format": "directory",
+        }
 
+    # Fall back to PDF
+    headers = {"User-Agent": "OmegaWiki-init-discovery/1.0"}
     try:
         pdf_resp = requests.get(f"https://arxiv.org/pdf/{arxiv_id}", timeout=30, headers=headers)
         pdf_resp.raise_for_status()


### PR DESCRIPTION
## Summary

- Strengthens `tools/init_discovery.py` arxiv-id detection by falling back to a Semantic Scholar (S2) search when the filename doesn't embed a recognizable arxiv id.
- Significant rewrite of `tools/init_discovery.py` (+302 / −201) with a greatly expanded test suite in `tests/test_init_discovery.py` (+648 / −56).
- Updates `/init` skill docs (en + zh + root copy) to describe the new discovery behavior.

## Other changes bundled in this PR (flagging for reviewer attention)

The branch name and commit message describe a focused arxiv-id fix, but the commit also includes:

- `CLAUDE.md` (+ i18n copies): new constraint — "user-facing skill parameters are user-owned" (agents must not invent/flip/drop CLI-facing params from repo state alone).
- `requirements.txt`: removes `anthropic>=0.20.0`.
- `setup.sh` / `setup.ps1`: substantial refactor (~80 / ~74 lines changed each).
- `tests/test_skill_setup.py` (+52) and `tests/test_skill_init.py` (+62): associated test additions.
- `.claude/skills/ingest/SKILL.md` (+ i18n): removes references to "translated `.tex`" from ingest docs.
- `docs/runtime-directory-structure.{en,zh}.md`: one-line edits each.

Reviewer may want to confirm whether these should be split into separate PRs, or whether they are intentional companions to the arxiv-id fix.

## Test plan

- [ ] `pytest tests/test_init_discovery.py` passes
- [ ] `pytest tests/test_skill_init.py` passes
- [ ] `pytest tests/test_skill_setup.py` passes
- [ ] Manually verify `/init` picks up an arxiv id via S2 search when filename contains none
- [ ] Confirm removing `anthropic` from `requirements.txt` does not break any remaining import
- [ ] Run `setup.sh` end-to-end on a fresh checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)