### PR TITLE
Refactored init skill and introduced agent-first pdf handling to both…

### DIFF
--- a/.claude/skills/ingest/SKILL.md
+++ b/.claude/skills/ingest/SKILL.md
@@ -63,7 +63,7 @@ Set `WIKI_ROOT=wiki/`.
 1. Detect source type:
    - **arXiv URL**: fetch tex source (ar5iv HTML or direct .tex download); fall back to PDF if unavailable
    - **local .tex**: read directly
-   - **local .pdf**: extract text (PyMuPDF or vision API fallback)
+   - **local .pdf**: inspect the PDF to recover a confident title when possible, and if the agent already recovered a confident arXiv ID keep that too; then run `python3 tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"] [--arxiv-id "<recovered-arxiv-id>"]`; the helper uses handed-off or filename/path arXiv IDs first, then agent-title Semantic Scholar recovery, and otherwise falls back directly to synthetic `.tex`. When a title was supplied by the agent, keep it authoritative; fetched/source titles are sanitized fallback metadata only.
    - **INIT MODE canonical handoff path**: if `/init` passes a path from `.checkpoints/init-sources.json`, ingest that exact `canonical_ingest_path` rather than rescanning sibling raw folders
 2. Extract metadata: title, abstract, author list (with affiliations), publication date, venue
 3. Extract reference list (BibTeX entries or reference section)
@@ -383,7 +383,7 @@ Wiki: +1 paper, +{N} claims, +{M} concepts, +{K} edges | Maturity: {level} ({cov
 
 ## Constraints
 
-- **raw/ is read-only**: do not modify files under `raw/`
+- **raw/ is read-only except canonical source prep**: treat `raw/papers/`, `raw/notes/`, and `raw/web/` as user-owned inputs. Direct local `/ingest` may write generated prepared local sidecars only under `raw/tmp/`, and direct arXiv ingests may write fetched source artifacts only under `raw/discovered/`. INIT MODE `/ingest` remains read-only and must consume the handed-off canonical path directly.
 - **INIT MODE source handoff is authoritative**: when `/init` passes a `canonical_ingest_path` from `.checkpoints/init-sources.json`, ingest that exact path rather than rescanning `raw/papers/`, `raw/tmp/`, or `raw/discovered/`
 - **graph/ via tools only**: do not manually edit files in `graph/` — use `python3 tools/research_wiki.py` only
 - **Bidirectional links**: always write the reverse link when writing a forward link (see CLAUDE.md Cross-Reference Rules table)
@@ -399,7 +399,7 @@ Wiki: +1 paper, +{N} claims, +{M} concepts, +{K} edges | Maturity: {level} ({cov
 
 ## Error Handling
 
-- **Source parse failure**: tex fails → PDF parse → vision API → report to user for manual handling. In INIT MODE, synthetic `.tex` under `raw/tmp/` and fetched source dirs / PDFs under `raw/discovered/` are valid inputs and should be consumed as handed off.
+- **Source parse failure**: tex fails → PDF parse → vision API → report to user for manual handling. For direct local PDFs, if no confident title is recovered, call `tools/prepare_paper_source.py` without `--title`; that means filename/path arXiv-ID recovery only, then immediate synthetic-`.tex` fallback. Metadata or filename titles are display-only and must not drive title-based lookup. In INIT MODE, synthetic `.tex` under `raw/tmp/` and fetched source dirs / PDFs under `raw/discovered/` are valid inputs and should be consumed as handed off.
 - **S2 API unavailable**: skip S2 steps (citations backfill, default importance to 3); note in report
 - **DeepXiv API unavailable**: skip DeepXiv enrichment (TLDR, structure verification, social metrics); fall back to S2 + source file parsing
 - **Slug conflict**: if generated slug already exists but content differs, append numeric suffix (e.g. `attention-mechanism-2`)
@@ -416,6 +416,7 @@ Wiki: +1 paper, +{N} claims, +{M} concepts, +{K} edges | Maturity: {level} ({cov
 - `python3 tools/research_wiki.py rebuild-context-brief wiki/` — rebuild compressed context
 - `python3 tools/research_wiki.py rebuild-open-questions wiki/` — rebuild knowledge gap map
 - `python3 tools/research_wiki.py log wiki/ "<message>"` — append log entry
+- `python3 tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"]` — normalize a local source into a canonical ingest path
 - `python3 tools/fetch_s2.py paper <arxiv_id>` — query Semantic Scholar
 - `python3 tools/fetch_s2.py citations <arxiv_id>` — query citations
 - `python3 tools/fetch_s2.py references <arxiv_id>` — query references

--- a/.claude/skills/init/SKILL.md
+++ b/.claude/skills/init/SKILL.md
@@ -5,13 +5,19 @@ argument-hint: "[topic] [--no-introduction]"
 
 # /init
 
-> Build a wiki from `raw/` with a deterministic discovery plan, an LLM trim step, provisional pages from `raw/notes/` and `raw/web/`, and parallel `/ingest` fan-out/fan-in.
+> Build a wiki from `raw/` with deterministic source preparation, planner-guided discovery, provisional notes/web scaffolding, and parallel `/ingest` fan-out/fan-in.
+
+Use these local references on demand:
+
+- `references/prepare-and-discovery.md` — prepare flow, final selection, fetch, and source-manifest rules
+- `references/planner-policy.md` — planner behavior and LLM trim expectations
+- `references/parallel-ingest.md` — worktree isolation, subagent prompt contract, merge, and cleanup
 
 ## Inputs
 
 - `topic` (optional): research direction keywords; omit it when `raw/papers/` already defines the seed set or when notes/web already capture the intent
 - `--no-introduction` (optional): disable external paper discovery; use only user-owned `raw/papers/`, `raw/notes/`, and `raw/web/`
-- parameter guardrail: treat `topic` and `--no-introduction` as user inputs, not agent strategy knobs; do not infer `--no-introduction` from repository state alone. A non-empty `raw/papers/`, empty `raw/notes/` or `raw/web/`, or an omitted `topic` is not by itself a reason to enable local-only mode. Use `--no-introduction` only when the user explicitly asked to disable external discovery.
+- parameter guardrail: treat `topic` and `--no-introduction` as user inputs, not agent strategy knobs. Do not infer `--no-introduction` from repository state alone. Use it only when the user explicitly asked to disable external discovery.
 - `raw/papers/`: user-owned paper sources (`.tex`, `.pdf`, archives)
 - `raw/notes/`: user-owned notes that express goals, hypotheses, exclusions, and preferred sub-directions
 - `raw/web/`: user-owned saved web pages that express goals, hypotheses, exclusions, and preferred sub-directions
@@ -19,10 +25,10 @@ argument-hint: "[topic] [--no-introduction]"
 ## Outputs
 
 - `wiki/` scaffold via `tools/research_wiki.py init`
-- `raw/tmp/` — `/init`-generated prepared local sources
-- `raw/discovered/` — newly downloaded papers selected by `/init` (only when discovery is enabled)
+- `raw/tmp/` — generated prepared local sources reused by `/init` and direct local `/ingest`
+- `raw/discovered/` — newly downloaded papers selected by `/init` when discovery is enabled
 - `wiki/Summary/{area}.md`, `wiki/topics/{topic}.md`, provisional `wiki/ideas/{slug}.md`, `wiki/concepts/{slug}.md`, `wiki/claims/{slug}.md`
-- `wiki/papers/*.md` plus paper-derived concepts/claims/people via parallel `/ingest`
+- `wiki/papers/*.md` plus paper-derived concepts / claims / people via parallel `/ingest`
 - updated `wiki/index.md`, `wiki/log.md`, `wiki/graph/edges.jsonl`, `wiki/graph/context_brief.md`, `wiki/graph/open_questions.md`
 - `.checkpoints/init-prepare.json`, `.checkpoints/init-plan.json`, `.checkpoints/init-sources.json`
 
@@ -31,8 +37,8 @@ argument-hint: "[topic] [--no-introduction]"
 ### Reads
 
 - `raw/papers/`, `raw/notes/`, `raw/web/`
-- `.checkpoints/init-prepare.json` and `.checkpoints/init-sources.json` for resume / fan-out
-- `wiki/index.md` plus existing `wiki/topics/`, `wiki/ideas/`, `wiki/concepts/`, `wiki/claims/` for resume and duplicate avoidance
+- `.checkpoints/init-prepare.json` and `.checkpoints/init-sources.json` for resume, planning, and fan-out
+- `wiki/index.md` plus existing `wiki/topics/`, `wiki/ideas/`, `wiki/concepts/`, `wiki/claims/` for duplicate avoidance and scaffold alignment
 
 ### Writes
 
@@ -48,7 +54,7 @@ argument-hint: "[topic] [--no-introduction]"
 
 ## Workflow
 
-**Pre-condition**: working directory is the project root containing `wiki/`, `raw/`, `tools/`. Set `WIKI_ROOT=wiki/`. Resolve `PYTHON_BIN` once and reuse it for every Python command during `/init` so the workflow stays on the same interpreter that `setup.sh` populated:
+**Pre-condition**: working directory is the project root containing `wiki/`, `raw/`, and `tools/`. Set `WIKI_ROOT=wiki/`. Resolve `PYTHON_BIN` once and reuse it for every Python command during `/init` so the workflow stays on the interpreter that `setup.sh` prepared:
 
 ```bash
 if [ -x .venv/bin/python ]; then
@@ -72,17 +78,21 @@ Create the standard wiki directories, `graph/`, `outputs/`, `index.md`, and `log
 ### Step 2: Prepare local inputs into `raw/tmp/`
 
 ```bash
-"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json
+"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --pdf-titles-json .checkpoints/init-pdf-titles.json --output-manifest .checkpoints/init-prepare.json
 ```
 
-- decode local PDFs into synthetic `.tex` under `raw/tmp/` when possible
-- for PDFs that lack an embedded arXiv ID, attempt title-based recovery via Semantic Scholar search; when an arXiv ID is recovered successfully, prefer the fetched raw TeX source from arXiv (`raw/tmp/papers/...-arxiv-src/`) over the synthetic `.tex`
+- before running `prepare`, inspect each local PDF and write the recovery handoff to `.checkpoints/init-pdf-titles.json` as either `{ "raw/papers/foo.pdf": "Recovered Paper Title" }` or `{ "raw/papers/foo.pdf": { "title": "Recovered Paper Title", "arxiv_id": "2401.00001" } }` when a confident arXiv ID is already known
+- use `"$PYTHON_BIN" tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"] [--arxiv-id "<recovered-arxiv-id>"]` for local paper normalization
+- local PDF recovery order is strict: handed-off arXiv ID or filename/path arXiv ID -> agent-recovered title via Semantic Scholar -> fetched arXiv source -> synthetic `.tex`
+- when the agent supplied a PDF title, treat that title as authoritative for the prepared manifest; fetched/source titles are sanitized fallback metadata only and must not overwrite it
+- do not use PDF metadata or body text as arXiv-ID hints during prepare
+- metadata or filename titles may remain as provisional display labels only; they are not trusted identity or title-search inputs
 - keep notes/web on their original source paths; `/init` reads them directly during planning
 - set each local paper's `canonical_ingest_path` to a prepared `raw/tmp/` path when available; otherwise fall back to the original `raw/papers/...` path
-- record warnings for failed decode / arXiv source fetch rather than aborting `/init`
-- save the manifest to `.checkpoints/init-prepare.json`
+- record warnings for failed decode / title recovery / arXiv source fetch rather than aborting `/init`
+- see `references/prepare-and-discovery.md` for the prepare decision tree and source-preference rules
 
-### Step 3: Build the discovery plan, trim it, and write the final source manifest
+### Step 3: Plan discovery, trim the final set, and write the source manifest
 
 ```bash
 "$PYTHON_BIN" tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json
@@ -90,52 +100,18 @@ Create the standard wiki directories, `graph/`, `outputs/`, `index.md`, and `log
 
 - `mode=seeded` when the prepare manifest contains at least one parseable local paper; otherwise `mode=bootstrap`
 - `plan` must read `.checkpoints/init-prepare.json` instead of rescanning `raw/`
-- `raw/notes/` and `raw/web/` signals are read directly from the original source files
-- if multiple local copies of the same paper exist, prefer better local sources in this order: original local `.tex` > archive-extracted source `.tex` or fetched arXiv source directory > PDF-derived synthetic `.tex` > raw `.pdf`
-- if Chinese note or web content is detected, preserve a planner warning that extraction/ranking may be less reliable and treat provisional outputs as lower-confidence
-- when `topic` is omitted in seeded mode, derive discovery and ranking cues from local paper titles/abstracts plus notes/web signals instead of refusing to plan
-- if seeded discovery adds no external papers, proceed with the user-owned paper set instead of treating that as a fatal planner error
-- when both `topic` and notes/web keywords are absent, bootstrap discovery has no query to search with, so it must surface that as a planner error instead of issuing an empty search
-- over-pick a shortlist of **10-12** candidates
-- use S2 citations/references/search plus optional DeepXiv search
-- when DeepXiv search is available, explicitly use returned `relevance_score` inside tool scoring rather than merely noting it in prose
-- if `SEMANTIC_SCHOLAR_API_KEY` is unset, continue anyway but record the slower public-rate-limit discovery path as a planner warning
-- planner output, warnings, and errors must be saved to `.checkpoints/init-plan.json`
-
-Planner policy:
-
-- relevance = 30
-- freshness = 20
-- anchor/connectivity bonus = 20
-- survey/benchmark/overview bonus = 15
-- citation/centrality = 15
-- prefer a survey if one is available
-- allow at most one older canonical anchor slot, and only in bootstrap or very roomy seeded cases
-- in seeded mode with limited introduced capacity, do not reserve an older anchor up front; freshness should dominate and older external non-survey papers must not pile up via citation advantage
-- otherwise freshness wins close decisions
-- seeded mode computes anchor bonus from user papers first, then notes/web priorities
-- bootstrap mode searches first, then expands citations/references from the strongest initial candidates
-
-LLM trim policy:
-
+- planner policy is qualitative at the skill layer: favor relevance, freshness, connectivity, and survey coverage
+- in seeded mode with limited introduced capacity, avoid over-prioritizing older citation-heavy anchors
+- in bootstrap mode, one older canonical anchor may be useful when it improves coverage
+- when DeepXiv search is available, use returned `relevance_score` in tool scoring rather than merely noting it in prose
+- exact ranking weights, shortlist constants, and threshold math belong to `tools/init_discovery.py`; treat the tool as the implementation authority and do not restate or override its constants in LLM reasoning
 - read `.checkpoints/init-plan.json` and explicitly trim the over-picked `shortlist` to a final **8-10** papers total before `fetch`
-- do not skip the trim step even if the shortlist already looks reasonable
-- keep all parseable user-owned papers by default, then use the remaining slots for introduced papers
-- if the user already provided more than 10 parseable papers, add no new papers
-- prefer one survey/overview when available, at most one older canonical anchor when it is actually useful, and fresh representatives across distinct clusters
-- when the user already supplied a substantial seed set, freshness should dominate and older canonical papers should be further deprioritized
-- "`at most one` older canonical anchor" is a ceiling, not a requirement
-- before `fetch`, emit an explicit final selection artifact in the workflow/response that includes: `shortlist_count`, `final_count`, and the exact final `candidate_id` list in shortlist order
-- if `final_count` is outside **8-10**, stop and revise the final selection before `fetch`, unless `--no-introduction` is active or the user already supplied more than 10 parseable papers
-- call `fetch` only with the exact final selected `candidate_id`s; never forward the whole shortlist implicitly or pass all shortlist IDs by default
+- emit an explicit final selection artifact before `fetch` with `shortlist_count`, `final_count`, and the exact final `candidate_id` list in shortlist order
+- if `final_count` falls outside **8-10**, stop and revise the final selection before `fetch`, unless `--no-introduction` is active or the user already supplied more than 10 parseable papers
+- if `--no-introduction` is present, only use this branch when the user explicitly requested local-only behavior; still run `fetch` with zero external IDs so it writes `.checkpoints/init-sources.json`
+- see `references/planner-policy.md` for planner behavior, trim expectations, and source-of-truth boundaries
 
-If `--no-introduction` is present:
-
-- only use this branch when the user explicitly requested local-only behavior
-- final paper set = all parseable user papers from `.checkpoints/init-prepare.json`
-- still run `fetch` with zero external IDs so it writes `.checkpoints/init-sources.json`
-
-Otherwise run:
+Then run:
 
 ```bash
 "$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id> --id <candidate-id>
@@ -143,9 +119,7 @@ Otherwise run:
 
 - external papers downloaded by `/init` go to `raw/discovered/`, never `raw/papers/`
 - never fetch a paper that is already represented by a prepared local source from `raw/tmp/`
-- `.checkpoints/init-sources.json` is the single source of truth for Step 5 ingest order
-- user-owned papers appear in `init-sources.json` with `origin=user_local` and their canonical prepared path when available
-- introduced papers appear in `init-sources.json` with `origin=introduced` and their canonical `raw/discovered/` path
+- `.checkpoints/init-sources.json` is the single source of truth for downstream ingest order
 
 ### Step 4: Create scaffold pages before paper ingest
 
@@ -164,61 +138,9 @@ Provisional note: seeded from raw/notes or raw/web during /init; pending validat
 - `ideas/`: create when the user states or strongly implies a research direction or hypothesis
 - `concepts/`: create only when the mechanism recurs across notes/web, or appears once in notes/web and once in the final paper set
 - `claims/`: create only from explicit assertive statements, never by inference
-
-For notes/web-derived claims, use:
-
-```yaml
-status: proposed
-confidence: 0.2
-source_papers: []
-evidence: []
-```
-
-Do not create `people/` pages or `foundations/` pages from `/init`. Update `wiki/index.md` for scaffold pages created directly in this step.
-
-### Step 4.5: Commit scaffold, stash unrelated dirty files, verify merge safety
-
-Before spawning subagents:
-
-- run `git status --short`
-- treat files under `wiki/`, `raw/papers/`, `raw/tmp/`, `raw/discovered/`, and `.checkpoints/init-*.json` as scaffold files
-- stash unrelated dirty files outside those paths:
-
-```bash
-UNRELATED=$(git status --short | awk '{print $2}' | grep -Ev '^(wiki/|raw/papers/|raw/tmp/|raw/discovered/|\.checkpoints/init-)' || true)
-if [ -n "$UNRELATED" ]; then
-  git stash push -u -m "init-unrelated-dirty-$(date +%Y%m%d-%H%M%S)" -- $UNRELATED
-fi
-```
-
-- save the stash ref:
-
-```bash
-STASH_REF=$(git stash list | head -1 | cut -d: -f1)
-"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session stash_ref "$STASH_REF"
-```
-
-- capture the current branch before worktree fan-out; `/init` worktree mode must run from a named branch, not detached HEAD:
-
-```bash
-BASE_BRANCH=$(git branch --show-current)
-if [ -z "$BASE_BRANCH" ]; then
-  echo "/init worktree mode requires a named branch; switch to or create one before continuing." >&2
-  exit 1
-fi
-"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_branch "$BASE_BRANCH"
-```
-
-- save final selected paper IDs (post-trim, not the over-picked shortlist) and planner mode into checkpoint metadata
-- verify `.gitattributes` contains `merge=union` for `wiki/log.md`, `wiki/graph/edges.jsonl`, and `wiki/index.md`
-- commit the scaffold:
-
-```bash
-git add wiki/ raw/papers/ raw/tmp/ raw/discovered/ .checkpoints/init-prepare.json .checkpoints/init-plan.json .checkpoints/init-sources.json
-git commit -m "init: scaffold before parallel ingest" --no-gpg-sign
-BASE_COMMIT=$(git rev-parse HEAD)
-"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_commit "$BASE_COMMIT"
-```
+- for notes/web-derived claims, use `status: proposed`, `confidence: 0.2`, `source_papers: []`, and `evidence: []`
+- `/prefill` is optional background seeding and is not part of `/init`
+- `/init` must not create `people/` pages directly and must not auto-create foundations
 
 ### Step 5: Parallel paper ingest with worktree isolation
 
@@ -227,30 +149,15 @@ Paper sources for this step come strictly from `.checkpoints/init-sources.json`:
 - `origin=user_local`: canonical prepared `.tex` under `raw/tmp/` when available, otherwise fallback `raw/papers/...`
 - `origin=introduced`: fetched dirs or PDFs under `raw/discovered/`
 
-Order papers by `shortlist_rank` from `init-sources.json`, not by rescanning raw folders or by raw citation count.
+Parallel ingest contract:
 
-Spawn one Agent subagent per paper with:
-
-- `run_in_background: true`
-- worktree isolation
-- a fresh temp branch created from `BASE_COMMIT`, never the already-checked-out `BASE_BRANCH`
-- a prompt that uses **relative paths only**
-- explicit INIT MODE skips
-
-For each paper, create the worktree from the scaffold commit on the current branch:
-
-```bash
-WT_BRANCH="init-${BASE_BRANCH//\//-}-<rank>-<paper-slug>"
-WT_PATH="../.worktrees/$WT_BRANCH"
-git worktree add -b "$WT_BRANCH" "$WT_PATH" "$BASE_COMMIT"
-```
-
-Do not run `git worktree add` against the current branch name itself; Git will refuse because that branch is already checked out in the main workspace.
-
-Subagent prompt requirements:
-
-- execute `/ingest` for exactly one relative source path
-- do not bypass `/ingest`
+- stash unrelated dirty files before fan-out, then record `stash_ref`, `base_branch`, and `base_commit` in checkpoint metadata
+- commit the freshly created scaffold and init manifests before fan-out so `BASE_COMMIT` actually contains the pages, manifests, and handoff metadata that subagents must branch from
+- verify `.gitattributes` contains `merge=union` for `wiki/log.md`, `wiki/graph/edges.jsonl`, and `wiki/index.md` before creating worktrees
+- `/init` worktree mode must run from a named branch, not detached HEAD
+- create each worktree from `BASE_COMMIT`, not from the already checked-out `BASE_BRANCH`
+- subagent prompts must use **relative paths only**
+- execute `/ingest` for exactly one handed-off source path; do not bypass `/ingest`
 - in INIT MODE, consume the handed-off canonical path exactly as provided
 - skip `fetch_s2.py citations`
 - skip `fetch_s2.py references`
@@ -258,28 +165,24 @@ Subagent prompt requirements:
 - skip per-subagent `rebuild-context-brief`
 - skip per-subagent `rebuild-open-questions`
 - skip conflict-prone topic writes
-- still run `find-similar-claim` and `find-similar-concept`
-- commit the result inside the worktree before exiting
+- commit the ingest result inside the worktree before exiting so fan-in merges a real paper-specific commit instead of an empty branch
+- see `references/parallel-ingest.md` for worktree commands, merge order, fan-in, and cleanup
 
-After all agents complete:
+### Step 6: Fan-in, rebuild, and final report
 
-1. switch the main workspace back to `BASE_BRANCH` if needed, then merge worktree branches sequentially there in planner order
-2. resolve true concept/claim conflicts conservatively — merge, do not multiply near-duplicates
-3. run:
+After all subagents complete:
+
+- merge worktree branches sequentially on `BASE_BRANCH`
+- resolve true concept / claim conflicts conservatively: merge, do not multiply near-duplicates
+- run:
 
 ```bash
-git switch "$BASE_BRANCH"
-git merge --no-ff "$WT_BRANCH" --no-edit
-git worktree remove "$WT_PATH"
-git branch -d "$WT_BRANCH"
 "$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/
 "$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/
 "$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/
 "$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/
 "$PYTHON_BIN" tools/lint.py wiki/ --fix
 ```
-
-### Step 6: Final report and cleanup
 
 Report separately:
 
@@ -293,39 +196,31 @@ Report separately:
 
 If `stash_ref` exists, pop it at the end. If stash pop fails, keep the checkpoint and report the failure.
 
-Also note explicitly:
-
-- `/prefill` was not used by `/init`
-- no foundations were auto-created
-- current people-page and claim-volume tightening remains a follow-up task for `/ingest`
-
 ## Constraints
 
 - `raw/papers/`, `raw/notes/`, and `raw/web/` are user-owned inputs
-- `raw/tmp/` and `raw/discovered/` are `/init`-generated handoff areas
-- `/init` may write external papers only to `raw/discovered/`, and generated prepared local sources only to `raw/tmp/`
+- `raw/tmp/` and `raw/discovered/` are generated handoff areas; direct local `/ingest` may also prepare reusable local sidecars under `raw/tmp/`
+- `/init` may write external papers only to `raw/discovered/`; `/init` and direct local `/ingest` may write generated prepared local sources to `raw/tmp/`
 - `/prefill` is optional background seeding, not part of `/init`
 - no skill other than `/prefill` may auto-create foundations
 - `/init` must not create `people/` pages directly
 - notes/web-derived pages are provisional and must carry the exact notice line above
-- no new frontmatter fields are introduced for provisional status
 - paper evidence outranks notes/web for claim confidence and concept consolidation
 - all paper ingest must run through parallel `/ingest` subagents with worktree isolation
 - Step 5 must read paper inputs from `.checkpoints/init-sources.json`, not by ad hoc folder scanning
-- subagent prompts must use relative paths only
+- exact deterministic planner policy belongs in `tools/init_discovery.py`, not in duplicated skill constants
 
 ## Error Handling
 
 - **No parseable paper in `raw/papers/`**: enter bootstrap mode
 - **`raw/notes/` and `raw/web/` empty**: skip provisional seeding, continue
 - **PDF decode fails during prepare**: keep the local source, record the warning in `.checkpoints/init-prepare.json`, and fall back to the original path if needed
+- **No confident PDF title is recovered**: omit `--title`, allow filename/path arXiv-ID recovery only, then fall back directly to synthetic `.tex`; any metadata-or-filename title is display-only
 - **Chinese content is detected in `raw/notes/` or `raw/web/`**: keep going, but preserve a planner warning that note/web extraction and ranking may be less reliable and treat rankings plus provisional pages as lower-confidence
 - **S2 or DeepXiv unavailable**: planner falls back to the remaining sources; preserve the warning in the checkpointed plan and note degraded discovery in the report
-- **arXiv ID recovery or TeX source fetch failure for a local PDF**: record a warning in `.checkpoints/init-prepare.json`, fall back to synthetic `.tex` or the original PDF path, and continue
 - **External fetch fails for one paper**: keep the remaining final set and report the failed download
 - **Single paper ingest fails**: record it via checkpoint, skip it, continue the rest, and list it in the report
 - **Current checkout is detached HEAD**: stop before worktree fan-out and ask the user to switch to or create a named branch first
-- **Worktree branch has no commit**: stop and recover that worktree before merge
 - **stash pop fails**: keep checkpoint metadata and report the manual recovery step
 
 ## Dependencies
@@ -340,14 +235,15 @@ Also note explicitly:
 - `"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/`
 - `"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/`
 - `"$PYTHON_BIN" tools/research_wiki.py log wiki/ "<message>"`
-- `"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json`
+- `"$PYTHON_BIN" tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"]`
+- `"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --pdf-titles-json .checkpoints/init-pdf-titles.json --output-manifest .checkpoints/init-prepare.json`
 - `"$PYTHON_BIN" tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json`
 - `"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id>`
 - `"$PYTHON_BIN" tools/lint.py wiki/ --fix`
 
 ### Skills
 
-- `/ingest` — one paper per subagent, INIT MODE
+- `/ingest` — one paper per subagent, in INIT MODE
 
 ### External APIs used by `init_discovery.py`
 

--- a/.claude/skills/init/references/parallel-ingest.md
+++ b/.claude/skills/init/references/parallel-ingest.md
@@ -1,0 +1,69 @@
+# /init Parallel Ingest
+
+Use this reference when `/init` is handing sources to parallel `/ingest` subagents and merging their work back.
+
+## Pre-Fan-Out Safety
+
+- Run `git status --short`.
+- Treat files under `wiki/`, `raw/papers/`, `raw/tmp/`, `raw/discovered/`, and `.checkpoints/init-*.json` as scaffold files.
+- Stash unrelated dirty files outside those paths.
+- Verify `.gitattributes` contains `merge=union` for `wiki/log.md`, `wiki/graph/edges.jsonl`, and `wiki/index.md`.
+- Commit the scaffold before fan-out so `BASE_COMMIT` contains the generated pages and manifests that every worktree must inherit:
+
+```bash
+git add wiki/ raw/papers/ raw/tmp/ raw/discovered/ .checkpoints/init-prepare.json .checkpoints/init-plan.json .checkpoints/init-sources.json
+git commit -m "init: scaffold before parallel ingest" --no-gpg-sign
+BASE_COMMIT=$(git rev-parse HEAD)
+```
+
+- Record `stash_ref`, `base_branch`, and `base_commit` with `tools/research_wiki.py checkpoint-set-meta`.
+- `/init` worktree mode requires a named branch; stop on detached HEAD.
+
+## Worktree Creation
+
+For each paper, create the worktree from the scaffold commit on the current branch:
+
+```bash
+WT_BRANCH="init-${BASE_BRANCH//\//-}-<rank>-<paper-slug>"
+WT_PATH="../.worktrees/$WT_BRANCH"
+git worktree add -b "$WT_BRANCH" "$WT_PATH" "$BASE_COMMIT"
+```
+
+- Do not run `git worktree add` against the current branch name itself; Git will refuse because that branch is already checked out in the main workspace.
+- Order papers by `shortlist_rank` from `.checkpoints/init-sources.json`, not by rescanning raw folders or by raw citation count.
+
+## Subagent Prompt Contract
+
+- Execute `/ingest` for exactly one relative source path.
+- Do not bypass `/ingest`.
+- In INIT MODE, consume the handed-off canonical path exactly as provided.
+- Skip `fetch_s2.py citations`.
+- Skip `fetch_s2.py references`.
+- Skip per-subagent `rebuild-index`.
+- Skip per-subagent `rebuild-context-brief`.
+- Skip per-subagent `rebuild-open-questions`.
+- Skip conflict-prone topic writes.
+- Commit the result inside the worktree before exiting so fan-in merges a real ingest commit.
+
+## Fan-In
+
+After all agents complete:
+
+1. Switch the main workspace back to `BASE_BRANCH` if needed, then merge worktree branches sequentially there in planner order.
+2. Resolve true concept/claim conflicts conservatively: merge, do not multiply near-duplicates.
+3. Merge only committed worktree branches. A branch with no ingest commit is an error to stop and fix, not something to merge through.
+3. Run:
+
+```bash
+git switch "$BASE_BRANCH"
+git merge --no-ff "$WT_BRANCH" --no-edit
+git worktree remove "$WT_PATH"
+git branch -d "$WT_BRANCH"
+"$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/
+"$PYTHON_BIN" tools/lint.py wiki/ --fix
+```
+
+If `stash_ref` exists, pop it at the end. If stash pop fails, keep the checkpoint and report the failure.

--- a/.claude/skills/init/references/planner-policy.md
+++ b/.claude/skills/init/references/planner-policy.md
@@ -1,0 +1,27 @@
+# /init Planner Policy
+
+Use this reference when reading `.checkpoints/init-plan.json`, trimming the shortlist, or interpreting planner warnings and errors.
+
+## Behavioral Policy
+
+- In seeded mode, derive discovery and ranking cues from local paper titles/abstracts plus notes/web signals when `topic` is omitted.
+- In bootstrap mode, if both `topic` and notes/web keywords are absent, surface a planner error instead of issuing an empty search.
+- Favor relevance, freshness, connectivity, and survey coverage.
+- Prefer one survey/overview when it improves coverage.
+- In seeded mode with limited introduced capacity, freshness should dominate and older external non-survey papers should not pile up via citation advantage.
+- In bootstrap mode or unusually roomy seeded cases, one older canonical anchor may be acceptable when it materially improves coverage.
+- When Chinese note or web content is detected, keep a planner warning that extraction/ranking may be less reliable and treat provisional outputs as lower-confidence.
+- If `SEMANTIC_SCHOLAR_API_KEY` is unset, continue anyway and preserve the slower public-rate-limit path as a planner warning.
+
+## LLM Trim Expectations
+
+- Read `.checkpoints/init-plan.json` and explicitly trim the over-picked shortlist before `fetch`.
+- Do not skip the trim step even if the shortlist already looks reasonable.
+- Emit a final selection artifact before `fetch` containing `shortlist_count`, `final_count`, and the final `candidate_id` list in shortlist order.
+- If the final count is out of range, revise the selection before `fetch` unless a documented exception applies.
+
+## Source Of Truth Boundary
+
+- `tools/init_discovery.py` is the implementation authority for exact weights, thresholds, shortlist constants, and scoring math.
+- `SKILL.md` and this reference describe orchestration and behavioral expectations only.
+- Do not duplicate numeric planner constants here or override tool-owned policy during LLM reasoning.

--- a/.claude/skills/init/references/prepare-and-discovery.md
+++ b/.claude/skills/init/references/prepare-and-discovery.md
@@ -1,0 +1,47 @@
+# /init Prepare And Discovery
+
+Use this reference when `/init` is preparing local inputs, selecting the final paper set, or writing `.checkpoints/init-sources.json`.
+
+## Prepare Flow
+
+- Run `"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --pdf-titles-json .checkpoints/init-pdf-titles.json --output-manifest .checkpoints/init-prepare.json`.
+- Before preparing local PDFs, recover confident titles when possible and write `.checkpoints/init-pdf-titles.json` as either `{ "raw/papers/foo.pdf": "Recovered Paper Title" }` or `{ "raw/papers/foo.pdf": { "title": "Recovered Paper Title", "arxiv_id": "2401.00001" } }` when a confident arXiv ID is already known.
+- `tools/init_discovery.py prepare` must pass those recovered titles and IDs into `"$PYTHON_BIN" tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"] [--arxiv-id "<recovered-arxiv-id>"]`.
+- `tools/init_discovery.py prepare` must delegate local paper normalization to the same helper and reuse pre-staged `raw/tmp/` artifacts when they already exist.
+- For local PDFs, use this recovery order only: handed-off arXiv ID or filename/path arXiv ID -> title-based Semantic Scholar recovery when a confident title was supplied -> fetched arXiv source -> synthetic `.tex`.
+- When the agent supplied a confident PDF title, that title is authoritative for the prepared manifest. Sanitized titles from fetched TeX are fallback metadata only and must not overwrite the agent title.
+- Do not use PDF metadata or PDF body text as arXiv-ID hints during prepare.
+- When arXiv ID recovery succeeds, prefer fetched raw TeX source under `raw/tmp/papers/...-arxiv-src/` over synthetic `.tex`.
+- If no confident PDF title is available, omit `--title`; if no confident arXiv ID is available, omit `--arxiv-id`; then allow filename/path arXiv-ID recovery only and fall back directly to synthetic `.tex`. Metadata or filename titles remain display-only.
+
+## Source Preference Rules
+
+- Prefer local sources in this order: original local `.tex` > archive-extracted source `.tex` or fetched arXiv source directory > PDF-derived synthetic `.tex` > raw `.pdf`.
+- Keep notes/web on their original source paths. `/init` reads them directly during planning.
+- If the handed-off source already lives under `raw/tmp/` or `raw/discovered/`, treat that path as canonical and do not duplicate it into `raw/papers/`.
+- Set each local paper's `canonical_ingest_path` to a prepared `raw/tmp/` path when available; otherwise fall back to the original `raw/papers/...` path.
+
+## Final Selection And Fetch
+
+- `plan` must read `.checkpoints/init-prepare.json` instead of rescanning `raw/`.
+- Over-pick a shortlist first, then explicitly trim it to the documented final target before `fetch`.
+- Keep all parseable user-owned papers by default, then use remaining slots for introduced papers.
+- If seeded discovery adds no external papers, proceed with the user-owned paper set instead of treating that as a fatal planner error.
+- If the user already provided more than 10 parseable papers, add no new papers.
+- If `--no-introduction` is active, final paper set = all parseable user papers, and `fetch` still runs with zero external IDs so it writes `.checkpoints/init-sources.json`.
+
+Run:
+
+```bash
+"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id> --id <candidate-id>
+```
+
+- External papers downloaded by `/init` go to `raw/discovered/`, never `raw/papers/`.
+- Never fetch a paper that is already represented by a prepared local source from `raw/tmp/`.
+
+## Source Manifest Contract
+
+- `.checkpoints/init-sources.json` is the single source of truth for Step 5 ingest order.
+- User-owned papers appear in `init-sources.json` with `origin=user_local` and their canonical prepared path when available.
+- Introduced papers appear in `init-sources.json` with `origin=introduced` and their canonical `raw/discovered/` path.
+- Step 5 must consume the handed-off `canonical_ingest_path` exactly as written.

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -232,7 +232,7 @@ If this is a fresh install (no `wiki/` directory):
 Configuration done. Next:
   • Put your own papers in raw/papers/ (.tex or .pdf)
   • Optional: add intent notes to raw/notes/ and saved pages to raw/web/
-  • /init will manage generated inputs under raw/discovered/ and raw/tmp/
+  • /init and direct local /ingest will manage generated inputs under raw/discovered/ and raw/tmp/
   • Run: /init [your-research-topic]
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,12 +28,14 @@ Keep this mental map in immediate context:
 
 - Open `docs/runtime-page-templates.en.md` before drafting or repairing wiki page structure, YAML, or body sections
 - Open `docs/runtime-support-files.en.md` when you need graph-derived file details or `index.md` / `log.md` format
+- `SKILL.md` is the immediate entrypoint for a skill; some larger skills may also provide local on-demand reference files under their skill directory
+- `/init` is the first concrete example of this pattern: read `skills/init/SKILL.md` first, then open `skills/init/references/*` only when needed
 
 ### `raw/` and `config/`
 
 - `raw/papers/`, `raw/notes/`, and `raw/web/` are user-owned inputs
 - `raw/discovered/` stores externally fetched papers from `/init` and `/daily-arxiv`
-- `raw/tmp/` stores `/init`-generated prepared local sidecars
+- `raw/tmp/` stores generated prepared local sidecars for `/init` and direct local `/ingest`
 - `config/` holds environment and remote-server templates
 
 ---
@@ -107,7 +109,7 @@ Standard log line:
 
 ## Constraints
 
-- **`raw/papers/`, `raw/notes/`, `raw/web/` are user-owned**: treat them as authoritative inputs. `/init` and `/daily-arxiv` may add externally fetched papers only under `raw/discovered/`, and only `/init` may add generated prepared local sidecars under `raw/tmp/` (additions only — never overwrite an existing user-owned file). `/edit` may add raw sources only when the user explicitly asked for it. All other skills, tools, and `/init` subagents running `/ingest` in INIT MODE treat `raw/` as strictly read-only.
+- **`raw/papers/`, `raw/notes/`, `raw/web/` are user-owned**: treat them as authoritative inputs. `/init` and `/daily-arxiv` may add externally fetched papers only under `raw/discovered/`. `/init` and direct local `/ingest` may add generated prepared local sidecars under `raw/tmp/` (additions only — never overwrite an existing user-owned file). `/edit` may add raw sources only when the user explicitly asked for it. `/init` subagents running `/ingest` in INIT MODE still treat `raw/` as strictly read-only and must consume the handed-off canonical path directly.
 - **User-facing skill parameters are user-owned**: flags and values shown in a skill's `argument-hint` belong to the user's command, not to agent strategy. Do not invent, flip, or drop those parameters from repository state alone. If the user omitted a parameter, only use a default or derived value when that skill explicitly documents omission behavior; otherwise leave it unset or ask the user. Internal derived settings that are not user-facing parameters may still be inferred by the skill.
 - **INIT MODE handoff is manifest-driven**: when `/init` writes `.checkpoints/init-sources.json`, that manifest becomes the single source of truth for ingest order and canonical source paths. Prepared local inputs should point to `raw/tmp/`; introduced external papers should point to `raw/discovered/`.
 - **graph/ is auto-generated**: never manually edit files in `graph/` — only via `tools/research_wiki.py`.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ chmod +x setup.sh && ./setup.sh        # Linux / macOS
 
 # 4. Put your own papers in raw/papers/ (.tex or .pdf)
 #    Optional: add intent notes to raw/notes/ and saved pages to raw/web/
-#    /init will manage generated inputs under raw/discovered/ and raw/tmp/
+#    /init and direct local /ingest will manage generated inputs under raw/discovered/ and raw/tmp/
 
 # 5. Build your wiki
 claude
@@ -220,7 +220,7 @@ OmegaWiki/
 ├── raw/                         # Source materials
 │   ├── papers/                  #   User-owned .tex / .pdf files
 │   ├── discovered/              #   /init and /daily-arxiv-downloaded external papers
-│   ├── tmp/                     #   /init-generated prepared local sidecars
+│   ├── tmp/                     #   generated prepared local sidecars for /init and direct local /ingest
 │   ├── notes/                   #   User-owned .md notes
 │   └── web/                     #   User-owned HTML / Markdown
 ├── tools/                       # Deterministic Python helpers
@@ -415,7 +415,7 @@ chmod +x setup.sh && ./setup.sh --lang zh        # Linux / macOS
 
 # 把你自己的论文放入 raw/papers/（.tex 或 .pdf）
 # 可选：把意图笔记放入 raw/notes/，网页存档放入 raw/web/
-# /init 会自动管理 raw/discovered/ 与 raw/tmp/ 下的生成内容
+# /init 与直接本地 /ingest 会自动管理 raw/discovered/ 与 raw/tmp/ 下的生成内容
 # 启动 Claude Code
 claude
 # 输入：/init [你的研究方向]

--- a/docs/runtime-directory-structure.en.md
+++ b/docs/runtime-directory-structure.en.md
@@ -25,7 +25,7 @@ wiki/
 raw/
 ├── papers/            ← user-owned .tex / .pdf sources
 ├── discovered/        ← externally fetched papers from /init and /daily-arxiv
-├── tmp/               ← /init-generated prepared local sources (synthetic tex, fetched source dirs)
+├── tmp/               ← generated prepared local sources for /init and direct local /ingest
 ├── notes/             ← user-owned .md notes
 └── web/               ← user-owned HTML / Markdown
 
@@ -40,5 +40,5 @@ config/
 
 - `raw/papers/`, `raw/notes/`, and `raw/web/` are user-owned inputs.
 - `raw/discovered/` is for fetched external papers, not user drop-ins.
-- `raw/tmp/` is generated intermediate state for `/init`.
+- `raw/tmp/` is generated intermediate state for `/init` and direct local `/ingest`.
 - `graph/` is derived and should be maintained only through `tools/research_wiki.py`.

--- a/docs/runtime-directory-structure.zh.md
+++ b/docs/runtime-directory-structure.zh.md
@@ -25,7 +25,7 @@ wiki/
 raw/
 ├── papers/            ← 用户自有 .tex / .pdf 来源
 ├── discovered/        ← /init 与 /daily-arxiv 抓取的外部论文
-├── tmp/               ← /init 生成的本地预处理来源（合成 tex、抓取到的源码目录）
+├── tmp/               ← /init 与直接本地 /ingest 生成的本地预处理来源
 ├── notes/             ← 用户自有 .md 笔记
 └── web/               ← 用户自有 HTML / Markdown
 
@@ -40,5 +40,5 @@ config/
 
 - `raw/papers/`、`raw/notes/`、`raw/web/` 是用户自有输入。
 - `raw/discovered/` 用于外部抓取论文，不是用户随手放文件的目录。
-- `raw/tmp/` 是 `/init` 的生成型中间状态。
+- `raw/tmp/` 是 `/init` 与直接本地 `/ingest` 的生成型中间状态。
 - `graph/` 是派生目录，只能通过 `tools/research_wiki.py` 维护。

--- a/i18n/en/CLAUDE.md
+++ b/i18n/en/CLAUDE.md
@@ -28,12 +28,14 @@ Keep this mental map in immediate context:
 
 - Open `docs/runtime-page-templates.en.md` before drafting or repairing wiki page structure, YAML, or body sections
 - Open `docs/runtime-support-files.en.md` when you need graph-derived file details or `index.md` / `log.md` format
+- `SKILL.md` is the immediate entrypoint for a skill; some larger skills may also provide local on-demand reference files under their skill directory
+- `/init` is the first concrete example of this pattern: read `skills/init/SKILL.md` first, then open `skills/init/references/*` only when needed
 
 ### `raw/` and `config/`
 
 - `raw/papers/`, `raw/notes/`, and `raw/web/` are user-owned inputs
 - `raw/discovered/` stores externally fetched papers from `/init` and `/daily-arxiv`
-- `raw/tmp/` stores `/init`-generated prepared local sidecars
+- `raw/tmp/` stores generated prepared local sidecars for `/init` and direct local `/ingest`
 - `config/` holds environment and remote-server templates
 
 ---
@@ -107,7 +109,7 @@ Standard log line:
 
 ## Constraints
 
-- **`raw/papers/`, `raw/notes/`, `raw/web/` are user-owned**: treat them as authoritative inputs. `/init` and `/daily-arxiv` may add externally fetched papers only under `raw/discovered/`, and only `/init` may add generated prepared local sidecars under `raw/tmp/` (additions only — never overwrite an existing user-owned file). `/edit` may add raw sources only when the user explicitly asked for it. All other skills, tools, and `/init` subagents running `/ingest` in INIT MODE treat `raw/` as strictly read-only.
+- **`raw/papers/`, `raw/notes/`, `raw/web/` are user-owned**: treat them as authoritative inputs. `/init` and `/daily-arxiv` may add externally fetched papers only under `raw/discovered/`. `/init` and direct local `/ingest` may add generated prepared local sidecars under `raw/tmp/` (additions only — never overwrite an existing user-owned file). `/edit` may add raw sources only when the user explicitly asked for it. `/init` subagents running `/ingest` in INIT MODE still treat `raw/` as strictly read-only and must consume the handed-off canonical path directly.
 - **User-facing skill parameters are user-owned**: flags and values shown in a skill's `argument-hint` belong to the user's command, not to agent strategy. Do not invent, flip, or drop those parameters from repository state alone. If the user omitted a parameter, only use a default or derived value when that skill explicitly documents omission behavior; otherwise leave it unset or ask the user. Internal derived settings that are not user-facing parameters may still be inferred by the skill.
 - **INIT MODE handoff is manifest-driven**: when `/init` writes `.checkpoints/init-sources.json`, that manifest becomes the single source of truth for ingest order and canonical source paths. Prepared local inputs should point to `raw/tmp/`; introduced external papers should point to `raw/discovered/`.
 - **graph/ is auto-generated**: never manually edit files in `graph/` — only via `tools/research_wiki.py`.

--- a/i18n/en/skills/ingest/SKILL.md
+++ b/i18n/en/skills/ingest/SKILL.md
@@ -63,7 +63,7 @@ Set `WIKI_ROOT=wiki/`.
 1. Detect source type:
    - **arXiv URL**: fetch tex source (ar5iv HTML or direct .tex download); fall back to PDF if unavailable
    - **local .tex**: read directly
-   - **local .pdf**: extract text (PyMuPDF or vision API fallback)
+   - **local .pdf**: inspect the PDF to recover a confident title when possible, and if the agent already recovered a confident arXiv ID keep that too; then run `python3 tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"] [--arxiv-id "<recovered-arxiv-id>"]`; the helper uses handed-off or filename/path arXiv IDs first, then agent-title Semantic Scholar recovery, and otherwise falls back directly to synthetic `.tex`. When a title was supplied by the agent, keep it authoritative; fetched/source titles are sanitized fallback metadata only.
    - **INIT MODE canonical handoff path**: if `/init` passes a path from `.checkpoints/init-sources.json`, ingest that exact `canonical_ingest_path` rather than rescanning sibling raw folders
 2. Extract metadata: title, abstract, author list (with affiliations), publication date, venue
 3. Extract reference list (BibTeX entries or reference section)
@@ -383,7 +383,7 @@ Wiki: +1 paper, +{N} claims, +{M} concepts, +{K} edges | Maturity: {level} ({cov
 
 ## Constraints
 
-- **raw/ is read-only**: do not modify files under `raw/`
+- **raw/ is read-only except canonical source prep**: treat `raw/papers/`, `raw/notes/`, and `raw/web/` as user-owned inputs. Direct local `/ingest` may write generated prepared local sidecars only under `raw/tmp/`, and direct arXiv ingests may write fetched source artifacts only under `raw/discovered/`. INIT MODE `/ingest` remains read-only and must consume the handed-off canonical path directly.
 - **INIT MODE source handoff is authoritative**: when `/init` passes a `canonical_ingest_path` from `.checkpoints/init-sources.json`, ingest that exact path rather than rescanning `raw/papers/`, `raw/tmp/`, or `raw/discovered/`
 - **graph/ via tools only**: do not manually edit files in `graph/` — use `python3 tools/research_wiki.py` only
 - **Bidirectional links**: always write the reverse link when writing a forward link (see CLAUDE.md Cross-Reference Rules table)
@@ -399,7 +399,7 @@ Wiki: +1 paper, +{N} claims, +{M} concepts, +{K} edges | Maturity: {level} ({cov
 
 ## Error Handling
 
-- **Source parse failure**: tex fails → PDF parse → vision API → report to user for manual handling. In INIT MODE, synthetic `.tex` under `raw/tmp/` and fetched source dirs / PDFs under `raw/discovered/` are valid inputs and should be consumed as handed off.
+- **Source parse failure**: tex fails → PDF parse → vision API → report to user for manual handling. For direct local PDFs, if no confident title is recovered, call `tools/prepare_paper_source.py` without `--title`; that means filename/path arXiv-ID recovery only, then immediate synthetic-`.tex` fallback. Metadata or filename titles are display-only and must not drive title-based lookup. In INIT MODE, synthetic `.tex` under `raw/tmp/` and fetched source dirs / PDFs under `raw/discovered/` are valid inputs and should be consumed as handed off.
 - **S2 API unavailable**: skip S2 steps (citations backfill, default importance to 3); note in report
 - **DeepXiv API unavailable**: skip DeepXiv enrichment (TLDR, structure verification, social metrics); fall back to S2 + source file parsing
 - **Slug conflict**: if generated slug already exists but content differs, append numeric suffix (e.g. `attention-mechanism-2`)
@@ -416,6 +416,7 @@ Wiki: +1 paper, +{N} claims, +{M} concepts, +{K} edges | Maturity: {level} ({cov
 - `python3 tools/research_wiki.py rebuild-context-brief wiki/` — rebuild compressed context
 - `python3 tools/research_wiki.py rebuild-open-questions wiki/` — rebuild knowledge gap map
 - `python3 tools/research_wiki.py log wiki/ "<message>"` — append log entry
+- `python3 tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"]` — normalize a local source into a canonical ingest path
 - `python3 tools/fetch_s2.py paper <arxiv_id>` — query Semantic Scholar
 - `python3 tools/fetch_s2.py citations <arxiv_id>` — query citations
 - `python3 tools/fetch_s2.py references <arxiv_id>` — query references

--- a/i18n/en/skills/init/SKILL.md
+++ b/i18n/en/skills/init/SKILL.md
@@ -5,13 +5,19 @@ argument-hint: "[topic] [--no-introduction]"
 
 # /init
 
-> Build a wiki from `raw/` with a deterministic discovery plan, an LLM trim step, provisional pages from `raw/notes/` and `raw/web/`, and parallel `/ingest` fan-out/fan-in.
+> Build a wiki from `raw/` with deterministic source preparation, planner-guided discovery, provisional notes/web scaffolding, and parallel `/ingest` fan-out/fan-in.
+
+Use these local references on demand:
+
+- `references/prepare-and-discovery.md` — prepare flow, final selection, fetch, and source-manifest rules
+- `references/planner-policy.md` — planner behavior and LLM trim expectations
+- `references/parallel-ingest.md` — worktree isolation, subagent prompt contract, merge, and cleanup
 
 ## Inputs
 
 - `topic` (optional): research direction keywords; omit it when `raw/papers/` already defines the seed set or when notes/web already capture the intent
 - `--no-introduction` (optional): disable external paper discovery; use only user-owned `raw/papers/`, `raw/notes/`, and `raw/web/`
-- parameter guardrail: treat `topic` and `--no-introduction` as user inputs, not agent strategy knobs; do not infer `--no-introduction` from repository state alone. A non-empty `raw/papers/`, empty `raw/notes/` or `raw/web/`, or an omitted `topic` is not by itself a reason to enable local-only mode. Use `--no-introduction` only when the user explicitly asked to disable external discovery.
+- parameter guardrail: treat `topic` and `--no-introduction` as user inputs, not agent strategy knobs. Do not infer `--no-introduction` from repository state alone. Use it only when the user explicitly asked to disable external discovery.
 - `raw/papers/`: user-owned paper sources (`.tex`, `.pdf`, archives)
 - `raw/notes/`: user-owned notes that express goals, hypotheses, exclusions, and preferred sub-directions
 - `raw/web/`: user-owned saved web pages that express goals, hypotheses, exclusions, and preferred sub-directions
@@ -19,10 +25,10 @@ argument-hint: "[topic] [--no-introduction]"
 ## Outputs
 
 - `wiki/` scaffold via `tools/research_wiki.py init`
-- `raw/tmp/` — `/init`-generated prepared local sources
-- `raw/discovered/` — newly downloaded papers selected by `/init` (only when discovery is enabled)
+- `raw/tmp/` — generated prepared local sources reused by `/init` and direct local `/ingest`
+- `raw/discovered/` — newly downloaded papers selected by `/init` when discovery is enabled
 - `wiki/Summary/{area}.md`, `wiki/topics/{topic}.md`, provisional `wiki/ideas/{slug}.md`, `wiki/concepts/{slug}.md`, `wiki/claims/{slug}.md`
-- `wiki/papers/*.md` plus paper-derived concepts/claims/people via parallel `/ingest`
+- `wiki/papers/*.md` plus paper-derived concepts / claims / people via parallel `/ingest`
 - updated `wiki/index.md`, `wiki/log.md`, `wiki/graph/edges.jsonl`, `wiki/graph/context_brief.md`, `wiki/graph/open_questions.md`
 - `.checkpoints/init-prepare.json`, `.checkpoints/init-plan.json`, `.checkpoints/init-sources.json`
 
@@ -31,8 +37,8 @@ argument-hint: "[topic] [--no-introduction]"
 ### Reads
 
 - `raw/papers/`, `raw/notes/`, `raw/web/`
-- `.checkpoints/init-prepare.json` and `.checkpoints/init-sources.json` for resume / fan-out
-- `wiki/index.md` plus existing `wiki/topics/`, `wiki/ideas/`, `wiki/concepts/`, `wiki/claims/` for resume and duplicate avoidance
+- `.checkpoints/init-prepare.json` and `.checkpoints/init-sources.json` for resume, planning, and fan-out
+- `wiki/index.md` plus existing `wiki/topics/`, `wiki/ideas/`, `wiki/concepts/`, `wiki/claims/` for duplicate avoidance and scaffold alignment
 
 ### Writes
 
@@ -48,7 +54,7 @@ argument-hint: "[topic] [--no-introduction]"
 
 ## Workflow
 
-**Pre-condition**: working directory is the project root containing `wiki/`, `raw/`, `tools/`. Set `WIKI_ROOT=wiki/`. Resolve `PYTHON_BIN` once and reuse it for every Python command during `/init` so the workflow stays on the same interpreter that `setup.sh` populated:
+**Pre-condition**: working directory is the project root containing `wiki/`, `raw/`, and `tools/`. Set `WIKI_ROOT=wiki/`. Resolve `PYTHON_BIN` once and reuse it for every Python command during `/init` so the workflow stays on the interpreter that `setup.sh` prepared:
 
 ```bash
 if [ -x .venv/bin/python ]; then
@@ -72,17 +78,21 @@ Create the standard wiki directories, `graph/`, `outputs/`, `index.md`, and `log
 ### Step 2: Prepare local inputs into `raw/tmp/`
 
 ```bash
-"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json
+"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --pdf-titles-json .checkpoints/init-pdf-titles.json --output-manifest .checkpoints/init-prepare.json
 ```
 
-- decode local PDFs into synthetic `.tex` under `raw/tmp/` when possible
-- for PDFs that lack an embedded arXiv ID, attempt title-based recovery via Semantic Scholar search; when an arXiv ID is recovered successfully, prefer the fetched raw TeX source from arXiv (`raw/tmp/papers/...-arxiv-src/`) over the synthetic `.tex`
+- before running `prepare`, inspect each local PDF and write the recovery handoff to `.checkpoints/init-pdf-titles.json` as either `{ "raw/papers/foo.pdf": "Recovered Paper Title" }` or `{ "raw/papers/foo.pdf": { "title": "Recovered Paper Title", "arxiv_id": "2401.00001" } }` when a confident arXiv ID is already known
+- use `"$PYTHON_BIN" tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"] [--arxiv-id "<recovered-arxiv-id>"]` for local paper normalization
+- local PDF recovery order is strict: handed-off arXiv ID or filename/path arXiv ID -> agent-recovered title via Semantic Scholar -> fetched arXiv source -> synthetic `.tex`
+- when the agent supplied a PDF title, treat that title as authoritative for the prepared manifest; fetched/source titles are sanitized fallback metadata only and must not overwrite it
+- do not use PDF metadata or body text as arXiv-ID hints during prepare
+- metadata or filename titles may remain as provisional display labels only; they are not trusted identity or title-search inputs
 - keep notes/web on their original source paths; `/init` reads them directly during planning
 - set each local paper's `canonical_ingest_path` to a prepared `raw/tmp/` path when available; otherwise fall back to the original `raw/papers/...` path
-- record warnings for failed decode / arXiv source fetch rather than aborting `/init`
-- save the manifest to `.checkpoints/init-prepare.json`
+- record warnings for failed decode / title recovery / arXiv source fetch rather than aborting `/init`
+- see `references/prepare-and-discovery.md` for the prepare decision tree and source-preference rules
 
-### Step 3: Build the discovery plan, trim it, and write the final source manifest
+### Step 3: Plan discovery, trim the final set, and write the source manifest
 
 ```bash
 "$PYTHON_BIN" tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json
@@ -90,52 +100,18 @@ Create the standard wiki directories, `graph/`, `outputs/`, `index.md`, and `log
 
 - `mode=seeded` when the prepare manifest contains at least one parseable local paper; otherwise `mode=bootstrap`
 - `plan` must read `.checkpoints/init-prepare.json` instead of rescanning `raw/`
-- `raw/notes/` and `raw/web/` signals are read directly from the original source files
-- if multiple local copies of the same paper exist, prefer better local sources in this order: original local `.tex` > archive-extracted source `.tex` or fetched arXiv source directory > PDF-derived synthetic `.tex` > raw `.pdf`
-- if Chinese note or web content is detected, preserve a planner warning that extraction/ranking may be less reliable and treat provisional outputs as lower-confidence
-- when `topic` is omitted in seeded mode, derive discovery and ranking cues from local paper titles/abstracts plus notes/web signals instead of refusing to plan
-- if seeded discovery adds no external papers, proceed with the user-owned paper set instead of treating that as a fatal planner error
-- when both `topic` and notes/web keywords are absent, bootstrap discovery has no query to search with, so it must surface that as a planner error instead of issuing an empty search
-- over-pick a shortlist of **10-12** candidates
-- use S2 citations/references/search plus optional DeepXiv search
-- when DeepXiv search is available, explicitly use returned `relevance_score` inside tool scoring rather than merely noting it in prose
-- if `SEMANTIC_SCHOLAR_API_KEY` is unset, continue anyway but record the slower public-rate-limit discovery path as a planner warning
-- planner output, warnings, and errors must be saved to `.checkpoints/init-plan.json`
-
-Planner policy:
-
-- relevance = 30
-- freshness = 20
-- anchor/connectivity bonus = 20
-- survey/benchmark/overview bonus = 15
-- citation/centrality = 15
-- prefer a survey if one is available
-- allow at most one older canonical anchor slot, and only in bootstrap or very roomy seeded cases
-- in seeded mode with limited introduced capacity, do not reserve an older anchor up front; freshness should dominate and older external non-survey papers must not pile up via citation advantage
-- otherwise freshness wins close decisions
-- seeded mode computes anchor bonus from user papers first, then notes/web priorities
-- bootstrap mode searches first, then expands citations/references from the strongest initial candidates
-
-LLM trim policy:
-
+- planner policy is qualitative at the skill layer: favor relevance, freshness, connectivity, and survey coverage
+- in seeded mode with limited introduced capacity, avoid over-prioritizing older citation-heavy anchors
+- in bootstrap mode, one older canonical anchor may be useful when it improves coverage
+- when DeepXiv search is available, use returned `relevance_score` in tool scoring rather than merely noting it in prose
+- exact ranking weights, shortlist constants, and threshold math belong to `tools/init_discovery.py`; treat the tool as the implementation authority and do not restate or override its constants in LLM reasoning
 - read `.checkpoints/init-plan.json` and explicitly trim the over-picked `shortlist` to a final **8-10** papers total before `fetch`
-- do not skip the trim step even if the shortlist already looks reasonable
-- keep all parseable user-owned papers by default, then use the remaining slots for introduced papers
-- if the user already provided more than 10 parseable papers, add no new papers
-- prefer one survey/overview when available, at most one older canonical anchor when it is actually useful, and fresh representatives across distinct clusters
-- when the user already supplied a substantial seed set, freshness should dominate and older canonical papers should be further deprioritized
-- "`at most one` older canonical anchor" is a ceiling, not a requirement
-- before `fetch`, emit an explicit final selection artifact in the workflow/response that includes: `shortlist_count`, `final_count`, and the exact final `candidate_id` list in shortlist order
-- if `final_count` is outside **8-10**, stop and revise the final selection before `fetch`, unless `--no-introduction` is active or the user already supplied more than 10 parseable papers
-- call `fetch` only with the exact final selected `candidate_id`s; never forward the whole shortlist implicitly or pass all shortlist IDs by default
+- emit an explicit final selection artifact before `fetch` with `shortlist_count`, `final_count`, and the exact final `candidate_id` list in shortlist order
+- if `final_count` falls outside **8-10**, stop and revise the final selection before `fetch`, unless `--no-introduction` is active or the user already supplied more than 10 parseable papers
+- if `--no-introduction` is present, only use this branch when the user explicitly requested local-only behavior; still run `fetch` with zero external IDs so it writes `.checkpoints/init-sources.json`
+- see `references/planner-policy.md` for planner behavior, trim expectations, and source-of-truth boundaries
 
-If `--no-introduction` is present:
-
-- only use this branch when the user explicitly requested local-only behavior
-- final paper set = all parseable user papers from `.checkpoints/init-prepare.json`
-- still run `fetch` with zero external IDs so it writes `.checkpoints/init-sources.json`
-
-Otherwise run:
+Then run:
 
 ```bash
 "$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id> --id <candidate-id>
@@ -143,9 +119,7 @@ Otherwise run:
 
 - external papers downloaded by `/init` go to `raw/discovered/`, never `raw/papers/`
 - never fetch a paper that is already represented by a prepared local source from `raw/tmp/`
-- `.checkpoints/init-sources.json` is the single source of truth for Step 5 ingest order
-- user-owned papers appear in `init-sources.json` with `origin=user_local` and their canonical prepared path when available
-- introduced papers appear in `init-sources.json` with `origin=introduced` and their canonical `raw/discovered/` path
+- `.checkpoints/init-sources.json` is the single source of truth for downstream ingest order
 
 ### Step 4: Create scaffold pages before paper ingest
 
@@ -164,61 +138,9 @@ Provisional note: seeded from raw/notes or raw/web during /init; pending validat
 - `ideas/`: create when the user states or strongly implies a research direction or hypothesis
 - `concepts/`: create only when the mechanism recurs across notes/web, or appears once in notes/web and once in the final paper set
 - `claims/`: create only from explicit assertive statements, never by inference
-
-For notes/web-derived claims, use:
-
-```yaml
-status: proposed
-confidence: 0.2
-source_papers: []
-evidence: []
-```
-
-Do not create `people/` pages or `foundations/` pages from `/init`. Update `wiki/index.md` for scaffold pages created directly in this step.
-
-### Step 4.5: Commit scaffold, stash unrelated dirty files, verify merge safety
-
-Before spawning subagents:
-
-- run `git status --short`
-- treat files under `wiki/`, `raw/papers/`, `raw/tmp/`, `raw/discovered/`, and `.checkpoints/init-*.json` as scaffold files
-- stash unrelated dirty files outside those paths:
-
-```bash
-UNRELATED=$(git status --short | awk '{print $2}' | grep -Ev '^(wiki/|raw/papers/|raw/tmp/|raw/discovered/|\.checkpoints/init-)' || true)
-if [ -n "$UNRELATED" ]; then
-  git stash push -u -m "init-unrelated-dirty-$(date +%Y%m%d-%H%M%S)" -- $UNRELATED
-fi
-```
-
-- save the stash ref:
-
-```bash
-STASH_REF=$(git stash list | head -1 | cut -d: -f1)
-"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session stash_ref "$STASH_REF"
-```
-
-- capture the current branch before worktree fan-out; `/init` worktree mode must run from a named branch, not detached HEAD:
-
-```bash
-BASE_BRANCH=$(git branch --show-current)
-if [ -z "$BASE_BRANCH" ]; then
-  echo "/init worktree mode requires a named branch; switch to or create one before continuing." >&2
-  exit 1
-fi
-"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_branch "$BASE_BRANCH"
-```
-
-- save final selected paper IDs (post-trim, not the over-picked shortlist) and planner mode into checkpoint metadata
-- verify `.gitattributes` contains `merge=union` for `wiki/log.md`, `wiki/graph/edges.jsonl`, and `wiki/index.md`
-- commit the scaffold:
-
-```bash
-git add wiki/ raw/papers/ raw/tmp/ raw/discovered/ .checkpoints/init-prepare.json .checkpoints/init-plan.json .checkpoints/init-sources.json
-git commit -m "init: scaffold before parallel ingest" --no-gpg-sign
-BASE_COMMIT=$(git rev-parse HEAD)
-"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_commit "$BASE_COMMIT"
-```
+- for notes/web-derived claims, use `status: proposed`, `confidence: 0.2`, `source_papers: []`, and `evidence: []`
+- `/prefill` is optional background seeding and is not part of `/init`
+- `/init` must not create `people/` pages directly and must not auto-create foundations
 
 ### Step 5: Parallel paper ingest with worktree isolation
 
@@ -227,30 +149,15 @@ Paper sources for this step come strictly from `.checkpoints/init-sources.json`:
 - `origin=user_local`: canonical prepared `.tex` under `raw/tmp/` when available, otherwise fallback `raw/papers/...`
 - `origin=introduced`: fetched dirs or PDFs under `raw/discovered/`
 
-Order papers by `shortlist_rank` from `init-sources.json`, not by rescanning raw folders or by raw citation count.
+Parallel ingest contract:
 
-Spawn one Agent subagent per paper with:
-
-- `run_in_background: true`
-- worktree isolation
-- a fresh temp branch created from `BASE_COMMIT`, never the already-checked-out `BASE_BRANCH`
-- a prompt that uses **relative paths only**
-- explicit INIT MODE skips
-
-For each paper, create the worktree from the scaffold commit on the current branch:
-
-```bash
-WT_BRANCH="init-${BASE_BRANCH//\//-}-<rank>-<paper-slug>"
-WT_PATH="../.worktrees/$WT_BRANCH"
-git worktree add -b "$WT_BRANCH" "$WT_PATH" "$BASE_COMMIT"
-```
-
-Do not run `git worktree add` against the current branch name itself; Git will refuse because that branch is already checked out in the main workspace.
-
-Subagent prompt requirements:
-
-- execute `/ingest` for exactly one relative source path
-- do not bypass `/ingest`
+- stash unrelated dirty files before fan-out, then record `stash_ref`, `base_branch`, and `base_commit` in checkpoint metadata
+- commit the freshly created scaffold and init manifests before fan-out so `BASE_COMMIT` actually contains the pages, manifests, and handoff metadata that subagents must branch from
+- verify `.gitattributes` contains `merge=union` for `wiki/log.md`, `wiki/graph/edges.jsonl`, and `wiki/index.md` before creating worktrees
+- `/init` worktree mode must run from a named branch, not detached HEAD
+- create each worktree from `BASE_COMMIT`, not from the already checked-out `BASE_BRANCH`
+- subagent prompts must use **relative paths only**
+- execute `/ingest` for exactly one handed-off source path; do not bypass `/ingest`
 - in INIT MODE, consume the handed-off canonical path exactly as provided
 - skip `fetch_s2.py citations`
 - skip `fetch_s2.py references`
@@ -258,28 +165,24 @@ Subagent prompt requirements:
 - skip per-subagent `rebuild-context-brief`
 - skip per-subagent `rebuild-open-questions`
 - skip conflict-prone topic writes
-- still run `find-similar-claim` and `find-similar-concept`
-- commit the result inside the worktree before exiting
+- commit the ingest result inside the worktree before exiting so fan-in merges a real paper-specific commit instead of an empty branch
+- see `references/parallel-ingest.md` for worktree commands, merge order, fan-in, and cleanup
 
-After all agents complete:
+### Step 6: Fan-in, rebuild, and final report
 
-1. switch the main workspace back to `BASE_BRANCH` if needed, then merge worktree branches sequentially there in planner order
-2. resolve true concept/claim conflicts conservatively — merge, do not multiply near-duplicates
-3. run:
+After all subagents complete:
+
+- merge worktree branches sequentially on `BASE_BRANCH`
+- resolve true concept / claim conflicts conservatively: merge, do not multiply near-duplicates
+- run:
 
 ```bash
-git switch "$BASE_BRANCH"
-git merge --no-ff "$WT_BRANCH" --no-edit
-git worktree remove "$WT_PATH"
-git branch -d "$WT_BRANCH"
 "$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/
 "$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/
 "$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/
 "$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/
 "$PYTHON_BIN" tools/lint.py wiki/ --fix
 ```
-
-### Step 6: Final report and cleanup
 
 Report separately:
 
@@ -293,39 +196,31 @@ Report separately:
 
 If `stash_ref` exists, pop it at the end. If stash pop fails, keep the checkpoint and report the failure.
 
-Also note explicitly:
-
-- `/prefill` was not used by `/init`
-- no foundations were auto-created
-- current people-page and claim-volume tightening remains a follow-up task for `/ingest`
-
 ## Constraints
 
 - `raw/papers/`, `raw/notes/`, and `raw/web/` are user-owned inputs
-- `raw/tmp/` and `raw/discovered/` are `/init`-generated handoff areas
-- `/init` may write external papers only to `raw/discovered/`, and generated prepared local sources only to `raw/tmp/`
+- `raw/tmp/` and `raw/discovered/` are generated handoff areas; direct local `/ingest` may also prepare reusable local sidecars under `raw/tmp/`
+- `/init` may write external papers only to `raw/discovered/`; `/init` and direct local `/ingest` may write generated prepared local sources to `raw/tmp/`
 - `/prefill` is optional background seeding, not part of `/init`
 - no skill other than `/prefill` may auto-create foundations
 - `/init` must not create `people/` pages directly
 - notes/web-derived pages are provisional and must carry the exact notice line above
-- no new frontmatter fields are introduced for provisional status
 - paper evidence outranks notes/web for claim confidence and concept consolidation
 - all paper ingest must run through parallel `/ingest` subagents with worktree isolation
 - Step 5 must read paper inputs from `.checkpoints/init-sources.json`, not by ad hoc folder scanning
-- subagent prompts must use relative paths only
+- exact deterministic planner policy belongs in `tools/init_discovery.py`, not in duplicated skill constants
 
 ## Error Handling
 
 - **No parseable paper in `raw/papers/`**: enter bootstrap mode
 - **`raw/notes/` and `raw/web/` empty**: skip provisional seeding, continue
 - **PDF decode fails during prepare**: keep the local source, record the warning in `.checkpoints/init-prepare.json`, and fall back to the original path if needed
+- **No confident PDF title is recovered**: omit `--title`, allow filename/path arXiv-ID recovery only, then fall back directly to synthetic `.tex`; any metadata-or-filename title is display-only
 - **Chinese content is detected in `raw/notes/` or `raw/web/`**: keep going, but preserve a planner warning that note/web extraction and ranking may be less reliable and treat rankings plus provisional pages as lower-confidence
 - **S2 or DeepXiv unavailable**: planner falls back to the remaining sources; preserve the warning in the checkpointed plan and note degraded discovery in the report
-- **arXiv ID recovery or TeX source fetch failure for a local PDF**: record a warning in `.checkpoints/init-prepare.json`, fall back to synthetic `.tex` or the original PDF path, and continue
 - **External fetch fails for one paper**: keep the remaining final set and report the failed download
 - **Single paper ingest fails**: record it via checkpoint, skip it, continue the rest, and list it in the report
 - **Current checkout is detached HEAD**: stop before worktree fan-out and ask the user to switch to or create a named branch first
-- **Worktree branch has no commit**: stop and recover that worktree before merge
 - **stash pop fails**: keep checkpoint metadata and report the manual recovery step
 
 ## Dependencies
@@ -340,14 +235,15 @@ Also note explicitly:
 - `"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/`
 - `"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/`
 - `"$PYTHON_BIN" tools/research_wiki.py log wiki/ "<message>"`
-- `"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json`
+- `"$PYTHON_BIN" tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"]`
+- `"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --pdf-titles-json .checkpoints/init-pdf-titles.json --output-manifest .checkpoints/init-prepare.json`
 - `"$PYTHON_BIN" tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json`
 - `"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id>`
 - `"$PYTHON_BIN" tools/lint.py wiki/ --fix`
 
 ### Skills
 
-- `/ingest` — one paper per subagent, INIT MODE
+- `/ingest` — one paper per subagent, in INIT MODE
 
 ### External APIs used by `init_discovery.py`
 

--- a/i18n/en/skills/init/references/parallel-ingest.md
+++ b/i18n/en/skills/init/references/parallel-ingest.md
@@ -1,0 +1,69 @@
+# /init Parallel Ingest
+
+Use this reference when `/init` is handing sources to parallel `/ingest` subagents and merging their work back.
+
+## Pre-Fan-Out Safety
+
+- Run `git status --short`.
+- Treat files under `wiki/`, `raw/papers/`, `raw/tmp/`, `raw/discovered/`, and `.checkpoints/init-*.json` as scaffold files.
+- Stash unrelated dirty files outside those paths.
+- Verify `.gitattributes` contains `merge=union` for `wiki/log.md`, `wiki/graph/edges.jsonl`, and `wiki/index.md`.
+- Commit the scaffold before fan-out so `BASE_COMMIT` contains the generated pages and manifests that every worktree must inherit:
+
+```bash
+git add wiki/ raw/papers/ raw/tmp/ raw/discovered/ .checkpoints/init-prepare.json .checkpoints/init-plan.json .checkpoints/init-sources.json
+git commit -m "init: scaffold before parallel ingest" --no-gpg-sign
+BASE_COMMIT=$(git rev-parse HEAD)
+```
+
+- Record `stash_ref`, `base_branch`, and `base_commit` with `tools/research_wiki.py checkpoint-set-meta`.
+- `/init` worktree mode requires a named branch; stop on detached HEAD.
+
+## Worktree Creation
+
+For each paper, create the worktree from the scaffold commit on the current branch:
+
+```bash
+WT_BRANCH="init-${BASE_BRANCH//\//-}-<rank>-<paper-slug>"
+WT_PATH="../.worktrees/$WT_BRANCH"
+git worktree add -b "$WT_BRANCH" "$WT_PATH" "$BASE_COMMIT"
+```
+
+- Do not run `git worktree add` against the current branch name itself; Git will refuse because that branch is already checked out in the main workspace.
+- Order papers by `shortlist_rank` from `.checkpoints/init-sources.json`, not by rescanning raw folders or by raw citation count.
+
+## Subagent Prompt Contract
+
+- Execute `/ingest` for exactly one relative source path.
+- Do not bypass `/ingest`.
+- In INIT MODE, consume the handed-off canonical path exactly as provided.
+- Skip `fetch_s2.py citations`.
+- Skip `fetch_s2.py references`.
+- Skip per-subagent `rebuild-index`.
+- Skip per-subagent `rebuild-context-brief`.
+- Skip per-subagent `rebuild-open-questions`.
+- Skip conflict-prone topic writes.
+- Commit the result inside the worktree before exiting so fan-in merges a real ingest commit.
+
+## Fan-In
+
+After all agents complete:
+
+1. Switch the main workspace back to `BASE_BRANCH` if needed, then merge worktree branches sequentially there in planner order.
+2. Resolve true concept/claim conflicts conservatively: merge, do not multiply near-duplicates.
+3. Merge only committed worktree branches. A branch with no ingest commit is an error to stop and fix, not something to merge through.
+3. Run:
+
+```bash
+git switch "$BASE_BRANCH"
+git merge --no-ff "$WT_BRANCH" --no-edit
+git worktree remove "$WT_PATH"
+git branch -d "$WT_BRANCH"
+"$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/
+"$PYTHON_BIN" tools/lint.py wiki/ --fix
+```
+
+If `stash_ref` exists, pop it at the end. If stash pop fails, keep the checkpoint and report the failure.

--- a/i18n/en/skills/init/references/planner-policy.md
+++ b/i18n/en/skills/init/references/planner-policy.md
@@ -1,0 +1,27 @@
+# /init Planner Policy
+
+Use this reference when reading `.checkpoints/init-plan.json`, trimming the shortlist, or interpreting planner warnings and errors.
+
+## Behavioral Policy
+
+- In seeded mode, derive discovery and ranking cues from local paper titles/abstracts plus notes/web signals when `topic` is omitted.
+- In bootstrap mode, if both `topic` and notes/web keywords are absent, surface a planner error instead of issuing an empty search.
+- Favor relevance, freshness, connectivity, and survey coverage.
+- Prefer one survey/overview when it improves coverage.
+- In seeded mode with limited introduced capacity, freshness should dominate and older external non-survey papers should not pile up via citation advantage.
+- In bootstrap mode or unusually roomy seeded cases, one older canonical anchor may be acceptable when it materially improves coverage.
+- When Chinese note or web content is detected, keep a planner warning that extraction/ranking may be less reliable and treat provisional outputs as lower-confidence.
+- If `SEMANTIC_SCHOLAR_API_KEY` is unset, continue anyway and preserve the slower public-rate-limit path as a planner warning.
+
+## LLM Trim Expectations
+
+- Read `.checkpoints/init-plan.json` and explicitly trim the over-picked shortlist before `fetch`.
+- Do not skip the trim step even if the shortlist already looks reasonable.
+- Emit a final selection artifact before `fetch` containing `shortlist_count`, `final_count`, and the final `candidate_id` list in shortlist order.
+- If the final count is out of range, revise the selection before `fetch` unless a documented exception applies.
+
+## Source Of Truth Boundary
+
+- `tools/init_discovery.py` is the implementation authority for exact weights, thresholds, shortlist constants, and scoring math.
+- `SKILL.md` and this reference describe orchestration and behavioral expectations only.
+- Do not duplicate numeric planner constants here or override tool-owned policy during LLM reasoning.

--- a/i18n/en/skills/init/references/prepare-and-discovery.md
+++ b/i18n/en/skills/init/references/prepare-and-discovery.md
@@ -1,0 +1,47 @@
+# /init Prepare And Discovery
+
+Use this reference when `/init` is preparing local inputs, selecting the final paper set, or writing `.checkpoints/init-sources.json`.
+
+## Prepare Flow
+
+- Run `"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --pdf-titles-json .checkpoints/init-pdf-titles.json --output-manifest .checkpoints/init-prepare.json`.
+- Before preparing local PDFs, recover confident titles when possible and write `.checkpoints/init-pdf-titles.json` as either `{ "raw/papers/foo.pdf": "Recovered Paper Title" }` or `{ "raw/papers/foo.pdf": { "title": "Recovered Paper Title", "arxiv_id": "2401.00001" } }` when a confident arXiv ID is already known.
+- `tools/init_discovery.py prepare` must pass those recovered titles and IDs into `"$PYTHON_BIN" tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"] [--arxiv-id "<recovered-arxiv-id>"]`.
+- `tools/init_discovery.py prepare` must delegate local paper normalization to the same helper and reuse pre-staged `raw/tmp/` artifacts when they already exist.
+- For local PDFs, use this recovery order only: handed-off arXiv ID or filename/path arXiv ID -> title-based Semantic Scholar recovery when a confident title was supplied -> fetched arXiv source -> synthetic `.tex`.
+- When the agent supplied a confident PDF title, that title is authoritative for the prepared manifest. Sanitized titles from fetched TeX are fallback metadata only and must not overwrite the agent title.
+- Do not use PDF metadata or PDF body text as arXiv-ID hints during prepare.
+- When arXiv ID recovery succeeds, prefer fetched raw TeX source under `raw/tmp/papers/...-arxiv-src/` over synthetic `.tex`.
+- If no confident PDF title is available, omit `--title`; if no confident arXiv ID is available, omit `--arxiv-id`; then allow filename/path arXiv-ID recovery only and fall back directly to synthetic `.tex`. Metadata or filename titles remain display-only.
+
+## Source Preference Rules
+
+- Prefer local sources in this order: original local `.tex` > archive-extracted source `.tex` or fetched arXiv source directory > PDF-derived synthetic `.tex` > raw `.pdf`.
+- Keep notes/web on their original source paths. `/init` reads them directly during planning.
+- If the handed-off source already lives under `raw/tmp/` or `raw/discovered/`, treat that path as canonical and do not duplicate it into `raw/papers/`.
+- Set each local paper's `canonical_ingest_path` to a prepared `raw/tmp/` path when available; otherwise fall back to the original `raw/papers/...` path.
+
+## Final Selection And Fetch
+
+- `plan` must read `.checkpoints/init-prepare.json` instead of rescanning `raw/`.
+- Over-pick a shortlist first, then explicitly trim it to the documented final target before `fetch`.
+- Keep all parseable user-owned papers by default, then use remaining slots for introduced papers.
+- If seeded discovery adds no external papers, proceed with the user-owned paper set instead of treating that as a fatal planner error.
+- If the user already provided more than 10 parseable papers, add no new papers.
+- If `--no-introduction` is active, final paper set = all parseable user papers, and `fetch` still runs with zero external IDs so it writes `.checkpoints/init-sources.json`.
+
+Run:
+
+```bash
+"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id> --id <candidate-id>
+```
+
+- External papers downloaded by `/init` go to `raw/discovered/`, never `raw/papers/`.
+- Never fetch a paper that is already represented by a prepared local source from `raw/tmp/`.
+
+## Source Manifest Contract
+
+- `.checkpoints/init-sources.json` is the single source of truth for Step 5 ingest order.
+- User-owned papers appear in `init-sources.json` with `origin=user_local` and their canonical prepared path when available.
+- Introduced papers appear in `init-sources.json` with `origin=introduced` and their canonical `raw/discovered/` path.
+- Step 5 must consume the handed-off `canonical_ingest_path` exactly as written.

--- a/i18n/en/skills/setup/SKILL.md
+++ b/i18n/en/skills/setup/SKILL.md
@@ -232,7 +232,7 @@ If this is a fresh install (no `wiki/` directory):
 Configuration done. Next:
   • Put your own papers in raw/papers/ (.tex or .pdf)
   • Optional: add intent notes to raw/notes/ and saved pages to raw/web/
-  • /init will manage generated inputs under raw/discovered/ and raw/tmp/
+  • /init and direct local /ingest will manage generated inputs under raw/discovered/ and raw/tmp/
   • Run: /init [your-research-topic]
 ```
 

--- a/i18n/zh/CLAUDE.md
+++ b/i18n/zh/CLAUDE.md
@@ -26,12 +26,14 @@
 
 - 在新建或修复 wiki 页面结构、YAML、正文章节前，先打开 `docs/runtime-page-templates.zh.md`
 - 需要 graph 派生文件细节或 `index.md` / `log.md` 格式时，打开 `docs/runtime-support-files.zh.md`
+- `SKILL.md` 是 skill 的即时入口；较大的 skill 也可以在各自目录下提供按需读取的本地参考文件
+- `/init` 是这一模式的第一个具体例子：先读 `skills/init/SKILL.md`，只有在需要时再打开 `skills/init/references/*`
 
 ### `raw/` 与 `config/`
 
 - `raw/papers/`、`raw/notes/`、`raw/web/` 是用户自有输入
 - `raw/discovered/` 存放 `/init` 与 `/daily-arxiv` 抓取的外部论文
-- `raw/tmp/` 存放 `/init` 生成的本地 prepared sidecar
+- `raw/tmp/` 存放 `/init` 与直接本地 `/ingest` 使用的生成型 prepared sidecar
 - `config/` 存放环境与远程服务器模板
 
 ---
@@ -103,7 +105,7 @@
 
 ## 约束
 
-- **`raw/papers/`、`raw/notes/`、`raw/web/` 归用户所有**：把它们当作权威输入。`/init` 与 `/daily-arxiv` 只能把外部抓取论文追加到 `raw/discovered/`，并且只有 `/init` 能把本地来源的预处理 sidecar 写到 `raw/tmp/`（只增不改，绝不覆盖用户自有文件）。`/edit` 仅在用户明确要求时才允许新增 raw 来源。除此之外，所有 skill、tool，以及 `/init` 在 INIT MODE 下 fan-out 的 `/ingest` 子代理都必须把 `raw/` 视为严格只读。
+- **`raw/papers/`、`raw/notes/`、`raw/web/` 归用户所有**：把它们当作权威输入。`/init` 与 `/daily-arxiv` 只能把外部抓取论文追加到 `raw/discovered/`。`/init` 与直接本地 `/ingest` 可以把生成的本地预处理 sidecar 写到 `raw/tmp/`（只增不改，绝不覆盖用户自有文件）。`/edit` 仅在用户明确要求时才允许新增 raw 来源。`/init` 在 INIT MODE 下 fan-out 的 `/ingest` 子代理仍必须把 `raw/` 视为严格只读，并直接消费交接的 canonical path。
 - **skill 的用户可见参数归用户所有**：skill 的 `argument-hint` 中列出的 flag 与取值属于用户命令，而不是 agent 可自行决定的策略开关。不得仅根据仓库状态擅自补出、切换或删除这些参数。若用户未提供某个参数，只有在该 skill 明确写出省略时的默认或推导规则时，才可使用该默认或推导值；否则应保持未设置，必要时询问用户。不是用户可见参数的内部派生设置，skill 仍可自行推断。
 - **INIT MODE 交接由 manifest 驱动**：当 `/init` 写出 `.checkpoints/init-sources.json` 后，该 manifest 就是 ingest 顺序与规范来源路径的唯一真相来源。预处理后的本地输入应指向 `raw/tmp/`；外部引入论文应指向 `raw/discovered/`。
 - **graph/ 自动生成**：不得手动编辑 `graph/` 下的文件，仅通过 `tools/research_wiki.py` 维护。

--- a/i18n/zh/skills/ingest/SKILL.md
+++ b/i18n/zh/skills/ingest/SKILL.md
@@ -63,7 +63,7 @@ argument-hint: <local-path-or-arXiv-URL>
 1. 检测 source 类型：
    - **arXiv URL**：尝试获取 tex source（ar5iv HTML 或直接下载 .tex）；若失败则下载 PDF
    - **本地 .tex**：直接读取
-   - **本地 .pdf**：提取文本（PyMuPDF 或 vision API fallback）
+   - **本地 .pdf**：先读取 PDF，在有把握时恢复标题；如果 agent 已经拿到可信 arXiv ID，也一并保留；然后运行 `python3 tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"] [--arxiv-id "<recovered-arxiv-id>"]`；该 helper 会优先使用 handoff 进来的或 filename/path 中的 arXiv ID，再尝试 agent 标题经 Semantic Scholar 的恢复，否则就直接回退到 synthetic `.tex`。如果 agent 已经提供标题，就把它当作 authoritative title；抓取源码里的标题只能作为清洗后的 fallback metadata
    - **INIT MODE 规范交接路径**：若 `/init` 传入来自 `.checkpoints/init-sources.json` 的路径，则直接 ingest 该 `canonical_ingest_path`，不要重新扫描相邻 raw 目录
 2. 提取元数据：标题、摘要、作者列表（含机构）、发表日期、venue
 3. 提取参考文献列表（BibTeX entries 或 reference section）
@@ -383,7 +383,7 @@ Wiki: +1 paper, +{N} claims, +{M} concepts, +{K} edges | Maturity: {level} ({cov
 
 ## Constraints
 
-- **raw/ 只读**：不得修改 `raw/` 下的文件
+- **raw/ 除 canonical source prep 外只读**：把 `raw/papers/`、`raw/notes/`、`raw/web/` 当作用户自有输入。直接本地 `/ingest` 只能把生成的 prepared local sidecar 写到 `raw/tmp/`，直接 arXiv ingest 只能把抓取到的来源写到 `raw/discovered/`。INIT MODE `/ingest` 仍然只读，并且必须直接消费交接的 canonical path。
 - **INIT MODE 的来源交接具有最高优先级**：当 `/init` 从 `.checkpoints/init-sources.json` 传入 `canonical_ingest_path` 时，直接 ingest 该路径，不要重新扫描 `raw/papers/`、`raw/tmp/` 或 `raw/discovered/`
 - **graph/ 仅通过 tools 维护**：不得手动编辑 `graph/` 下的文件，仅通过 `python3 tools/research_wiki.py` 操作
 - **双向链接**：写正向链接时同步写反向链接（参照 CLAUDE.md Cross Reference 规则表）
@@ -399,7 +399,7 @@ Wiki: +1 paper, +{N} claims, +{M} concepts, +{K} edges | Maturity: {level} ({cov
 
 ## Error Handling
 
-- **来源解析失败**：tex 失败 → PDF 解析 → vision API → 报告用户手动处理。INIT MODE 下，`raw/tmp/` 中的合成 `.tex` 与 `raw/discovered/` 中的抓取源码目录 / PDF 都是合法输入，应按交接路径直接消费。
+- **来源解析失败**：tex 失败 → PDF 解析 → vision API → 报告用户手动处理。对于直接本地 PDF，如果没有恢复出可信标题，就在不带 `--title` 的情况下调用 `tools/prepare_paper_source.py`；这意味着只允许 filename/path arXiv-ID 恢复，然后立刻回退到 synthetic `.tex`。metadata 或 filename 标题只用于显示，不能驱动按标题检索。INIT MODE 下，`raw/tmp/` 中的合成 `.tex` 与 `raw/discovered/` 中的抓取源码目录 / PDF 都是合法输入，应按交接路径直接消费。
 - **S2 API 不可用**：跳过 S2 相关步骤（citations 回填、importance 使用默认值 3），在报告中注明
 - **DeepXiv API 不可用**：跳过 DeepXiv 增强步骤（TLDR、结构验证、社交指标），仅依赖 S2 + 源文件解析
 - **slug 冲突**：若生成的 slug 已存在但内容不同，追加数字后缀（如 `attention-mechanism-2`）
@@ -416,6 +416,7 @@ Wiki: +1 paper, +{N} claims, +{M} concepts, +{K} edges | Maturity: {level} ({cov
 - `python3 tools/research_wiki.py rebuild-context-brief wiki/` — 重建压缩上下文
 - `python3 tools/research_wiki.py rebuild-open-questions wiki/` — 重建知识缺口地图
 - `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+- `python3 tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"]` — 把本地来源规范化成 canonical ingest path
 - `python3 tools/fetch_s2.py paper <arxiv_id>` — 查询 Semantic Scholar
 - `python3 tools/fetch_s2.py citations <arxiv_id>` — 查询引用
 - `python3 tools/fetch_s2.py references <arxiv_id>` — 查询参考文献

--- a/i18n/zh/skills/init/SKILL.md
+++ b/i18n/zh/skills/init/SKILL.md
@@ -5,22 +5,28 @@ argument-hint: "[topic] [--no-introduction]"
 
 # /init
 
-> 从 `raw/` 搭建 wiki：先跑确定性 discovery planner，再由 LLM 做最终裁剪；`raw/notes/` 与 `raw/web/` 可种下 provisional 的 topics / ideas / concepts / claims；论文消化仍走并行 `/ingest` fan-out / fan-in。
+> 从 `raw/` 搭建 wiki：先做确定性 prepare，再跑 planner-guided discovery；`raw/notes/` 与 `raw/web/` 可种下 provisional scaffold；论文消化仍走并行 `/ingest` fan-out / fan-in。
+
+按需打开这些本地参考文件：
+
+- `references/prepare-and-discovery.md` — prepare 流程、最终选择、fetch 与 source-manifest 规则
+- `references/planner-policy.md` — planner 行为与 LLM 裁剪期望
+- `references/parallel-ingest.md` — worktree 隔离、子代理 prompt 合同、merge 与清理
 
 ## Inputs
 
 - `topic`（可选）：研究方向关键词；如果 `raw/papers/` 已经给出了 seed set，或 notes/web 已经表达了意图，就可以省略
 - `--no-introduction`（可选）：禁用外部找论文；只使用用户自有的 `raw/papers/`、`raw/notes/`、`raw/web/`
-- 参数护栏：把 `topic` 与 `--no-introduction` 视为用户输入，而不是 agent 自行决定的策略开关；不得仅根据仓库状态推断 `--no-introduction`。`raw/papers/` 非空、`raw/notes/` 或 `raw/web/` 为空、或用户省略 `topic`，都不能单独成为启用 local-only 模式的理由。只有当用户明确要求禁用外部发现时，才可使用 `--no-introduction`。
+- 参数护栏：把 `topic` 与 `--no-introduction` 视为用户输入，而不是 agent 的策略开关。不得仅根据仓库状态推断 `--no-introduction`。只有当用户明确要求禁用外部发现时，才可使用它。
 - `raw/papers/`：用户自有论文来源（`.tex`、`.pdf`、压缩包）
-- `raw/notes/`：用户笔记
-- `raw/web/`：用户提供的网页存档
+- `raw/notes/`：用户自有笔记，表达目标、假设、排除项与偏好方向
+- `raw/web/`：用户保存的网页存档
 
 ## Outputs
 
 - 通过 `tools/research_wiki.py init` 建立 `wiki/` scaffold
-- `raw/tmp/` — `/init` 生成的本地 prepared 来源
-- `raw/discovered/` — `/init` 选中的外部论文（在 `--no-introduction` 时关闭）
+- `raw/tmp/` — `/init` 与直接本地 `/ingest` 复用的生成型 prepared 来源
+- `raw/discovered/` — `/init` 选中的外部论文（启用外部发现时）
 - `wiki/Summary/{area}.md`、`wiki/topics/{topic}.md`、provisional `wiki/ideas/{slug}.md`、`wiki/concepts/{slug}.md`、`wiki/claims/{slug}.md`
 - 通过并行 `/ingest` 创建的 `wiki/papers/*.md` 与论文驱动的 concepts / claims / people
 - 更新后的 `wiki/index.md`、`wiki/log.md`、`wiki/graph/edges.jsonl`、`wiki/graph/context_brief.md`、`wiki/graph/open_questions.md`
@@ -31,7 +37,7 @@ argument-hint: "[topic] [--no-introduction]"
 ### Reads
 
 - `raw/papers/`、`raw/notes/`、`raw/web/`
-- `.checkpoints/init-prepare.json` 与 `.checkpoints/init-sources.json`，供 resume / fan-out 使用
+- `.checkpoints/init-prepare.json` 与 `.checkpoints/init-sources.json`，供 resume、planning 与 fan-out 使用
 - `wiki/index.md` 以及已有 `wiki/topics/`、`wiki/ideas/`、`wiki/concepts/`、`wiki/claims/`
 
 ### Writes
@@ -69,83 +75,51 @@ export PYTHON_BIN
 
 创建标准目录、`graph/`、`outputs/`、`index.md` 与 `log.md`。这里不要重复写第二条 init 日志。
 
-### Step 2: 先把本地输入 prepare 到 `raw/tmp/`
+### Step 2: 把本地输入 prepare 到 `raw/tmp/`
 
 ```bash
-"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json
+"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --pdf-titles-json .checkpoints/init-pdf-titles.json --output-manifest .checkpoints/init-prepare.json
 ```
 
-- 本地 PDF 能 decode 时，先转成 `raw/tmp/` 下的 synthetic `.tex`
-- 对于不含嵌入 arXiv ID 的 PDF，尝试通过 Semantic Scholar 按标题搜索恢复 arXiv ID；恢复成功后，优先使用从 arXiv 抓取的原始 TeX 源码（`raw/tmp/papers/...-arxiv-src/`），而非 synthetic `.tex`
-- notes / web 保持原始来源路径，`/init` 在 planning 阶段直接读取
-- 本地论文若存在 usable 的 prepared `.tex`，其 `canonical_ingest_path` 必须指向 `raw/tmp/`
-- decode / arXiv 源码抓取失败时记录 warning，而不是中止 `/init`
-- 输出 manifest 到 `.checkpoints/init-prepare.json`
+- 在运行 `prepare` 前，先读取每个本地 PDF，并把恢复 handoff 写入 `.checkpoints/init-pdf-titles.json`。格式既可以是 `{ "raw/papers/foo.pdf": "Recovered Paper Title" }`，也可以是在已知可信 arXiv ID 时写成 `{ "raw/papers/foo.pdf": { "title": "Recovered Paper Title", "arxiv_id": "2401.00001" } }`
+- 使用 `"$PYTHON_BIN" tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"] [--arxiv-id "<recovered-arxiv-id>"]` 做本地论文规范化
+- 本地 PDF 的恢复顺序必须严格遵守：handoff 进来的 arXiv ID 或 filename/path 中的 arXiv ID -> agent 恢复出的标题经 Semantic Scholar 搜索 -> 抓取到的 arXiv 源码 -> synthetic `.tex`
+- 如果 agent 已经提供了 PDF 标题，就把这个标题当作 prepared manifest 的 authoritative title；抓取源码里提取出的标题只能作为经过清洗后的 fallback metadata，不能反过来覆盖 agent 标题
+- prepare 阶段不得把 PDF metadata 或正文文本当作 arXiv-ID hint
+- metadata 或 filename 中的标题最多只是 provisional display label，不能当作可信 identity，也不能作为标题检索输入
+- notes/web 保持原始来源路径，`/init` 在 planning 阶段直接读取
+- 本地论文若存在 usable 的 prepared 结果，其 `canonical_ingest_path` 必须指向 `raw/tmp/`；否则回退到原始 `raw/papers/...`
+- decode / 标题恢复 / arXiv 源码抓取失败时记录 warning，而不是中止 `/init`
+- prepare 的细化决策树与来源优先级见 `references/prepare-and-discovery.md`
 
-### Step 3: 基于 prepared 输入生成 plan、裁剪 shortlist，并写出最终 source manifest
+### Step 3: 生成 discovery plan、裁剪最终论文集，并写出 source manifest
 
 ```bash
 "$PYTHON_BIN" tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json
 ```
 
-- `mode=seeded` 取决于 `.checkpoints/init-prepare.json` 中是否存在可解析本地论文；否则为 `bootstrap`
-- `plan` 必须读取 prepare manifest，而不是重新扫描 `raw/`
-- notes/web 的用户信号直接从原始来源文件读取
-- 如果同一篇本地论文出现多个副本，优先级必须明确：原始本地 `.tex` > archive 解出的源码 `.tex` 或抓取到的 arXiv 源码目录 > 由 PDF 生成的 synthetic `.tex` > 原始 `.pdf`
-- 若检测到中文 notes 或 web 内容，要保留 planner warning：当前 note/web 提取与排序对中文输入的可靠性可能更低，provisional 输出也应视为较低置信度
-- seeded 模式下如果省略 `topic`，要从本地论文标题/摘要以及 notes/web 信号里提取 discovery 与 ranking 线索，而不是直接拒绝初始化
-- 如果 seeded discovery 最终没有新增任何外部论文，也要继续用用户自带论文集往下走，而不是把它当成 fatal planner error
-- 如果 `topic` 与 notes/web 关键词都缺失，bootstrap discovery 就没有可搜索的 query；此时应把它记为 planner error，而不是发起空搜索
-- tool 先 over-pick 一个 **10-12** 篇的 shortlist
-- tool 使用 S2 的 citations / references / search，以及可选 DeepXiv search
-- 若 DeepXiv 可用，要在 tool 打分里显式使用返回的 `relevance_score`，而不是只在文字说明里提一句
-- 若 `SEMANTIC_SCHOLAR_API_KEY` 未配置，也继续执行；但要把“走公开限速、会更慢”记录为 planner warning
-- planner 输出、warnings、errors 都必须保存到 `.checkpoints/init-plan.json`
+- `mode=seeded` 取决于 prepare manifest 中是否存在可解析本地论文；否则为 `bootstrap`
+- `plan` 必须读取 `.checkpoints/init-prepare.json`，而不是重新扫描 `raw/`
+- skill 层只保留定性 planner 策略：优先 relevance、freshness、connectivity 与 survey coverage
+- 在 seeded 模式且 introduced 容量有限时，不要让偏旧且 citation 很高的 anchor 抢走太多名额
+- 在 bootstrap 模式下，如果确实有助于覆盖面，可以保留一篇偏旧 canonical anchor
+- 若 DeepXiv search 可用，要在工具打分里使用返回的 `relevance_score`，而不是只在文字里提一句
+- 精确 ranking weights、shortlist 常量与 threshold 计算都属于 `tools/init_discovery.py`；把工具视为实现层唯一权威，不要在 LLM 推理里重述或覆盖这些常量
+- 在 `fetch` 前读取 `.checkpoints/init-plan.json`，并把 over-picked 的 `shortlist` 明确裁成最终 **8-10** 篇
+- 在 `fetch` 前必须给出明确的最终选择结果，至少包含 `shortlist_count`、`final_count` 与按 shortlist 顺序排列的最终 `candidate_id` 列表
+- 若 `final_count` 不在 **8-10** 范围内，则必须先停止并修正最终选择，再执行 `fetch`；`--no-introduction` 或“用户已提供超过 10 篇可解析论文”除外
+- 若传入 `--no-introduction`，只有在用户明确要求只使用本地论文时，才走这一分支；即便如此也仍要执行 `fetch`（不给外部 ID），以写出 `.checkpoints/init-sources.json`
+- planner 行为、trim 期望与 source-of-truth 边界详见 `references/planner-policy.md`
 
-planner 评分策略：
-
-- relevance = 30
-- freshness = 20
-- anchor/connectivity bonus = 20
-- survey/benchmark/overview bonus = 15
-- citation/centrality = 15
-- 有 survey 就优先保留
-- 最多保留一个偏旧 canonical anchor，而且只应在 bootstrap 或 seeded 且最终新增容量非常宽裕时考虑
-- 在 seeded 模式且可新增论文空间有限时，不要预留偏旧 anchor；此时应让 freshness 主导，并防止偏旧的外部非 survey 论文仅凭 citation 优势堆积进入 shortlist
-- 其余近分时 freshness 优先
-- seeded 模式先看用户论文连接，再看 notes/web 偏好
-- bootstrap 模式先 search，再从最强初始候选做 citation/reference 扩展
-
-LLM 裁剪策略：
-
-- 在 `fetch` 前读取 `.checkpoints/init-plan.json`，并把 over-pick 的 `shortlist` 明确裁成最终 **8-10** 篇
-- 即使 shortlist 看起来已经“差不多”，也不得跳过裁剪步骤
-- 默认保留所有可解析的用户论文，再用剩余名额选择 introduced 论文
-- 若用户已提供超过 10 篇可解析论文，则不再新增外部论文
-- 优先保留 survey/overview、在确有帮助时至多一篇偏旧 canonical anchor，以及来自不同 cluster 的近期代表作
-- 当用户已经提供较充足的 seed set 时，应优先 freshness，并进一步降低偏旧 canonical 论文的优先级
-- “至多一篇” 是上限，不代表必须保留一篇偏旧 canonical anchor
-- 在 `fetch` 前，必须在工作流/响应中给出一个明确的最终选择结果，至少包含：`shortlist_count`、`final_count`，以及按 shortlist 顺序排列的最终 `candidate_id` 列表
-- 若 `final_count` 不在 **8-10** 范围内，则必须先停止并修正最终选择，再执行 `fetch`；`--no-introduction` 或“用户已提供超过 10 篇可解析论文”这两种已说明例外除外
-- `fetch` 只能接收最终选中的那组 `candidate_id`；禁止把整个 shortlist 默认原样转发，或默认把所有 shortlist ID 都传进去
-
-若传入 `--no-introduction`：
-
-- 只有在用户明确要求只使用本地论文时，才走这一分支
-- 最终论文集 = `.checkpoints/init-prepare.json` 中所有可解析本地论文
-- 仍然要执行 `fetch`（不给外部 ID），以写出 `.checkpoints/init-sources.json`
-
-否则运行：
+然后执行：
 
 ```bash
 "$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id> --id <candidate-id>
 ```
 
 - `/init` 下载的论文只允许写入 `raw/discovered/`，绝不写入 `raw/papers/`
-- 若某篇 shortlist 论文已经由 prepared local source 覆盖，则禁止重复抓取
-- `.checkpoints/init-sources.json` 是 Step 5 ingest 顺序的唯一真相源
-- 用户本地论文在 `init-sources.json` 中以 `origin=user_local` 记录
-- introduced 论文在 `init-sources.json` 中以 `origin=introduced` 记录，canonical path 位于 `raw/discovered/`
+- 若某篇候选已经由 prepared local source 覆盖，则禁止重复抓取
+- `.checkpoints/init-sources.json` 是下游 ingest 顺序的唯一真相源
 
 ### Step 4: 在论文 ingest 前建立 scaffold 页面
 
@@ -164,122 +138,51 @@ Provisional note: seeded from raw/notes or raw/web during /init; pending validat
 - `ideas/`：用户明确提出或强烈暗示研究方向 / 假设时创建
 - `concepts/`：技术机制在 notes/web 中反复出现，或在 notes/web 与最终论文集中各出现至少一次时创建
 - `claims/`：只允许从显式断言创建，禁止靠推断补全
-
-notes/web 派生 claim 的默认值：
-
-```yaml
-status: proposed
-confidence: 0.2
-source_papers: []
-evidence: []
-```
-
-禁止创建 `people/` 页面与 `foundations/` 页面。此阶段直接创建的 scaffold 页面要同步写入 `wiki/index.md`。
-
-### Step 4.5: commit scaffold、stash 无关脏文件、验证 merge 安全
-
-spawn subagent 前：
-
-- 运行 `git status --short`
-- 将 `wiki/`、`raw/papers/`、`raw/tmp/`、`raw/discovered/` 与 `.checkpoints/init-*.json` 视作 scaffold 文件
-- 将这些路径之外的脏文件先 stash：
-
-```bash
-UNRELATED=$(git status --short | awk '{print $2}' | grep -Ev '^(wiki/|raw/papers/|raw/tmp/|raw/discovered/|\.checkpoints/init-)' || true)
-if [ -n "$UNRELATED" ]; then
-  git stash push -u -m "init-unrelated-dirty-$(date +%Y%m%d-%H%M%S)" -- $UNRELATED
-fi
-```
-
-- 记录 stash ref：
-
-```bash
-STASH_REF=$(git stash list | head -1 | cut -d: -f1)
-"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session stash_ref "$STASH_REF"
-```
-
-- 在 worktree fan-out 前先记录当前 branch；`/init` 的 worktree 模式必须运行在一个有名字的 branch 上，不能处于 detached HEAD：
-
-```bash
-BASE_BRANCH=$(git branch --show-current)
-if [ -z "$BASE_BRANCH" ]; then
-  echo "/init 的 worktree 模式要求当前位于一个命名分支；请先切换到或创建分支。" >&2
-  exit 1
-fi
-"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_branch "$BASE_BRANCH"
-```
-
-- 同时把最终选中的 paper IDs（post-trim 后的结果，不是 over-pick 的 shortlist）与 planner mode 写入 checkpoint metadata
-- 验证 `.gitattributes` 对 `wiki/log.md`、`wiki/graph/edges.jsonl`、`wiki/index.md` 使用了 `merge=union`
-- commit scaffold：
-
-```bash
-git add wiki/ raw/papers/ raw/tmp/ raw/discovered/ .checkpoints/init-prepare.json .checkpoints/init-plan.json .checkpoints/init-sources.json
-git commit -m "init: scaffold before parallel ingest" --no-gpg-sign
-BASE_COMMIT=$(git rev-parse HEAD)
-"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session base_commit "$BASE_COMMIT"
-```
+- notes/web 派生 claim 使用 `status: proposed`、`confidence: 0.2`、`source_papers: []`、`evidence: []`
+- `/prefill` 只是可选背景预填充，不属于 `/init`
+- `/init` 不得直接创建 `people/` 页面，也不得自动创建 foundations
 
 ### Step 5: 通过 worktree 隔离并行 ingest 论文
 
 本步骤的论文来源只能来自 `.checkpoints/init-sources.json`：
 
-- `origin=user_local`：优先 ingest `raw/tmp/` 中的 canonical prepared `.tex`；若 prepare 失败则回退到原始 `raw/papers/...`
+- `origin=user_local`：优先 ingest `raw/tmp/` 中的 canonical prepared `.tex`；prepare 失败时回退到原始 `raw/papers/...`
 - `origin=introduced`：ingest `raw/discovered/` 中抓取到的目录或 PDF
 
-顺序以 `init-sources.json` 中的 `shortlist_rank` 为准，而不是重新扫目录或按 citation count。
+并行 ingest 合同：
 
-为每篇论文启动一个 Agent 子代理，要求：
-
-- `run_in_background: true`
-- 使用 worktree isolation
-- 从 `BASE_COMMIT` 新建临时 branch，绝不要直接复用已经签出的 `BASE_BRANCH`
-- prompt 只使用**相对路径**
-- 明确给出 INIT MODE skip 列表
-
-每篇论文的 worktree 都应从当前 branch 上的 scaffold commit 拉出：
-
-```bash
-WT_BRANCH="init-${BASE_BRANCH//\//-}-<rank>-<paper-slug>"
-WT_PATH="../.worktrees/$WT_BRANCH"
-git worktree add -b "$WT_BRANCH" "$WT_PATH" "$BASE_COMMIT"
-```
-
-不要对当前 branch 名直接执行 `git worktree add`；Git 会因为该 branch 已经在主工作区签出而拒绝。
-
-子代理 prompt 必须要求：
-
-- 只对一个相对路径执行 `/ingest`
-- 不得绕过 `/ingest`
-- 在 INIT MODE 下，必须原样消费 handoff 给它的 canonical path，不能自己重选来源
+- fan-out 前先 stash 无关脏文件，再把 `stash_ref`、`base_branch`、`base_commit` 写入 checkpoint metadata
+- fan-out 前必须先提交刚创建的 scaffold 与 init manifests，确保 `BASE_COMMIT` 真的包含后续子代理要继承的页面、manifest 与 handoff metadata
+- 创建 worktree 前先验证 `.gitattributes` 对 `wiki/log.md`、`wiki/graph/edges.jsonl`、`wiki/index.md` 使用了 `merge=union`
+- `/init` 的 worktree 模式必须运行在一个命名分支上，不能处于 detached HEAD
+- 每个 worktree 都必须从 `BASE_COMMIT` 拉出，而不是复用已经签出的 `BASE_BRANCH`
+- 子代理 prompt 只能使用**相对路径**
+- 只对一个 handoff 进来的 source path 执行 `/ingest`，不得绕过 `/ingest`
+- 在 INIT MODE 下，必须原样消费 handoff 给它的 canonical path
 - 跳过 `fetch_s2.py citations`
 - 跳过 `fetch_s2.py references`
 - 跳过每个子代理自己的 `rebuild-index`
 - 跳过每个子代理自己的 `rebuild-context-brief`
 - 跳过每个子代理自己的 `rebuild-open-questions`
 - 跳过易冲突 topic 写入
-- 仍然必须运行 `find-similar-claim` 与 `find-similar-concept`
-- 退出前必须在各自 worktree 内提交 ingest 结果
+- 子代理退出前必须在各自 worktree 内提交 ingest 结果，避免 fan-in 时 merge 到空 branch
+- worktree 命令、merge 顺序、fan-in 与清理见 `references/parallel-ingest.md`
+
+### Step 6: fan-in、rebuild 与最终报告
 
 全部子代理完成后：
 
-1. 如有需要先切回 `BASE_BRANCH`，再按 planner 顺序在该 branch 上逐个 merge worktree branch
-2. concept / claim 冲突默认保守合并，不要扩散近重复页面
-3. 运行：
+- 在 `BASE_BRANCH` 上按顺序 merge worktree branches
+- concept / claim 冲突默认保守合并，不要扩散 near-duplicate 页面
+- 执行：
 
 ```bash
-git switch "$BASE_BRANCH"
-git merge --no-ff "$WT_BRANCH" --no-edit
-git worktree remove "$WT_PATH"
-git branch -d "$WT_BRANCH"
 "$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/
 "$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/
 "$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/
 "$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/
 "$PYTHON_BIN" tools/lint.py wiki/ --fix
 ```
-
-### Step 6: 最终报告与清理
 
 报告中必须分开列出：
 
@@ -293,44 +196,36 @@ git branch -d "$WT_BRANCH"
 
 若 `stash_ref` 存在，在最后再 pop。若 stash pop 失败，保留 checkpoint 并在报告中说明。
 
-同时显式说明：
-
-- `/prefill` 没有参与本次 `/init`
-- 没有自动创建 foundations
-- `people/` 与 claim 数量控制仍是后续 `/ingest` 任务
-
 ## Constraints
 
 - `raw/papers/`、`raw/notes/`、`raw/web/` 是用户自有输入
-- `raw/tmp/` 与 `raw/discovered/` 是 `/init` 生成的 handoff 区
-- `/init` 只能把外部论文写到 `raw/discovered/`，把生成的 prepared local source 写到 `raw/tmp/`
-- `/prefill` 只是可选背景预填充，不属于 `/init`
+- `raw/tmp/` 与 `raw/discovered/` 是生成型 handoff 区；直接本地 `/ingest` 也可以在 `raw/tmp/` 下准备可复用的 local sidecar
+- `/init` 只能把外部论文写到 `raw/discovered/`；`/init` 与直接本地 `/ingest` 可以把生成的 prepared local source 写到 `raw/tmp/`
+- `/prefill` 是可选背景预填充，不属于 `/init`
 - 只有 `/prefill` 可以自动创建 foundations
 - `/init` 不得直接创建 `people/` 页面
 - notes/web 派生页面必须包含上面的 exact provisional notice
-- provisional 状态不引入新的 frontmatter 字段
 - 对 claim 置信度与 concept 合并，论文证据永远高于 notes/web
 - 所有论文 ingest 必须通过并行 `/ingest` 子代理执行
-- Step 5 必须读取 `.checkpoints/init-sources.json`，不得临时扫描 `raw/papers/` / `raw/tmp/` / `raw/discovered/`
-- 子代理 prompt 只能出现相对路径
+- Step 5 必须读取 `.checkpoints/init-sources.json`，不得临时扫描目录
+- 精确的 planner 常量属于 `tools/init_discovery.py`，不属于重复写在 skill 文档中的常量
 
 ## Error Handling
 
 - **`raw/papers/` 无可解析论文**：自动切换到 bootstrap 模式
 - **`raw/notes/` 与 `raw/web/` 为空**：跳过 provisional seeding，继续
-- **prepare 阶段的 PDF decode 失败**：把 warning 记入 `.checkpoints/init-prepare.json`，必要时回退到原始路径
-- **`raw/notes/` 或 `raw/web/` 中检测到中文内容**：继续执行，但要保留 planner warning，说明当前 note/web 提取与排序对中文输入的可靠性可能更低，并把 rankings 与 provisional 页面视为较低置信度
+- **prepare 阶段的 PDF decode 失败**：保留本地来源，把 warning 记入 `.checkpoints/init-prepare.json`，必要时回退到原始路径
+- **没有恢复出可信 PDF 标题**：省略 `--title`，只允许走 filename/path arXiv-ID 恢复，然后直接回退到 synthetic `.tex`；metadata 或 filename 标题只用于显示
+- **`raw/notes/` 或 `raw/web/` 中检测到中文内容**：继续执行，但要保留 planner warning，说明 note/web 提取与排序可能更不可靠，并把 rankings 与 provisional 页面视为较低置信度
 - **S2 或 DeepXiv 不可用**：planner 使用剩余来源并继续执行；把 warning 保留在 checkpoint plan 中，并在最终报告里注明 discovery 降级
-- **本地 PDF 的 arXiv ID 恢复或 TeX 源码抓取失败**：把 warning 记入 `.checkpoints/init-prepare.json`，回退到 synthetic `.tex` 或原始 PDF 路径，然后继续
 - **某篇外部论文下载失败**：保留其余最终论文集，报告失败项
 - **单篇 ingest 失败**：写 checkpoint，跳过该篇，继续其他论文，并在最终报告中列出
 - **当前 checkout 处于 detached HEAD**：在 worktree fan-out 前停止，并要求用户先切换到或创建一个命名分支
-- **worktree branch 没有 commit**：停止并先修复该 worktree，再进入 merge
 - **stash pop 失败**：保留 checkpoint metadata，并给出手动恢复提示
 
 ## Dependencies
 
-### Tools (via Bash)
+### Tools（via Bash）
 
 - `"$PYTHON_BIN" tools/research_wiki.py init wiki/`
 - `"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session <key> <value>`
@@ -340,7 +235,8 @@ git branch -d "$WT_BRANCH"
 - `"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/`
 - `"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/`
 - `"$PYTHON_BIN" tools/research_wiki.py log wiki/ "<message>"`
-- `"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json`
+- `"$PYTHON_BIN" tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"]`
+- `"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --pdf-titles-json .checkpoints/init-pdf-titles.json --output-manifest .checkpoints/init-prepare.json`
 - `"$PYTHON_BIN" tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json`
 - `"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id>`
 - `"$PYTHON_BIN" tools/lint.py wiki/ --fix`

--- a/i18n/zh/skills/init/references/parallel-ingest.md
+++ b/i18n/zh/skills/init/references/parallel-ingest.md
@@ -1,0 +1,69 @@
+# /init Parallel Ingest
+
+当 `/init` 需要把来源交给并行 `/ingest` 子代理并把结果 merge 回来时，打开此参考文件。
+
+## Fan-out 前的安全步骤
+
+- 运行 `git status --short`。
+- 将 `wiki/`、`raw/papers/`、`raw/tmp/`、`raw/discovered/` 与 `.checkpoints/init-*.json` 视作 scaffold 文件。
+- 先 stash 这些路径之外的无关脏文件。
+- 先验证 `.gitattributes` 对 `wiki/log.md`、`wiki/graph/edges.jsonl`、`wiki/index.md` 使用了 `merge=union`。
+- fan-out 前先提交 scaffold，确保 `BASE_COMMIT` 真的包含所有生成的页面与 manifests：
+
+```bash
+git add wiki/ raw/papers/ raw/tmp/ raw/discovered/ .checkpoints/init-prepare.json .checkpoints/init-plan.json .checkpoints/init-sources.json
+git commit -m "init: scaffold before parallel ingest" --no-gpg-sign
+BASE_COMMIT=$(git rev-parse HEAD)
+```
+
+- 用 `tools/research_wiki.py checkpoint-set-meta` 记录 `stash_ref`、`base_branch`、`base_commit`。
+- `/init` 的 worktree 模式要求当前位于一个命名分支上；detached HEAD 必须先停止。
+
+## 创建 Worktree
+
+每篇论文的 worktree 都应从 scaffold commit 拉出：
+
+```bash
+WT_BRANCH="init-${BASE_BRANCH//\//-}-<rank>-<paper-slug>"
+WT_PATH="../.worktrees/$WT_BRANCH"
+git worktree add -b "$WT_BRANCH" "$WT_PATH" "$BASE_COMMIT"
+```
+
+- 不要对当前 branch 名直接执行 `git worktree add`；Git 会因为该 branch 已经在主工作区签出而拒绝。
+- 论文顺序以 `.checkpoints/init-sources.json` 的 `shortlist_rank` 为准，而不是重新扫目录或按 citation count。
+
+## 子代理 Prompt 合同
+
+- 只对一个相对路径执行 `/ingest`。
+- 不得绕过 `/ingest`。
+- 在 INIT MODE 下，必须原样消费 handoff 给它的 canonical path。
+- 跳过 `fetch_s2.py citations`。
+- 跳过 `fetch_s2.py references`。
+- 跳过每个子代理自己的 `rebuild-index`。
+- 跳过每个子代理自己的 `rebuild-context-brief`。
+- 跳过每个子代理自己的 `rebuild-open-questions`。
+- 跳过易冲突 topic 写入。
+- 退出前必须在各自 worktree 内提交结果，确保 fan-in merge 的是实际 ingest commit。
+
+## Fan-in
+
+全部子代理完成后：
+
+1. 如有需要先切回 `BASE_BRANCH`，再按 planner 顺序在该 branch 上逐个 merge worktree branch。
+2. concept / claim 冲突默认保守合并，不要扩散 near-duplicate 页面。
+3. 只 merge 已经产生 ingest commit 的 worktree branch。若某个 branch 没有提交结果，应先停止并修复，而不是硬合并。
+4. 运行：
+
+```bash
+git switch "$BASE_BRANCH"
+git merge --no-ff "$WT_BRANCH" --no-edit
+git worktree remove "$WT_PATH"
+git branch -d "$WT_BRANCH"
+"$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/
+"$PYTHON_BIN" tools/lint.py wiki/ --fix
+```
+
+若 `stash_ref` 存在，在最后再 pop。若 stash pop 失败，保留 checkpoint 并在报告中说明。

--- a/i18n/zh/skills/init/references/planner-policy.md
+++ b/i18n/zh/skills/init/references/planner-policy.md
@@ -1,0 +1,27 @@
+# /init Planner Policy
+
+当 `/init` 需要读取 `.checkpoints/init-plan.json`、裁剪 shortlist、或解释 planner 的 warning / error 时，打开此参考文件。
+
+## 行为策略
+
+- seeded 模式下，如果用户省略 `topic`，就从本地论文标题/摘要以及 notes/web 信号里提取 discovery 与 ranking 线索。
+- bootstrap 模式下，如果 `topic` 与 notes/web 关键词都缺失，应把它记为 planner error，而不是发起空搜索。
+- 优先 relevance、freshness、connectivity 与 survey coverage。
+- 如有帮助，优先保留一篇 survey/overview。
+- 在 seeded 模式且 introduced 容量有限时，应让 freshness 主导，并避免偏旧外部非 survey 论文仅凭 citation 优势堆积进入结果。
+- 在 bootstrap 模式或非常宽裕的 seeded 情况下，如果确实有助于覆盖面，可以保留一篇偏旧 canonical anchor。
+- 若检测到中文 notes/web 内容，要保留 planner warning，说明提取与排序可靠性可能较低，并把 provisional 输出视为较低置信度。
+- 若 `SEMANTIC_SCHOLAR_API_KEY` 未配置，也继续执行；但要把公开限速路径记录为 planner warning。
+
+## LLM 裁剪期望
+
+- 在 `fetch` 前读取 `.checkpoints/init-plan.json`，并显式裁剪 over-picked 的 shortlist。
+- 即使 shortlist 看起来已经“差不多”，也不得跳过裁剪步骤。
+- 在 `fetch` 前给出最终选择结果，至少包含 `shortlist_count`、`final_count` 与最终 `candidate_id` 列表。
+- 如果最终数量超出允许范围，就先修正选择，再进入 `fetch`，除非命中已文档化的例外分支。
+
+## 真相源边界
+
+- `tools/init_discovery.py` 是精确 weights、thresholds、shortlist 常量与 scoring math 的唯一实现权威。
+- `SKILL.md` 与本参考文件只描述 orchestration 与行为期望。
+- 不要在这里重复写数字常量，也不要在 LLM 推理里覆盖工具拥有的确定性策略。

--- a/i18n/zh/skills/init/references/prepare-and-discovery.md
+++ b/i18n/zh/skills/init/references/prepare-and-discovery.md
@@ -1,0 +1,47 @@
+# /init Prepare And Discovery
+
+当 `/init` 需要 prepare 本地输入、选择最终论文集、或写出 `.checkpoints/init-sources.json` 时，打开此参考文件。
+
+## Prepare 流程
+
+- 执行 `"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --pdf-titles-json .checkpoints/init-pdf-titles.json --output-manifest .checkpoints/init-prepare.json`。
+- prepare 本地 PDF 前，先尽量恢复可信标题，并把结果写入 `.checkpoints/init-pdf-titles.json`。格式既可以是 `{ "raw/papers/foo.pdf": "Recovered Paper Title" }`，也可以是在已知可信 arXiv ID 时写成 `{ "raw/papers/foo.pdf": { "title": "Recovered Paper Title", "arxiv_id": "2401.00001" } }`。
+- `tools/init_discovery.py prepare` 必须把这些恢复出的标题和 ID 传给 `"$PYTHON_BIN" tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"] [--arxiv-id "<recovered-arxiv-id>"]`。
+- `tools/init_discovery.py prepare` 必须委托给同一个 helper 做本地论文规范化，并在已有预处理结果时复用现成的 `raw/tmp/` artifact。
+- 本地 PDF 只允许采用这一条恢复顺序：handoff 进来的 arXiv ID 或 filename/path 中的 arXiv ID -> 在提供可信标题时经 Semantic Scholar 按标题恢复 -> 抓取到的 arXiv 源码 -> synthetic `.tex`。
+- 如果 agent 已经提供了可信 PDF 标题，这个标题就是 prepared manifest 的 authoritative title。抓取到的 TeX 源码标题只能作为清洗后的 fallback metadata，不能覆盖 agent 标题。
+- prepare 阶段不得把 PDF metadata 或正文文本当作 arXiv-ID hint。
+- 恢复成功后，优先使用 `raw/tmp/papers/...-arxiv-src/` 下抓取到的原始 TeX 源码，而不是 synthetic `.tex`。
+- 如果拿不到可信 PDF 标题，就省略 `--title`；如果也拿不到可信 arXiv ID，就省略 `--arxiv-id`；随后只允许走 filename/path arXiv-ID 恢复，然后直接回退到 synthetic `.tex`。metadata 或 filename 标题只用于显示。
+
+## 来源优先级
+
+- 本地来源优先级：原始本地 `.tex` > archive 解出的源码 `.tex` 或抓取到的 arXiv 源码目录 > 由 PDF 生成的 synthetic `.tex` > 原始 `.pdf`。
+- notes/web 保持原始来源路径，`/init` 在 planning 阶段直接读取。
+- 如果 handoff 进来的来源已经在 `raw/tmp/` 或 `raw/discovered/` 下，就把它视为 canonical path，不要再复制进 `raw/papers/`。
+- 本地论文若存在 prepared 结果，其 `canonical_ingest_path` 必须指向 `raw/tmp/`；否则回退到原始 `raw/papers/...`。
+
+## 最终选择与 Fetch
+
+- `plan` 必须读取 `.checkpoints/init-prepare.json`，而不是重新扫描 `raw/`。
+- 先 over-pick 一个 shortlist，再在 `fetch` 前显式裁成文档规定的最终范围。
+- 默认保留所有可解析的用户论文，再用剩余名额选择 introduced 论文。
+- 如果 seeded discovery 最终没有新增外部论文，也要继续用用户自带论文集往下走，而不是把它当成 fatal planner error。
+- 如果用户已提供超过 10 篇可解析论文，则不再新增外部论文。
+- 如果 `--no-introduction` 开启，最终论文集 = 所有可解析本地论文；即便如此也仍要运行 `fetch`（不给外部 ID），以写出 `.checkpoints/init-sources.json`。
+
+执行：
+
+```bash
+"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id> --id <candidate-id>
+```
+
+- `/init` 下载的论文只允许写入 `raw/discovered/`，绝不写入 `raw/papers/`。
+- 若某篇候选已经由 prepared local source 覆盖，则禁止重复抓取。
+
+## Source Manifest 合同
+
+- `.checkpoints/init-sources.json` 是 Step 5 ingest 顺序的唯一真相源。
+- 用户本地论文在 `init-sources.json` 中以 `origin=user_local` 记录，并在可用时带上 canonical prepared path。
+- introduced 论文在 `init-sources.json` 中以 `origin=introduced` 记录，其 canonical path 位于 `raw/discovered/`。
+- Step 5 必须原样消费 handoff 过来的 `canonical_ingest_path`。

--- a/i18n/zh/skills/setup/SKILL.md
+++ b/i18n/zh/skills/setup/SKILL.md
@@ -230,7 +230,7 @@ for k in keys:
 配置完成。接下来：
   • 将你自己的论文放入 raw/papers/（.tex 或 .pdf）
   • 可选：把意图笔记放入 raw/notes/，网页存档放入 raw/web/
-  • /init 会自动管理 raw/discovered/ 与 raw/tmp/ 下的生成内容
+  • /init 与直接本地 /ingest 会自动管理 raw/discovered/ 与 raw/tmp/ 下的生成内容
   • 运行：/init [你的研究主题]
 ```
 

--- a/setup.sh
+++ b/setup.sh
@@ -164,15 +164,7 @@ for src in "$I18N_DIR/skills"/*/SKILL.md; do
     skill_dir=$(dirname "$src")
     name=$(basename "$skill_dir")
     mkdir -p ".claude/skills/$name"
-    cp "$src" ".claude/skills/$name/SKILL.md"
-    # Copy any sibling resource files (e.g. prefill/foundations-catalog.yaml)
-    for extra in "$skill_dir"/*; do
-        [ -f "$extra" ] || continue
-        case "$(basename "$extra")" in
-            SKILL.md) ;;
-            *) cp "$extra" ".claude/skills/$name/" ;;
-        esac
-    done
+    cp -R "$skill_dir"/. ".claude/skills/$name/"
 done
 mkdir -p ".claude/skills/shared-references"
 cp "$I18N_DIR/shared-references"/*.md ".claude/skills/shared-references/"

--- a/tests/test_init_discovery.py
+++ b/tests/test_init_discovery.py
@@ -13,6 +13,7 @@ import pytest
 
 sys.path.insert(0, "tools")
 import init_discovery as disc  # noqa: E402
+import prepare_paper_source as prep  # noqa: E402
 
 
 def _s2_paper(
@@ -74,11 +75,11 @@ def raw_root(tmp_path):
 def test_prepare_pdf_emits_canonical_tmp_tex(raw_root, monkeypatch):
     (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
     monkeypatch.setattr(
-        disc,
+        prep,
         "_extract_pdf_text",
         lambda _path: ("Adapter Tuning for LLMs\nAbstract\nImproves multilingual transfer.", []),
     )
-    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(prep, "s2_search", lambda *_args, **_kwargs: [])
 
     manifest = disc.prepare_inputs(raw_root)
 
@@ -91,28 +92,31 @@ def test_prepare_pdf_emits_canonical_tmp_tex(raw_root, monkeypatch):
     assert (raw_root.parent / entry["canonical_ingest_path"]).exists()
 
 
-def test_prepare_prefers_local_tex_over_pdf_for_same_paper(raw_root, monkeypatch):
+def test_prepare_keeps_unresolved_local_sources_distinct(raw_root, monkeypatch):
     (raw_root / "papers" / "paper.tex").write_text(
         "\\title{Adapter Tuning for LLMs}\n\\begin{abstract}tex version\\end{abstract}\n",
         encoding="utf-8",
     )
     (raw_root / "papers" / "paper.pdf").write_bytes(b"%PDF")
     monkeypatch.setattr(
-        disc,
+        prep,
         "_extract_pdf_text",
         lambda _path: ("Adapter Tuning for LLMs\nAbstract\npdf version", []),
     )
-    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(prep, "s2_search", lambda *_args, **_kwargs: [])
 
     manifest = disc.prepare_inputs(raw_root)
     paper_entries = [item for item in manifest["entries"] if item["source_kind"] == "paper"]
 
-    assert len(paper_entries) == 1
-    assert paper_entries[0]["source_path"] == "raw/papers/paper.tex"
-    assert paper_entries[0]["canonical_ingest_path"] == "raw/papers/paper.tex"
-    assert "translated_to_english" not in paper_entries[0]
-    assert "original_language" not in paper_entries[0]
-    assert any("duplicate local source skipped" in warning for warning in paper_entries[0]["warnings"])
+    assert len(paper_entries) == 2
+    assert {item["candidate_id"] for item in paper_entries} == {
+        "local:papers-paper-pdf",
+        "local:papers-paper-tex",
+    }
+    assert any(item["source_path"] == "raw/papers/paper.tex" for item in paper_entries)
+    assert any(item["source_path"] == "raw/papers/paper.pdf" for item in paper_entries)
+    assert all("translated_to_english" not in item for item in paper_entries)
+    assert all("original_language" not in item for item in paper_entries)
 
 
 def test_prepare_notes_keep_original_paths(raw_root):
@@ -243,11 +247,11 @@ def test_seeded_mode_without_topic_uses_local_terms_for_search_query(raw_root, m
 def test_plan_uses_prepared_manifest_canonical_paths(raw_root, monkeypatch):
     (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
     monkeypatch.setattr(
-        disc,
+        prep,
         "_extract_pdf_text",
         lambda _path: ("Adapter Tuning for LLMs\nAbstract\nImproves multilingual transfer.", []),
     )
-    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(prep, "s2_search", lambda *_args, **_kwargs: [])
     manifest = disc.prepare_inputs(raw_root)
     monkeypatch.setattr(disc, "s2_citations", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(disc, "s2_references", lambda *_args, **_kwargs: [])
@@ -848,6 +852,10 @@ def test_extract_old_style_arxiv_id():
     assert disc._extract_arxiv_id("classic identifier cs/9901001 in title") == "cs/9901001"
 
 
+def test_extract_embedded_filename_arxiv_id_strips_version():
+    assert disc._extract_arxiv_id("YOLO1506.02640v5.pdf") == "1506.02640"
+
+
 def test_download_source_rejects_archive_escape_and_falls_back_to_pdf(raw_root, monkeypatch):
     archive_bytes = io.BytesIO()
     with tarfile.open(fileobj=archive_bytes, mode="w:gz") as tar:
@@ -907,21 +915,23 @@ def test_fetch_writes_into_raw_discovered_only(raw_root, monkeypatch, tmp_path):
 def test_fetch_skips_prepared_local_duplicate_and_writes_source_manifest(raw_root, monkeypatch, tmp_path):
     (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
     monkeypatch.setattr(
-        disc,
+        prep,
         "_extract_pdf_text",
         lambda _path: ("Fetched Paper\nAbstract\nAdapter tuning setup.", []),
     )
-    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(prep, "s2_search", lambda *_args, **_kwargs: [])
+    prep.prepare_paper_source(raw_root / "papers" / "seed.pdf", raw_root, title="Fetched Paper")
     prepare_manifest = disc.prepare_inputs(raw_root)
     prepare_json = tmp_path / "prepare.json"
     prepare_json.write_text(json.dumps(prepare_manifest), encoding="utf-8")
+    local_entry = next(item for item in prepare_manifest["entries"] if item["source_kind"] == "paper")
 
     plan_json = tmp_path / "plan.json"
     plan_json.write_text(json.dumps({
         "shortlist": [
             {
-                "candidate_id": "local:fetched-paper",
-                "title": "Fetched Paper",
+                "candidate_id": local_entry["candidate_id"],
+                "title": local_entry["title"],
                 "user_owned": True,
                 "shortlist_rank": 1,
             },
@@ -957,21 +967,23 @@ def test_fetch_skips_prepared_local_duplicate_and_writes_source_manifest(raw_roo
 def test_fetch_writes_mixed_source_manifest_from_tmp_and_discovered(raw_root, monkeypatch, tmp_path):
     (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
     monkeypatch.setattr(
-        disc,
+        prep,
         "_extract_pdf_text",
         lambda _path: ("Seed Paper\nAbstract\nLocal adapter seed.", []),
     )
-    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(prep, "s2_search", lambda *_args, **_kwargs: [])
+    prep.prepare_paper_source(raw_root / "papers" / "seed.pdf", raw_root, title="Seed Paper")
     prepare_manifest = disc.prepare_inputs(raw_root)
     prepare_json = tmp_path / "prepare.json"
     prepare_json.write_text(json.dumps(prepare_manifest), encoding="utf-8")
+    local_entry = next(item for item in prepare_manifest["entries"] if item["source_kind"] == "paper")
 
     plan_json = tmp_path / "plan.json"
     plan_json.write_text(json.dumps({
         "shortlist": [
             {
-                "candidate_id": "local:seed-paper",
-                "title": "Seed Paper",
+                "candidate_id": local_entry["candidate_id"],
+                "title": local_entry["title"],
                 "user_owned": True,
                 "shortlist_rank": 1,
             },
@@ -1039,130 +1051,20 @@ def test_download_to_discovered_writes_under_raw_discovered(raw_root, monkeypatc
     assert Path(result["canonical_ingest_path"]).exists()
 
 
-def test_prepare_pdf_recovers_arxiv_id_by_title(raw_root, monkeypatch):
+def test_prepare_inputs_skips_title_search_without_agent_title(raw_root, monkeypatch):
     (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
     monkeypatch.setattr(
-        disc,
+        prep,
         "_extract_pdf_text",
-        lambda _path: ("Adapter Tuning for LLMs\nAbstract\nImproves multilingual transfer.", []),
+        lambda _path: ("Adapter Tuning for LLMs\nAbstract\nSome content.", []),
     )
+    calls = []
 
-    def _fake_s2_search(query, limit=5):
-        if "adapter tuning" in query.lower():
-            return [
-                {
-                    "title": "Adapter Tuning for LLMs",
-                    "abstract": "Improves multilingual transfer.",
-                    "authors": [{"name": "Author"}],
-                    "year": 2024,
-                    "citationCount": 50,
-                    "venue": "TestConf",
-                    "externalIds": {"ArXiv": "2401.00001"},
-                    "url": "https://arxiv.org/abs/2401.00001",
-                }
-            ]
+    def _spy_s2_search(query, limit=5):
+        calls.append(query)
         return []
 
-    monkeypatch.setattr(disc, "s2_search", _fake_s2_search)
-
-    def _fake_download(arxiv_id, dest_dir):
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        (dest_dir / "main.tex").write_text(
-            "\\title{Adapter Tuning for LLMs}\n"
-            "\\begin{abstract}\nImproves multilingual transfer.\n\\end{abstract}\n",
-            encoding="utf-8",
-        )
-        return {"success": True, "format": "directory", "error": None}
-
-    monkeypatch.setattr(disc, "_download_arxiv_source", _fake_download)
-
-    manifest = disc.prepare_inputs(raw_root)
-    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
-
-    assert entry["arxiv_id"] == "2401.00001"
-    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
-    assert entry["ingest_format"] == "directory"
-    assert (raw_root.parent / entry["canonical_ingest_path"]).exists()
-
-
-def test_prepare_pdf_prefers_arxiv_tex_over_synthetic(raw_root, monkeypatch):
-    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
-    monkeypatch.setattr(
-        disc,
-        "_extract_pdf_text",
-        lambda _path: ("Adapter Tuning for LLMs\nAbstract\nSome content.", []),
-    )
-    monkeypatch.setattr(
-        disc,
-        "s2_search",
-        lambda query, limit=5: [
-            {
-                "title": "Adapter Tuning for LLMs",
-                "externalIds": {"ArXiv": "2401.00002"},
-            }
-        ],
-    )
-
-    def _fake_download(arxiv_id, dest_dir):
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        (dest_dir / "main.tex").write_text("\\title{Adapter Tuning for LLMs}\n", encoding="utf-8")
-        return {"success": True, "format": "directory", "error": None}
-
-    monkeypatch.setattr(disc, "_download_arxiv_source", _fake_download)
-
-    manifest = disc.prepare_inputs(raw_root)
-    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
-
-    assert entry["original_format"] == "pdf"
-    assert entry["ingest_format"] == "directory"
-    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
-    assert "recovered arXiv ID" in entry["warnings"][0]
-
-
-def test_prepare_pdf_falls_back_to_synthetic_when_tex_unavailable(raw_root, monkeypatch):
-    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
-    monkeypatch.setattr(
-        disc,
-        "_extract_pdf_text",
-        lambda _path: ("Adapter Tuning for LLMs\nAbstract\nSome content.", []),
-    )
-    monkeypatch.setattr(
-        disc,
-        "s2_search",
-        lambda query, limit=5: [
-            {
-                "title": "Adapter Tuning for LLMs",
-                "externalIds": {"ArXiv": "2401.00003"},
-            }
-        ],
-    )
-    monkeypatch.setattr(
-        disc,
-        "_download_arxiv_source",
-        lambda _arxiv_id, _dest: {"success": False, "format": "", "error": "no source tarball"},
-    )
-
-    manifest = disc.prepare_inputs(raw_root)
-    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
-
-    assert entry["arxiv_id"] == "2401.00003"
-    assert entry["canonical_ingest_path"].endswith(".tex")
-    assert entry["ingest_format"] == "tex"
-    assert any("TeX source download failed" in w for w in entry["warnings"])
-
-
-def test_prepare_pdf_arxiv_recovery_warns_on_api_failure(raw_root, monkeypatch):
-    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
-    monkeypatch.setattr(
-        disc,
-        "_extract_pdf_text",
-        lambda _path: ("Adapter Tuning for LLMs\nAbstract\nSome content.", []),
-    )
-    monkeypatch.setattr(
-        disc,
-        "s2_search",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("network down")),
-    )
+    monkeypatch.setattr(prep, "s2_search", _spy_s2_search)
 
     manifest = disc.prepare_inputs(raw_root)
     entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
@@ -1170,223 +1072,173 @@ def test_prepare_pdf_arxiv_recovery_warns_on_api_failure(raw_root, monkeypatch):
     assert entry["usable"] is True
     assert entry["canonical_ingest_path"].endswith(".tex")
     assert entry["arxiv_id"] == ""
+    assert entry["title"] == "seed"
+    assert entry["candidate_id"] == "local:papers-seed-pdf"
+    assert "title_source" not in entry
+    assert not calls
 
 
-def test_prepare_pdf_skips_title_search_when_arxiv_id_in_text(raw_root, monkeypatch):
+def test_prepare_inputs_passes_pdf_titles_map(raw_root, monkeypatch):
     (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
     monkeypatch.setattr(
-        disc,
+        prep,
         "_extract_pdf_text",
-        lambda _path: (
-            "arXiv:2401.00004\nAdapter Tuning for LLMs\nAbstract\nSome content.",
-            [],
-        ),
+        lambda _path: ("Recovered Title\nAbstract\nSome content.", []),
     )
+    queries = []
 
-    calls = []
-
-    def _spy_s2_search(query, limit=5):
-        calls.append(query)
-        return []
-
-    monkeypatch.setattr(disc, "s2_search", _spy_s2_search)
+    def _fake_s2_search(query, limit=5):
+        queries.append(query)
+        return [{"title": "Recovered Title", "externalIds": {"ArXiv": "2401.00004"}}]
 
     def _fake_download(arxiv_id, dest_dir):
         dest_dir.mkdir(parents=True, exist_ok=True)
         (dest_dir / "main.tex").write_text(
-            "\\title{Adapter Tuning for LLMs}\n"
+            "\\title{Recovered Title}\n"
             "\\begin{abstract}\nSome content.\n\\end{abstract}\n",
             encoding="utf-8",
         )
         return {"success": True, "format": "directory", "error": None}
 
-    monkeypatch.setattr(disc, "_download_arxiv_source", _fake_download)
+    monkeypatch.setattr(prep, "s2_search", _fake_s2_search)
+    monkeypatch.setattr(prep, "_download_arxiv_source", _fake_download)
 
+    manifest = disc.prepare_inputs(
+        raw_root,
+        pdf_titles={"raw/papers/seed.pdf": "Recovered Title"},
+    )
+    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
+
+    assert queries == ["Recovered Title"]
+    assert entry["arxiv_id"] == "2401.00004"
+    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
+    assert entry["title"] == "Recovered Title"
+
+
+def test_prepare_inputs_keeps_agent_title_when_fetched_source_title_is_latex(raw_root, monkeypatch):
+    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("Recovered Title\nAbstract\nSome content.", []),
+    )
+
+    monkeypatch.setattr(
+        prep,
+        "s2_search",
+        lambda query, limit=5: [{"title": "Recovered Title", "externalIds": {"ArXiv": "2401.00004"}}],
+    )
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{\\vspace{-1cm}Recovered Title\\\\Extra Formatting\\vspace{-.25cm}}\n"
+            "\\begin{abstract}\\vspace{-.25cm} Some content.\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(prep, "_download_arxiv_source", _fake_download)
+
+    manifest = disc.prepare_inputs(
+        raw_root,
+        pdf_titles={"raw/papers/seed.pdf": "Recovered Title"},
+    )
+    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
+
+    assert entry["title"] == "Recovered Title"
+    assert entry["arxiv_id"] == "2401.00004"
+    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
+
+
+def test_prepare_inputs_passes_pdf_arxiv_id_map(raw_root, monkeypatch):
+    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("Recovered Title\nAbstract\nSome content.", []),
+    )
+    queries = []
+
+    def _spy_s2_search(query, limit=5):
+        queries.append(query)
+        return []
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{Recovered Title}\n"
+            "\\begin{abstract}\nSome content.\n\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(prep, "s2_search", _spy_s2_search)
+    monkeypatch.setattr(prep, "_download_arxiv_source", _fake_download)
+
+    manifest = disc.prepare_inputs(
+        raw_root,
+        pdf_titles={"raw/papers/seed.pdf": {"title": "Recovered Title", "arxiv_id": "2401.00004v3"}},
+    )
+    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
+
+    assert not queries
+    assert entry["arxiv_id"] == "2401.00004"
+    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
+    assert entry["title"] == "Recovered Title"
+
+
+def test_prepare_inputs_warns_for_unknown_pdf_title_mapping(raw_root, monkeypatch):
+    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("Recovered Title\nAbstract\nSome content.", []),
+    )
+    monkeypatch.setattr(prep, "s2_search", lambda *_args, **_kwargs: [])
+    warnings: list[str] = []
+
+    manifest = disc.prepare_inputs(
+        raw_root,
+        pdf_titles={"raw/papers/missing.pdf": "Recovered Title"},
+        warning_sink=warnings,
+    )
+
+    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
+    assert entry["title"] == "seed"
+    assert warnings == ["ignored unknown PDF title mapping: raw/papers/missing.pdf"]
+
+
+def test_prepare_inputs_reuses_agent_staged_artifact(raw_root, monkeypatch):
+    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("Recovered Title\nAbstract\nSome content.", []),
+    )
+
+    monkeypatch.setattr(
+        prep,
+        "s2_search",
+        lambda query, limit=5: [{"title": "Recovered Title", "externalIds": {"ArXiv": "2401.00004"}}],
+    )
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{Recovered Title}\n"
+            "\\begin{abstract}\nSome content.\n\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(prep, "_download_arxiv_source", _fake_download)
+    prep.prepare_paper_source(raw_root / "papers" / "seed.pdf", raw_root, title="Recovered Title")
+    monkeypatch.setattr(prep, "s2_search", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected search")))
     manifest = disc.prepare_inputs(raw_root)
     entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
 
     assert entry["arxiv_id"] == "2401.00004"
-    assert not calls  # s2_search should not have been called
-
-
-def test_guess_title_skips_conference_header():
-    text = "Published as a conference paper at ICLR 2023\nReal Paper Title Here\nAbstract\nSome content."
-    assert disc._guess_title_from_text(text, "fallback") == "Real Paper Title Here"
-
-
-def test_guess_title_skips_arxiv_line():
-    text = "arXiv:2401.00001 [cs.CL]\nActual Paper Title\nAbstract\nContent."
-    assert disc._guess_title_from_text(text, "fallback") == "Actual Paper Title"
-
-
-def test_extract_arxiv_id_from_pdf_metadata(raw_root, monkeypatch):
-    pdf_path = raw_root / "papers" / "meta.pdf"
-    pdf_path.write_bytes(b"%PDF")
-
-    class FakeDoc:
-        def __init__(self, metadata):
-            self.metadata = metadata
-        def close(self):
-            pass
-
-    class FakeFitz:
-        @staticmethod
-        def open(path):
-            return FakeDoc({"subject": "See arXiv:2106.09685", "keywords": "", "title": ""})
-
-    monkeypatch.setattr(disc, "HAS_PYMUPDF", True)
-    monkeypatch.setattr(disc, "fitz", FakeFitz())
-
-    result = disc._extract_arxiv_id_from_pdf_metadata(pdf_path)
-    assert result == "2106.09685"
-
-
-def test_extract_arxiv_id_from_pdf_metadata_tries_all_fields(raw_root, monkeypatch):
-    pdf_path = raw_root / "papers" / "meta.pdf"
-    pdf_path.write_bytes(b"%PDF")
-
-    class FakeDoc:
-        def __init__(self, metadata):
-            self.metadata = metadata
-        def close(self):
-            pass
-
-    class FakeFitz:
-        @staticmethod
-        def open(path):
-            return FakeDoc({"subject": "", "keywords": "", "title": "Paper on arXiv:2107.00001"})
-
-    monkeypatch.setattr(disc, "HAS_PYMUPDF", True)
-    monkeypatch.setattr(disc, "fitz", FakeFitz())
-
-    result = disc._extract_arxiv_id_from_pdf_metadata(pdf_path)
-    assert result == "2107.00001"
-
-
-def test_extract_arxiv_source_metadata_reads_title_and_abstract(tmp_path):
-    source_dir = tmp_path / "source"
-    source_dir.mkdir()
-    (source_dir / "main.tex").write_text(
-        "\\title{Adapter Tuning for LLMs}\n"
-        "\\begin{abstract}\nImproves multilingual transfer.\n\\end{abstract}\n",
-        encoding="utf-8",
-    )
-    result = disc._extract_arxiv_source_metadata(source_dir)
-    assert result["source_title"] == "Adapter Tuning for LLMs"
-    assert result["source_abstract"] == "Improves multilingual transfer."
-
-
-def test_extract_arxiv_source_metadata_handles_missing_title_tex(tmp_path):
-    source_dir = tmp_path / "source"
-    source_dir.mkdir()
-    (source_dir / "main.tex").write_text(
-        "\\section{Body}\nNo title here.\n",
-        encoding="utf-8",
-    )
-    result = disc._extract_arxiv_source_metadata(source_dir)
-    assert result == {"source_title": "", "source_abstract": ""}
-
-
-def test_prepare_pdf_refreshes_metadata_from_accepted_arxiv_source(raw_root, monkeypatch):
-    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
-    monkeypatch.setattr(
-        disc,
-        "_extract_pdf_text",
-        lambda _path: (
-            "Adapter Tuning\n"
-            "Abstract\n"
-            "We study efficient multilingual transfer for large language models with low-rank adapters "
-            "and parameter-efficient finetuning.",
-            [],
-        ),
-    )
-    monkeypatch.setattr(
-        disc,
-        "s2_search",
-        lambda query, limit=5: [
-            {
-                "title": "Adapter Tuning for Large Language Models",
-                "externalIds": {"ArXiv": "2401.00005"},
-            }
-        ],
-    )
-
-    def _fake_download(arxiv_id, dest_dir):
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        (dest_dir / "main.tex").write_text(
-            "\\title{Adapter Tuning for Large Language Models}\n"
-            "\\begin{abstract}\n"
-            "We study efficient multilingual transfer for large language models with low-rank adapters "
-            "and parameter-efficient finetuning.\n"
-            "\\end{abstract}\n",
-            encoding="utf-8",
-        )
-        return {"success": True, "format": "directory", "error": None}
-
-    monkeypatch.setattr(disc, "_download_arxiv_source", _fake_download)
-
-    manifest = disc.prepare_inputs(raw_root)
-    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
-
-    assert entry["title"] == "Adapter Tuning for Large Language Models"
-    assert entry["candidate_id"] == f"local:{disc.slugify('Adapter Tuning for Large Language Models')}"
-    assert entry["abstract_excerpt"].startswith("We study efficient multilingual transfer")
     assert entry["canonical_ingest_path"].endswith("-arxiv-src")
-
-
-def test_prepare_pdf_keeps_fetched_source_with_weak_local_abstract(raw_root, monkeypatch):
-    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
-    monkeypatch.setattr(
-        disc,
-        "_extract_pdf_text",
-        lambda _path: ("Adapter Tuning\nAbstract\nBrief note.", []),
-    )
-    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [
-        {"title": "Adapter Tuning for Large Language Models", "externalIds": {"ArXiv": "2401.00001"}}
-    ])
-
-    def _fake_download(arxiv_id, dest_dir):
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        (dest_dir / "main.tex").write_text(
-            "\\title{Adapter Tuning for Large Language Models}\n"
-            "\\begin{abstract}\nWe study efficient multilingual transfer for large language models.\n\\end{abstract}\n",
-            encoding="utf-8",
-        )
-        return {"success": True, "format": "directory", "error": None}
-
-    monkeypatch.setattr(disc, "_download_arxiv_source", _fake_download)
-
-    manifest = disc.prepare_inputs(raw_root)
-    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
-
-    assert entry["arxiv_id"] == "2401.00001"
-    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
-    assert entry["ingest_format"] == "directory"
-    assert any("using fetched TeX source" in w for w in entry["warnings"])
-
-
-def test_prepare_pdf_keeps_fetched_source_without_source_metadata(raw_root, monkeypatch):
-    (raw_root / "papers" / "seed.pdf").write_bytes(b"%PDF")
-    monkeypatch.setattr(
-        disc,
-        "_extract_pdf_text",
-        lambda _path: ("Adapter Tuning\nAbstract\nBrief note.", []),
-    )
-    monkeypatch.setattr(disc, "s2_search", lambda *_args, **_kwargs: [
-        {"title": "Adapter Tuning for Large Language Models", "externalIds": {"ArXiv": "2401.00006"}}
-    ])
-
-    def _fake_download(arxiv_id, dest_dir):
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        (dest_dir / "main.tex").write_text("\\section{Body}\nNo title metadata.\n", encoding="utf-8")
-        return {"success": True, "format": "directory", "error": None}
-
-    monkeypatch.setattr(disc, "_download_arxiv_source", _fake_download)
-
-    manifest = disc.prepare_inputs(raw_root)
-    entry = next(item for item in manifest["entries"] if item["source_kind"] == "paper")
-
-    assert entry["arxiv_id"] == "2401.00006"
-    assert entry["title"] == "Adapter Tuning"
-    assert entry["abstract_excerpt"] == "Brief note."
-    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
+    assert entry["title"] == "Recovered Title"
+    assert entry["candidate_id"] == "local:papers-seed-pdf"

--- a/tests/test_prepare_paper_source.py
+++ b/tests/test_prepare_paper_source.py
@@ -1,0 +1,486 @@
+"""Tests for tools/prepare_paper_source.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+sys.path.insert(0, "tools")
+import prepare_paper_source as prep  # noqa: E402
+
+
+@pytest.fixture
+def raw_root(tmp_path):
+    raw = tmp_path / "raw"
+    for sub in ("papers", "notes", "web", "discovered", "tmp"):
+        (raw / sub).mkdir(parents=True)
+        (raw / sub / ".gitkeep").touch()
+    return raw
+
+
+def test_prepare_pdf_with_filename_arxiv_prefers_source_fetch(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "2401.00007-seed.pdf"
+    pdf_path.write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("Recovered Title\nAbstract\nSome content.", []),
+    )
+
+    calls = []
+
+    def _spy_s2_search(query, limit=5):
+        calls.append(query)
+        return []
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{Source Truth Title}\n\\begin{abstract}\nSome content.\n\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(prep, "s2_search", _spy_s2_search)
+    monkeypatch.setattr(prep, "_download_arxiv_source", _fake_download)
+
+    entry = prep.prepare_paper_source(pdf_path, raw_root)
+
+    assert not calls
+    assert entry["arxiv_id"] == "2401.00007"
+    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
+    assert entry["ingest_format"] == "directory"
+    assert entry["title"] == "Source Truth Title"
+    assert entry["candidate_id"] == "local:papers-2401-00007-seed-pdf"
+    assert "title_source" not in entry
+
+
+def test_prepare_pdf_with_embedded_filename_arxiv_prefers_source_fetch(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "YOLO1506.02640v5.pdf"
+    pdf_path.write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("You Only Look Once\nAbstract\nSome content.", []),
+    )
+
+    calls = []
+
+    def _spy_s2_search(query, limit=5):
+        calls.append(query)
+        return []
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{You Only Look Once}\n\\begin{abstract}\nSome content.\n\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(prep, "s2_search", _spy_s2_search)
+    monkeypatch.setattr(prep, "_download_arxiv_source", _fake_download)
+
+    entry = prep.prepare_paper_source(pdf_path, raw_root)
+
+    assert not calls
+    assert entry["arxiv_id"] == "1506.02640"
+    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
+    assert entry["ingest_format"] == "directory"
+    assert entry["title"] == "You Only Look Once"
+
+
+def test_prepare_pdf_with_supplied_title_uses_title_search(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "seed.pdf"
+    pdf_path.write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("Recovered Title\nAbstract\nSome content.", []),
+    )
+
+    queries = []
+
+    def _fake_s2_search(query, limit=5):
+        queries.append(query)
+        return [{"title": "Recovered Title", "externalIds": {"ArXiv": "2401.00001"}}]
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{Source Truth Title}\n\\begin{abstract}\nSome content.\n\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(prep, "s2_search", _fake_s2_search)
+    monkeypatch.setattr(prep, "_download_arxiv_source", _fake_download)
+
+    entry = prep.prepare_paper_source(pdf_path, raw_root, title="Recovered Title")
+
+    assert queries == ["Recovered Title"]
+    assert entry["arxiv_id"] == "2401.00001"
+    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
+    assert entry["ingest_format"] == "directory"
+    assert entry["title"] == "Recovered Title"
+    assert entry["candidate_id"] == "local:papers-seed-pdf"
+    assert "title_source" not in entry
+
+
+def test_prepare_pdf_with_supplied_arxiv_id_bypasses_title_search(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "seed.pdf"
+    pdf_path.write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("Recovered Title\nAbstract\nSome content.", []),
+    )
+
+    calls = []
+
+    def _spy_s2_search(query, limit=5):
+        calls.append(query)
+        return []
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{Source Truth Title}\n\\begin{abstract}\nSome content.\n\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(prep, "s2_search", _spy_s2_search)
+    monkeypatch.setattr(prep, "_download_arxiv_source", _fake_download)
+
+    entry = prep.prepare_paper_source(pdf_path, raw_root, title="Recovered Title", arxiv_id="2401.00009v2")
+
+    assert not calls
+    assert entry["arxiv_id"] == "2401.00009"
+    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
+    assert entry["title"] == "Recovered Title"
+
+
+def test_prepare_pdf_without_supplied_title_skips_title_search_and_falls_back_to_synthetic(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "seed.pdf"
+    pdf_path.write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("Recovered Title\nAbstract\nSome content.", []),
+    )
+    monkeypatch.setattr(prep, "_extract_pdf_metadata_title", lambda _path: "")
+
+    calls = []
+
+    def _spy_s2_search(query, limit=5):
+        calls.append(query)
+        return []
+
+    monkeypatch.setattr(prep, "s2_search", _spy_s2_search)
+
+    entry = prep.prepare_paper_source(pdf_path, raw_root)
+
+    assert not calls
+    assert entry["arxiv_id"] == ""
+    assert entry["canonical_ingest_path"].endswith(".tex")
+    assert entry["title"] == "seed"
+    assert entry["candidate_id"] == "local:papers-seed-pdf"
+    assert "title_source" not in entry
+
+
+def test_prepare_pdf_fetched_source_title_is_sanitized_when_no_agent_title(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "YOLO1506.02640v5.pdf"
+    pdf_path.write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("You Only Look Once\nAbstract\nSome content.", []),
+    )
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{\\vspace{-1cm}You Only Look Once: \\\\ Unified, Real-Time Object Detection\\vspace{-.25cm}}\n"
+            "\\begin{abstract}\\vspace{-.25cm} Some content.\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(prep, "_download_arxiv_source", _fake_download)
+    monkeypatch.setattr(prep, "s2_search", lambda *_args, **_kwargs: [])
+
+    entry = prep.prepare_paper_source(pdf_path, raw_root)
+
+    assert entry["arxiv_id"] == "1506.02640"
+    assert entry["title"] == "You Only Look Once: Unified, Real-Time Object Detection"
+    assert entry["abstract_excerpt"] == "Some content."
+
+
+def test_prepare_pdf_fetched_source_title_does_not_override_agent_title(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "seed.pdf"
+    pdf_path.write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("Recovered Title\nAbstract\nSome content.", []),
+    )
+
+    def _fake_s2_search(query, limit=5):
+        return [{"title": "Recovered Title", "externalIds": {"ArXiv": "2401.00001"}}]
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{Hybrid Layout Control for Diffusion Transformer:}\n"
+            "\\begin{abstract}Some content.\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(prep, "s2_search", _fake_s2_search)
+    monkeypatch.setattr(prep, "_download_arxiv_source", _fake_download)
+
+    entry = prep.prepare_paper_source(pdf_path, raw_root, title="Recovered Title")
+
+    assert entry["title"] == "Recovered Title"
+    assert entry["canonical_ingest_path"].endswith("-arxiv-src")
+
+
+def test_prepare_pdf_rewrites_fetched_source_title_when_agent_title_supplied(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "YOLO1506.02640v5.pdf"
+    pdf_path.write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("You Only Look Once\nAbstract\nSome content.", []),
+    )
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{\\vspace{-1cm}You Only Look Once: \\\\ Unified, Real-Time Object Detection\\vspace{-.25cm}}\n"
+            "\\begin{abstract}\\vspace{-.25cm} Some content.\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(prep, "_download_arxiv_source", _fake_download)
+    monkeypatch.setattr(prep, "s2_search", lambda *_args, **_kwargs: [])
+
+    entry = prep.prepare_paper_source(
+        pdf_path,
+        raw_root,
+        title="You Only Look Once: Unified, Real-Time Object Detection",
+        arxiv_id="1506.02640",
+    )
+
+    rewritten_tex = raw_root / "tmp" / "papers" / "papers-yolo1506-02640v5-pdf-arxiv-src" / "main.tex"
+    assert entry["title"] == "You Only Look Once: Unified, Real-Time Object Detection"
+    assert rewritten_tex.exists()
+    assert "\\title{You Only Look Once: Unified, Real-Time Object Detection}" in rewritten_tex.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_prepare_pdf_uses_metadata_title_only_as_provisional_display(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "seed.pdf"
+    pdf_path.write_bytes(b"%PDF")
+    monkeypatch.setattr(prep, "_extract_pdf_text", lambda _path: ("Abstract\nSome content.", []))
+    monkeypatch.setattr(prep, "_extract_pdf_metadata_title", lambda _path: "Metadata Title")
+    monkeypatch.setattr(prep, "s2_search", lambda *_args, **_kwargs: [])
+
+    entry = prep.prepare_paper_source(pdf_path, raw_root)
+
+    assert entry["title"] == "Metadata Title"
+    assert entry["candidate_id"] == "local:papers-seed-pdf"
+    assert entry["canonical_ingest_path"].endswith(".tex")
+    assert "title_source" not in entry
+
+
+def test_prepare_pdf_with_supplied_title_falls_back_to_synthetic(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "seed.pdf"
+    pdf_path.write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("Recovered Title\nAbstract\nSome content.", []),
+    )
+    monkeypatch.setattr(
+        prep,
+        "s2_search",
+        lambda query, limit=5: [{"title": "Recovered Title", "externalIds": {"ArXiv": "2401.00002"}}],
+    )
+    monkeypatch.setattr(
+        prep,
+        "_download_arxiv_source",
+        lambda _arxiv_id, _dest: {"success": False, "format": "", "error": "no source tarball"},
+    )
+
+    entry = prep.prepare_paper_source(pdf_path, raw_root, title="Recovered Title")
+
+    assert entry["arxiv_id"] == "2401.00002"
+    assert entry["canonical_ingest_path"].endswith(".tex")
+    assert entry["ingest_format"] == "tex"
+    assert entry["title"] == "Recovered Title"
+    assert entry["candidate_id"] == "local:papers-seed-pdf"
+    assert any("TeX source download failed" in warning for warning in entry["warnings"])
+    assert "title_source" not in entry
+
+
+def test_prepare_pdf_refreshes_existing_synthetic_title(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "seed.pdf"
+    pdf_path.write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("Recovered Title\nAbstract\nSome content.", []),
+    )
+    monkeypatch.setattr(prep, "_extract_pdf_metadata_title", lambda _path: "")
+    monkeypatch.setattr(prep, "s2_search", lambda *_args, **_kwargs: [])
+
+    first = prep.prepare_paper_source(pdf_path, raw_root)
+    second = prep.prepare_paper_source(pdf_path, raw_root, title="Recovered Title")
+
+    synthetic_path = raw_root.parent / second["canonical_ingest_path"]
+    assert first["title"] == "seed"
+    assert second["title"] == "Recovered Title"
+    assert "\\title{Recovered Title}" in synthetic_path.read_text(encoding="utf-8")
+
+
+def test_prepare_pdf_existing_synthetic_tex_does_not_overwrite_agent_title(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "seed.pdf"
+    pdf_path.write_bytes(b"%PDF")
+    monkeypatch.setattr(prep, "_extract_pdf_text", lambda _path: ("Recovered body text.", []))
+    monkeypatch.setattr(prep, "_extract_pdf_metadata_title", lambda _path: "")
+    monkeypatch.setattr(prep, "s2_search", lambda *_args, **_kwargs: [])
+
+    out_path = raw_root / "tmp" / "papers" / "papers-seed-pdf.tex"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        "\\title{LOSS LANDSCAPES ARE ALL YOU NEED: NEURAL}\n\\begin{abstract}Some content.\\end{abstract}\n",
+        encoding="utf-8",
+    )
+
+    entry = prep.prepare_paper_source(pdf_path, raw_root, title="Loss Landscapes Are All You Need")
+
+    assert entry["title"] == "Loss Landscapes Are All You Need"
+    assert "\\title{Loss Landscapes Are All You Need}" in out_path.read_text(encoding="utf-8")
+
+
+def test_prepare_pdf_existing_fetched_source_dir_is_rewritten_from_stored_authoritative_title(raw_root, monkeypatch):
+    pdf_path = raw_root / "papers" / "seed.pdf"
+    pdf_path.write_bytes(b"%PDF")
+    monkeypatch.setattr(
+        prep,
+        "_extract_pdf_text",
+        lambda _path: ("Recovered Title\nAbstract\nSome content.", []),
+    )
+
+    def _fake_download(arxiv_id, dest_dir):
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / "main.tex").write_text(
+            "\\title{Recovered Title}\n\\begin{abstract}Some content.\\end{abstract}\n",
+            encoding="utf-8",
+        )
+        return {"success": True, "format": "directory", "error": None}
+
+    monkeypatch.setattr(
+        prep,
+        "s2_search",
+        lambda query, limit=5: [{"title": "Recovered Title", "externalIds": {"ArXiv": "2401.00004"}}],
+    )
+    monkeypatch.setattr(prep, "_download_arxiv_source", _fake_download)
+
+    first = prep.prepare_paper_source(pdf_path, raw_root, title="Recovered Title")
+    staged_dir = raw_root.parent / first["canonical_ingest_path"]
+    staged_tex = staged_dir / "main.tex"
+    staged_tex.write_text(
+        "\\title{\\vspace{-1cm}Recovered Title\\\\Extra Formatting\\vspace{-.25cm}}\n"
+        "\\begin{abstract}\\vspace{-.25cm} Some content.\\end{abstract}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(prep, "s2_search", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected search")))
+
+    second = prep.prepare_paper_source(pdf_path, raw_root)
+
+    assert second["title"] == "Recovered Title"
+    assert "\\title{Recovered Title}" in staged_tex.read_text(encoding="utf-8")
+
+
+def test_prepare_tex_passthrough(raw_root):
+    tex_path = raw_root / "papers" / "seed.tex"
+    tex_path.write_text(
+        "\\title{Recovered Title}\n\\begin{abstract}Some content.\\end{abstract}\n",
+        encoding="utf-8",
+    )
+
+    entry = prep.prepare_paper_source(tex_path, raw_root)
+
+    assert entry["canonical_ingest_path"] == "raw/papers/seed.tex"
+    assert entry["prepared_path"] is None
+    assert entry["title"] == "Recovered Title"
+    assert entry["candidate_id"] == "local:papers-seed-tex"
+    assert "title_source" not in entry
+
+
+def test_prepare_source_dir_passthrough(raw_root):
+    source_dir = raw_root / "papers" / "seed-dir"
+    source_dir.mkdir()
+    (source_dir / "main.tex").write_text(
+        "\\title{Recovered Title}\n\\begin{abstract}Some content.\\end{abstract}\n",
+        encoding="utf-8",
+    )
+
+    entry = prep.prepare_paper_source(source_dir, raw_root)
+
+    assert entry["canonical_ingest_path"] == "raw/papers/seed-dir/main.tex"
+    assert entry["prepared_path"] is None
+    assert entry["title"] == "Recovered Title"
+    assert entry["candidate_id"] == "local:papers-seed-dir"
+    assert "title_source" not in entry
+
+
+def test_extract_arxiv_source_metadata_reads_title_and_abstract(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "main.tex").write_text(
+        "\\title{Recovered Title}\n\\begin{abstract}\nSome content.\n\\end{abstract}\n",
+        encoding="utf-8",
+    )
+
+    result = prep._extract_arxiv_source_metadata(source_dir)
+
+    assert result["source_title"] == "Recovered Title"
+    assert result["source_abstract"] == "Some content."
+
+
+def test_prepare_paper_source_cli_outputs_json(raw_root):
+    tex_path = raw_root / "papers" / "seed.tex"
+    tex_path.write_text("\\title{Recovered Title}\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(PROJECT_ROOT / "tools" / "prepare_paper_source.py"),
+            "--raw-root",
+            str(raw_root),
+            "--source",
+            str(tex_path),
+        ],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["title"] == "Recovered Title"
+    assert payload["canonical_ingest_path"] == "raw/papers/seed.tex"
+    assert "title_source" not in payload

--- a/tests/test_skill_ingest.py
+++ b/tests/test_skill_ingest.py
@@ -139,6 +139,13 @@ class TestWorkflow:
         steps = re.findall(r"^### Step \d+", workflow, re.MULTILINE)
         assert len(steps) >= 8, f"Expected >= 8 workflow steps, found {len(steps)}"
 
+    def test_local_pdf_flow_is_agent_first(self, skill_text):
+        lowered = skill_text.lower()
+        assert "filename/path arxiv" in lowered
+        assert "--arxiv-id" in skill_text
+        assert "authoritative" in lowered
+        assert "synthetic `.tex`" in skill_text
+
 
 # ── 4. Tool references ─────────────────────────────────────────────────
 
@@ -148,6 +155,7 @@ REQUIRED_TOOL_CALLS = [
     ("research_wiki.py rebuild-context-brief", "Must use research_wiki.py rebuild-context-brief"),
     ("research_wiki.py rebuild-open-questions", "Must use research_wiki.py rebuild-open-questions"),
     ("research_wiki.py log", "Must use research_wiki.py log for audit logging"),
+    ("prepare_paper_source.py", "Must reference prepare_paper_source.py for direct local PDF normalization"),
 ]
 
 
@@ -165,6 +173,10 @@ class TestToolReferences:
     def test_fetch_s2_tool_exists(self):
         assert (TOOLS_DIR / "fetch_s2.py").exists(), \
             "tools/fetch_s2.py must exist"
+
+    def test_prepare_paper_source_tool_exists(self):
+        assert (TOOLS_DIR / "prepare_paper_source.py").exists(), \
+            "tools/prepare_paper_source.py must exist"
 
     def test_references_fetch_s2(self, skill_text):
         assert "fetch_s2.py" in skill_text, \

--- a/tests/test_skill_init.py
+++ b/tests/test_skill_init.py
@@ -1,261 +1,241 @@
-"""Tests for the rewritten /init skill."""
+"""Tests for the refactored /init skill."""
 
 from pathlib import Path
 
 import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-SKILL_PATH = PROJECT_ROOT / ".claude" / "skills" / "init" / "SKILL.md"
-CLAUDE_MD = PROJECT_ROOT / "CLAUDE.md"
-I18N_EN_CLAUDE_MD = PROJECT_ROOT / "i18n" / "en" / "CLAUDE.md"
-I18N_ZH_CLAUDE_MD = PROJECT_ROOT / "i18n" / "zh" / "CLAUDE.md"
+EN_SKILL = PROJECT_ROOT / "i18n" / "en" / "skills" / "init" / "SKILL.md"
+ZH_SKILL = PROJECT_ROOT / "i18n" / "zh" / "skills" / "init" / "SKILL.md"
+ACTIVE_SKILL = PROJECT_ROOT / ".claude" / "skills" / "init" / "SKILL.md"
+EN_REFS = PROJECT_ROOT / "i18n" / "en" / "skills" / "init" / "references"
+ZH_REFS = PROJECT_ROOT / "i18n" / "zh" / "skills" / "init" / "references"
+ACTIVE_REFS = PROJECT_ROOT / ".claude" / "skills" / "init" / "references"
+EN_CLAUDE_MD = PROJECT_ROOT / "i18n" / "en" / "CLAUDE.md"
+ZH_CLAUDE_MD = PROJECT_ROOT / "i18n" / "zh" / "CLAUDE.md"
+ROOT_CLAUDE_MD = PROJECT_ROOT / "CLAUDE.md"
 
 
 @pytest.fixture(scope="module")
-def skill_content():
-    return SKILL_PATH.read_text(encoding="utf-8")
+def en_skill_text():
+    return EN_SKILL.read_text(encoding="utf-8")
 
 
 @pytest.fixture(scope="module")
-def claude_content():
-    return CLAUDE_MD.read_text(encoding="utf-8")
+def zh_skill_text():
+    return ZH_SKILL.read_text(encoding="utf-8")
 
 
-@pytest.fixture(scope="module")
-def i18n_en_claude_content():
-    return I18N_EN_CLAUDE_MD.read_text(encoding="utf-8")
+REQUIRED_SECTIONS = [
+    "## Inputs",
+    "## Outputs",
+    "## Wiki Interaction",
+    "## Workflow",
+    "## Constraints",
+    "## Error Handling",
+    "## Dependencies",
+]
 
 
-@pytest.fixture(scope="module")
-def i18n_zh_claude_content():
-    return I18N_ZH_CLAUDE_MD.read_text(encoding="utf-8")
+class TestSkillFiles:
+    def test_en_skill_exists(self):
+        assert EN_SKILL.exists()
+
+    def test_zh_skill_exists(self):
+        assert ZH_SKILL.exists()
+
+    def test_reference_dirs_exist(self):
+        assert EN_REFS.exists()
+        assert ZH_REFS.exists()
+
+    def test_reference_files_exist(self):
+        for root in (EN_REFS, ZH_REFS):
+            assert (root / "prepare-and-discovery.md").exists()
+            assert (root / "planner-policy.md").exists()
+            assert (root / "parallel-ingest.md").exists()
+
+    def test_active_skill_exists_if_setup_was_run(self):
+        lang_file = PROJECT_ROOT / ".claude" / ".current-lang"
+        if not lang_file.exists():
+            pytest.skip("setup.sh has not been run yet — skipping active runtime check")
+        assert ACTIVE_SKILL.exists()
+        assert (ACTIVE_REFS / "prepare-and-discovery.md").exists()
+        assert (ACTIVE_REFS / "planner-policy.md").exists()
+        assert (ACTIVE_REFS / "parallel-ingest.md").exists()
 
 
 class TestSkillStructure:
-    def test_exists(self):
-        assert SKILL_PATH.exists()
+    def test_frontmatter(self, en_skill_text):
+        assert en_skill_text.startswith("---")
+        assert "description:" in en_skill_text
+        assert "argument-hint:" in en_skill_text
 
-    def test_frontmatter(self, skill_content):
-        assert skill_content.startswith("---")
-        assert "description:" in skill_content
-        assert "argument-hint:" in skill_content
+    @pytest.mark.parametrize("section", REQUIRED_SECTIONS)
+    def test_required_sections_present(self, en_skill_text, zh_skill_text, section):
+        assert section in en_skill_text
+        assert section in zh_skill_text
 
-    @pytest.mark.parametrize("section", [
-        "## Inputs",
-        "## Outputs",
-        "## Wiki Interaction",
-        "## Workflow",
-        "## Constraints",
-        "## Error Handling",
-        "## Dependencies",
-    ])
-    def test_required_sections(self, skill_content, section):
-        assert section in skill_content
+    def test_skill_links_local_references(self, en_skill_text, zh_skill_text):
+        for name in (
+            "references/prepare-and-discovery.md",
+            "references/planner-policy.md",
+            "references/parallel-ingest.md",
+        ):
+            assert name in en_skill_text
+            assert name in zh_skill_text
 
 
 class TestPublicContract:
-    def test_supports_no_introduction(self, skill_content):
-        assert "--no-introduction" in skill_content
+    def test_supports_no_introduction(self, en_skill_text):
+        assert "--no-introduction" in en_skill_text
 
-    def test_no_introduction_is_user_controlled(self, skill_content):
-        lowered = skill_content.lower()
+    def test_no_introduction_is_user_controlled(self, en_skill_text):
+        lowered = en_skill_text.lower()
         assert "do not infer `--no-introduction` from repository state alone" in lowered
         assert "user explicitly asked to disable external discovery" in lowered
 
-    def test_mentions_raw_discovered(self, skill_content):
-        assert "raw/discovered/" in skill_content
+    def test_mentions_raw_tmp_and_discovered(self, en_skill_text):
+        assert "raw/tmp/" in en_skill_text
+        assert "raw/discovered/" in en_skill_text
 
-    def test_mentions_raw_tmp(self, skill_content):
-        assert "raw/tmp/" in skill_content
+    def test_reads_notes_and_web(self, en_skill_text):
+        assert "raw/notes/" in en_skill_text
+        assert "raw/web/" in en_skill_text
 
-    def test_reads_notes_and_web(self, skill_content):
-        assert "raw/notes/" in skill_content
-        assert "raw/web/" in skill_content
+    def test_provisional_notice_is_exact(self, en_skill_text):
+        assert "Provisional note: seeded from raw/notes or raw/web during /init; pending validation from ingested papers." in en_skill_text
 
-    def test_provisional_notice_is_exact(self, skill_content):
-        assert "Provisional note: seeded from raw/notes or raw/web during /init; pending validation from ingested papers." in skill_content
+    def test_notes_web_claim_defaults_documented(self, en_skill_text):
+        assert "status: proposed" in en_skill_text
+        assert "confidence: 0.2" in en_skill_text
+        assert "source_papers: []" in en_skill_text
+        assert "evidence: []" in en_skill_text
 
-    def test_notes_web_claim_defaults(self, skill_content):
-        assert "status: proposed" in skill_content
-        assert "confidence: 0.2" in skill_content
-        assert "source_papers: []" in skill_content
-        assert "evidence: []" in skill_content
+    def test_prefill_is_optional(self, en_skill_text, zh_skill_text):
+        assert "/prefill" in en_skill_text
+        assert "optional" in en_skill_text.lower()
+        assert "/prefill" in zh_skill_text
+        assert "可选" in zh_skill_text
 
-    def test_init_does_not_create_people_or_foundations(self, skill_content):
-        lowered = skill_content.lower()
-        assert "must not create `people/` pages directly" in lowered or "不得直接创建 `people/`" in skill_content
-        assert "auto-create foundations" in lowered or "自动创建 foundations" in skill_content
-
-    def test_prefill_is_optional(self, skill_content):
-        assert "/prefill" in skill_content
-        assert "optional" in skill_content.lower() or "可选" in skill_content
-
-    def test_mentions_degraded_chinese_notes_warning(self, skill_content):
-        lowered = skill_content.lower()
-        assert "lower-confidence" in lowered or "较低置信度" in skill_content
-        assert "raw/notes/" in skill_content
+    def test_init_does_not_create_people_or_foundations(self, en_skill_text, zh_skill_text):
+        lowered = en_skill_text.lower()
+        assert "must not create `people/` pages directly" in lowered
+        assert "must not auto-create foundations" in lowered
+        assert "不得直接创建 `people/` 页面" in zh_skill_text
+        assert "不得自动创建 foundations" in zh_skill_text
 
 
 class TestWorkflow:
-    def test_prefers_repo_python_bin(self, skill_content):
-        assert "PYTHON_BIN" in skill_content
-        assert ".venv/bin/python" in skill_content
-        assert ".venv/Scripts/python.exe" in skill_content
+    def test_prefers_repo_python_bin(self, en_skill_text):
+        assert "PYTHON_BIN" in en_skill_text
+        assert ".venv/bin/python" in en_skill_text
+        assert ".venv/Scripts/python.exe" in en_skill_text
 
-    def test_step1_init(self, skill_content):
-        assert "### Step 1" in skill_content
-        assert "research_wiki.py init" in skill_content
-        assert '"$PYTHON_BIN" tools/research_wiki.py init wiki/' in skill_content
+    def test_core_steps_present(self, en_skill_text):
+        for step in ("### Step 1", "### Step 2", "### Step 3", "### Step 4", "### Step 5", "### Step 6"):
+            assert step in en_skill_text
 
-    def test_step2_prepare(self, skill_content):
-        assert "### Step 2" in skill_content
-        assert "init_discovery.py prepare" in skill_content
-        assert ".checkpoints/init-prepare.json" in skill_content
-        assert '"$PYTHON_BIN" tools/init_discovery.py prepare' in skill_content
+    def test_prepare_and_plan_commands_present(self, en_skill_text):
+        assert '"$PYTHON_BIN" tools/init_discovery.py prepare' in en_skill_text
+        assert "--pdf-titles-json .checkpoints/init-pdf-titles.json" in en_skill_text
+        assert '"$PYTHON_BIN" tools/init_discovery.py plan' in en_skill_text
+        assert '"$PYTHON_BIN" tools/init_discovery.py fetch' in en_skill_text
 
-    def test_step3_discovery_plan_and_fetch(self, skill_content):
-        assert "### Step 3" in skill_content
-        assert "init_discovery.py plan" in skill_content
-        assert "--output-plan .checkpoints/init-plan.json" in skill_content
-        assert "init_discovery.py fetch" in skill_content
-        assert ".checkpoints/init-sources.json" in skill_content
-        assert "8-10" in skill_content
-        assert '"$PYTHON_BIN" tools/init_discovery.py plan' in skill_content
-        assert '"$PYTHON_BIN" tools/init_discovery.py fetch' in skill_content
+    def test_prepare_helper_present(self, en_skill_text):
+        assert "prepare_paper_source.py" in en_skill_text
 
-    def test_step3_requires_explicit_final_selection_before_fetch(self, skill_content):
-        assert "read `.checkpoints/init-plan.json`" in skill_content
-        assert "before `fetch`" in skill_content
-        assert "final selection artifact" in skill_content
-        assert "`candidate_id`" in skill_content
+    def test_prepare_contract_is_agent_first(self, en_skill_text):
+        lowered = en_skill_text.lower()
+        assert ".checkpoints/init-pdf-titles.json" in en_skill_text
+        assert "arxiv_id" in en_skill_text
+        assert "filename/path arxiv id" in lowered
+        assert "authoritative" in lowered
+        assert "do not use pdf metadata or body text as arxiv-id hints" in lowered
 
-    def test_step3_requires_revise_before_fetch_when_count_is_wrong(self, skill_content):
-        lowered = skill_content.lower()
-        assert "stop and revise the final selection before `fetch`" in lowered
-        assert "`--no-introduction`" in skill_content
-        assert "more than 10 parseable papers" in skill_content
+    def test_final_selection_contract_present(self, en_skill_text):
+        assert "shortlist" in en_skill_text
+        assert "final **8-10** papers total" in en_skill_text
+        assert "final selection artifact" in en_skill_text
+        assert "`candidate_id`" in en_skill_text
+        assert "stop and revise the final selection before `fetch`" in en_skill_text
 
-    def test_step3_distinguishes_shortlist_from_final_set(self, skill_content):
-        assert "over-picked `shortlist`" in skill_content
-        assert "final **8-10** papers total" in skill_content
-        assert "never forward the whole shortlist implicitly" in skill_content
+    def test_planner_policy_is_qualitative_in_skill_doc(self, en_skill_text):
+        lowered = en_skill_text.lower()
+        assert "favor relevance, freshness, connectivity, and survey coverage" in lowered
+        assert "exact ranking weights" in lowered
+        assert "tools/init_discovery.py" in en_skill_text
+        assert "relevance = 30" not in en_skill_text
+        assert "freshness = 20" not in en_skill_text
+        assert "anchor/connectivity bonus = 20" not in en_skill_text
 
-    def test_step4_scaffold_pages(self, skill_content):
-        assert "### Step 4" in skill_content
-        assert "Summary" in skill_content
-        assert "topics/" in skill_content
-        assert "ideas/" in skill_content
-        assert "concepts/" in skill_content
-        assert "claims/" in skill_content
-
-    def test_step4_5_scaffold_commit(self, skill_content):
-        assert "### Step 4.5" in skill_content
-        assert "git stash" in skill_content
-        assert "raw/tmp/" in skill_content
-        assert "raw/discovered/" in skill_content
-        assert 'commit -m "init: scaffold before parallel ingest"' in skill_content
-
-    def test_step4_5_records_base_branch_and_commit(self, skill_content):
-        assert "git branch --show-current" in skill_content
-        assert "base_branch" in skill_content
-        assert "git rev-parse HEAD" in skill_content
-        assert "base_commit" in skill_content
-
-    def test_step4_5_checkpoint_ids_are_post_trim(self, skill_content):
-        assert "post-trim" in skill_content
-        assert "not the over-picked shortlist" in skill_content
-
-    def test_step5_parallel_ingest(self, skill_content):
-        assert "### Step 5" in skill_content
-        assert "/ingest" in skill_content
-        assert "run_in_background" in skill_content
-        assert "worktree" in skill_content.lower()
-        assert "dedup-edges" in skill_content
-        assert ".checkpoints/init-sources.json" in skill_content
-
-    def test_step6_report(self, skill_content):
-        assert "### Step 6" in skill_content
-        assert "raw/tmp/" in skill_content
-        assert "raw/discovered/" in skill_content
-
-    def test_resume_manifest_checkpoint(self, skill_content):
-        assert ".checkpoints/init-prepare.json" in skill_content
-        assert ".checkpoints/init-plan.json" in skill_content
-        assert ".checkpoints/init-sources.json" in skill_content
-        assert "checkpoint-set-meta" in skill_content
-
-    def test_step3_mentions_explicit_deepxiv_relevance_score(self, skill_content):
-        lowered = skill_content.lower()
-        assert "`relevance_score`" in skill_content or "relevance_score" in skill_content
-        assert "explicitly" in lowered or "显式" in skill_content
-
-
-class TestParallelGuardrails:
-    def test_gitattributes_union_merge(self, skill_content):
-        assert ".gitattributes" in skill_content
-        assert "merge=union" in skill_content
-
-    def test_relative_paths_only(self, skill_content):
-        assert "relative paths only" in skill_content.lower() or "相对路径" in skill_content
-
-    def test_worktrees_branch_from_scaffold_commit(self, skill_content):
-        assert "git worktree add -b" in skill_content
-        assert "BASE_COMMIT" in skill_content
-        assert "BASE_BRANCH" in skill_content
-
-    def test_init_mode_skips(self, skill_content):
-        lowered = skill_content.lower()
+    def test_parallel_ingest_contract_present(self, en_skill_text):
+        lowered = en_skill_text.lower()
+        assert ".checkpoints/init-sources.json" in en_skill_text
+        assert "relative paths only" in lowered
+        assert "detached head" in lowered
+        assert "commit the freshly created scaffold" in lowered
+        assert ".gitattributes" in en_skill_text
+        assert "merge=union" in en_skill_text
         assert "skip `fetch_s2.py citations`" in lowered
         assert "skip `fetch_s2.py references`" in lowered
         assert "skip per-subagent `rebuild-index`" in lowered
-        assert "skip per-subagent `rebuild-context-brief`" in lowered
-        assert "skip per-subagent `rebuild-open-questions`" in lowered
+        assert "commit the ingest result inside the worktree before exiting" in lowered
 
-    def test_dedup_tools_still_required(self, skill_content):
-        assert "find-similar-claim" in skill_content
-        assert "find-similar-concept" in skill_content
-
-
-class TestErrorHandling:
-    def test_detached_head_is_called_out(self, skill_content):
-        lowered = skill_content.lower()
-        assert "detached head" in lowered
-        assert "named branch" in lowered or "命名分支" in skill_content
+    def test_rebuild_steps_present(self, en_skill_text):
+        assert "dedup-edges" in en_skill_text
+        assert "rebuild-index" in en_skill_text
+        assert "rebuild-context-brief" in en_skill_text
+        assert "rebuild-open-questions" in en_skill_text
+        assert 'tools/lint.py wiki/ --fix' in en_skill_text
 
 
-class TestDependencies:
-    def test_new_tool_exists(self):
-        assert (PROJECT_ROOT / "tools" / "init_discovery.py").exists()
+class TestReferenceDocs:
+    def test_prepare_reference_covers_manifest_and_fetch(self):
+        text = (EN_REFS / "prepare-and-discovery.md").read_text(encoding="utf-8")
+        lowered = text.lower()
+        assert "canonical_ingest_path" in text
+        assert ".checkpoints/init-sources.json" in text
+        assert ".checkpoints/init-pdf-titles.json" in text
+        assert "arxiv_id" in text
+        assert "authoritative" in lowered
+        assert "raw/discovered/" in text
+        assert "raw/tmp/" in text
+        assert "prepare_paper_source.py" in text
 
-    @pytest.mark.parametrize("name", [
-        "init_discovery.py",
-        "research_wiki.py",
-        "lint.py",
-    ])
-    def test_tool_referenced(self, skill_content, name):
-        assert name in skill_content
+    def test_planner_reference_is_behavioral_not_numeric(self):
+        text = (EN_REFS / "planner-policy.md").read_text(encoding="utf-8")
+        lowered = text.lower()
+        assert "behavioral policy" in lowered
+        assert "tools/init_discovery.py" in text
+        assert "exact weights" in lowered
+        assert "30" not in text
+        assert "20" not in text
+        assert "15" not in text
+
+    def test_parallel_reference_covers_worktrees(self):
+        text = (EN_REFS / "parallel-ingest.md").read_text(encoding="utf-8")
+        assert "git worktree add -b" in text
+        assert "relative source path" in text
+        assert "dedup-edges" in text
+        assert 'git commit -m "init: scaffold before parallel ingest" --no-gpg-sign' in text
+        assert ".gitattributes" in text
+        assert "merge=union" in text
+        assert "Commit the result inside the worktree before exiting" in text
+        assert "A branch with no ingest commit is an error" in text
 
 
 class TestClaudemdConsistency:
-    def test_skill_listed(self, claude_content):
-        assert "/init" in claude_content
+    def test_claude_mentions_local_skill_references(self):
+        for path in (EN_CLAUDE_MD, ZH_CLAUDE_MD, ROOT_CLAUDE_MD):
+            text = path.read_text(encoding="utf-8")
+            assert "SKILL.md" in text
+            assert "reference" in text.lower() or "参考文件" in text
+            assert "/init" in text
 
-    def test_claude_mentions_raw_discovered(self, claude_content):
-        assert "raw/discovered/" in claude_content
 
-    def test_claude_mentions_raw_tmp(self, claude_content):
-        assert "raw/tmp/" in claude_content
-
-    def test_claude_declares_user_owned_skill_parameters(self, claude_content):
-        lowered = claude_content.lower()
-        assert "user-facing skill parameters are user-owned" in lowered
-        assert "argument-hint" in claude_content
-
-    def test_i18n_en_claude_declares_user_owned_skill_parameters(self, i18n_en_claude_content):
-        lowered = i18n_en_claude_content.lower()
-        assert "user-facing skill parameters are user-owned" in lowered
-        assert "argument-hint" in i18n_en_claude_content
-
-    def test_i18n_zh_claude_declares_user_owned_skill_parameters(self, i18n_zh_claude_content):
-        assert "用户可见参数归用户所有" in i18n_zh_claude_content
-        assert "argument-hint" in i18n_zh_claude_content
+class TestDependencies:
+    def test_required_tools_exist(self):
+        assert (PROJECT_ROOT / "tools" / "init_discovery.py").exists()
+        assert (PROJECT_ROOT / "tools" / "prepare_paper_source.py").exists()
+        assert (PROJECT_ROOT / "tools" / "research_wiki.py").exists()
+        assert (PROJECT_ROOT / "tools" / "lint.py").exists()

--- a/tests/test_skill_setup.py
+++ b/tests/test_skill_setup.py
@@ -242,6 +242,13 @@ def test_readme_mentions_setup_venv_behavior():
     assert "/init 会自动使用 .venv" in content
 
 
+def test_setup_sh_recursively_syncs_skill_subtrees():
+    content = SETUP_SH.read_text(encoding="utf-8")
+    assert 'cp -R "$skill_dir"/. ".claude/skills/$name/"' in content, (
+        "setup.sh should recursively copy skill subtrees so local references sync with SKILL.md"
+    )
+
+
 # ── Active skill file (after setup.sh --lang sync) ────────────────────────
 
 def test_active_skill_exists_if_setup_was_run():

--- a/tools/init_discovery.py
+++ b/tools/init_discovery.py
@@ -2,7 +2,7 @@
 """Source preparation + discovery planner for /init.
 
 Usage:
-    python3 tools/init_discovery.py prepare --raw-root raw --output-manifest .checkpoints/init-prepare.json
+    python3 tools/init_discovery.py prepare --raw-root raw --pdf-titles-json .checkpoints/init-pdf-titles.json --output-manifest .checkpoints/init-prepare.json
     python3 tools/init_discovery.py plan [--topic "efficient llm finetuning"] --prepared-manifest .checkpoints/init-prepare.json --output-plan .checkpoints/init-plan.json
     python3 tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id arxiv:2106.09685
     python3 tools/init_discovery.py download --raw-root raw --arxiv-id 2106.09685 --title "Example Paper"
@@ -27,6 +27,7 @@ from typing import Any
 
 import requests
 
+import prepare_paper_source as paper_source
 from fetch_deepxiv import search as deepxiv_search
 from fetch_s2 import citations as s2_citations
 from fetch_s2 import references as s2_references
@@ -47,8 +48,9 @@ STOP_WORDS = {
     "the", "their", "this", "to", "we", "with", "you", "your",
 }
 TOKEN_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9.+/_-]*|[\u4e00-\u9fff]{2,}")
-ARXIV_ID_PATTERN = re.compile(
-    r"\b(?:\d{4}\.\d{4,5}(?:v\d+)?|[a-z\-]+(?:\.[A-Z]{2})?/\d{7}(?:v\d+)?)\b",
+ARXIV_NEW_ID_PATTERN = re.compile(r"(?<!\d)(\d{4}\.\d{4,5}(?:v\d+)?)(?!\d)", re.IGNORECASE)
+ARXIV_OLD_ID_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9])([a-z\-]+(?:\.[A-Z]{2})?/\d{7}(?:v\d+)?)(?!\d)",
     re.IGNORECASE,
 )
 CHINESE_CHAR_PATTERN = re.compile(r"[\u4e00-\u9fff]")
@@ -91,6 +93,16 @@ def _paper_entry_match_key(entry: dict[str, Any]) -> tuple[str, str]:
     return (str(entry.get("arxiv_id") or ""), _normalize_text(str(entry.get("title") or "")))
 
 
+def _paper_entry_source_key(entry: dict[str, Any]) -> str:
+    source_path = Path(str(entry.get("source_path") or ""))
+    name = source_path.name.lower()
+    if name.endswith(".tar.gz"):
+        base = source_path.name[:-7]
+    else:
+        base = source_path.stem
+    return _normalize_text(base.replace("_", " ").replace("-", " "))
+
+
 def _paper_entry_preference(entry: dict[str, Any]) -> tuple[int, int, int]:
     original_format = str(entry.get("original_format") or "")
     ingest_format = str(entry.get("ingest_format") or "")
@@ -122,6 +134,70 @@ def _relative_to_project(path: Path, raw_root: Path) -> str:
 
 def _resolve_project_path(raw_root: Path, rel_path: str) -> Path:
     return _project_root(raw_root) / rel_path
+
+
+def _local_candidate_id(path: Path, raw_root: Path) -> str:
+    return f"local:{_path_slug(path.relative_to(raw_root))}"
+
+
+def _normalize_prepare_source_path(raw_root: Path, source_path: str) -> str:
+    raw_source = str(source_path or "").strip()
+    if not raw_source:
+        return ""
+
+    candidate = Path(raw_source)
+    if candidate.is_absolute():
+        resolved = candidate.resolve()
+    else:
+        project_root = _project_root(raw_root)
+        resolved = (project_root / raw_source).resolve()
+        if not resolved.exists() and not raw_source.startswith("raw/"):
+            resolved = (raw_root / raw_source).resolve()
+
+    try:
+        return _relative_to_project(resolved, raw_root)
+    except ValueError:
+        return ""
+
+
+def _normalize_arxiv_id(arxiv_id: str) -> str:
+    arxiv_id = str(arxiv_id or "").strip()
+    if not arxiv_id:
+        return ""
+    return re.sub(r"v\d+$", "", arxiv_id, flags=re.IGNORECASE)
+
+
+def _normalize_pdf_titles_map(
+    raw_root: Path,
+    pdf_titles: dict[str, Any] | None,
+    warning_sink: list[str] | None = None,
+) -> tuple[dict[str, dict[str, str]], dict[str, str]]:
+    normalized_payloads: dict[str, dict[str, str]] = {}
+    original_keys: dict[str, str] = {}
+    for raw_key, raw_title in (pdf_titles or {}).items():
+        key = _normalize_prepare_source_path(raw_root, str(raw_key))
+        if isinstance(raw_title, dict):
+            title = " ".join(str(raw_title.get("title") or "").split())
+            arxiv_id = _normalize_arxiv_id(str(raw_title.get("arxiv_id") or ""))
+        else:
+            title = " ".join(str(raw_title or "").split())
+            arxiv_id = ""
+        if not key:
+            if warning_sink is not None:
+                warning_sink.append(f"ignored invalid PDF title mapping: {raw_key}")
+            continue
+        if not title and not arxiv_id:
+            continue
+        normalized_payloads[key] = {"title": title, "arxiv_id": arxiv_id}
+        original_keys[key] = str(raw_key)
+    return normalized_payloads, original_keys
+
+
+def _load_pdf_titles_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("expected a JSON object mapping source paths to titles or {title, arxiv_id} records")
+    return payload
 
 
 def _read_text(path: Path, limit: int = 20000) -> str:
@@ -161,8 +237,11 @@ def _top_terms(text: str, limit: int = 12) -> list[str]:
 
 
 def _extract_arxiv_id(text: str) -> str:
-    match = ARXIV_ID_PATTERN.search(text)
-    return match.group(0) if match else ""
+    for pattern in (ARXIV_NEW_ID_PATTERN, ARXIV_OLD_ID_PATTERN):
+        match = pattern.search(text)
+        if match:
+            return _normalize_arxiv_id(match.group(1))
+    return ""
 
 
 def _recover_arxiv_id_by_title(title: str) -> str:
@@ -187,14 +266,14 @@ def _recover_arxiv_id_by_title(title: str) -> str:
             continue
         # Exact normalized match
         if result_title == normalized_title:
-            return str(arxiv_id)
+            return _normalize_arxiv_id(str(arxiv_id))
         # High token-overlap match (at least 80% of tokens in common)
         result_tokens = set(_tokenize(result_title))
         if result_tokens and title_tokens:
             overlap = len(result_tokens & title_tokens)
             min_len = min(len(result_tokens), len(title_tokens))
             if min_len > 0 and overlap / min_len >= 0.8:
-                return str(arxiv_id)
+                return _normalize_arxiv_id(str(arxiv_id))
     return ""
 
 
@@ -549,158 +628,46 @@ def _prepare_text_entry(path: Path, raw_root: Path, kind: str) -> dict[str, Any]
     }
 
 
-def _prepare_paper_entry(path: Path, raw_root: Path) -> dict[str, Any]:
-    warnings: list[str] = []
-    source_rel = _relative_to_project(path, raw_root)
-    working_entry = path
-    original_format = "directory" if path.is_dir() else path.suffix.lower().lstrip(".")
-    prepared_path = ""
-    canonical_path = ""
-    resolved_source_path = source_rel
-    title = _guess_local_title(path) if path.is_file() else (path.stem.replace("_", " ").replace("-", " ").strip() or "Untitled")
-    abstract_excerpt = ""
-    arxiv_id = ""
-    usable = True
-
-    if path.is_file() and _is_archive(path):
-        extract_dir = raw_root / "tmp" / "papers" / f"{_path_slug(path.relative_to(raw_root))}-src"
-        warnings.extend(_extract_archive_to_tmp(path, extract_dir))
-        if extract_dir.exists():
-            working_entry = extract_dir
-            prepared_path = _relative_to_project(extract_dir, raw_root)
-            original_format = "archive"
-
-    candidate_path: Path | None
-    if working_entry.is_dir():
-        candidate_path = _scan_paper_dir(working_entry)
-    else:
-        candidate_path = working_entry
-
-    if candidate_path is None:
-        usable = False
-        warnings.append("no parseable .tex or .pdf found for local paper source")
-        title = path.stem.replace("_", " ").replace("-", " ").strip() or "Untitled"
-        candidate_id = f"local:{slugify(title)}"
-        return {
-            "entry_id": candidate_id,
-            "candidate_id": candidate_id,
-            "source_kind": "paper",
-            "source_path": source_rel,
-            "resolved_source_path": source_rel,
-            "prepared_path": prepared_path or None,
-            "canonical_ingest_path": source_rel,
-            "original_format": original_format,
-            "ingest_format": _ingest_format_from_path(source_rel),
-            "title": title,
-            "abstract_excerpt": "",
-            "arxiv_id": "",
-            "warnings": warnings,
-            "usable": usable,
-        }
-
-    resolved_source_path = _relative_to_project(candidate_path, raw_root)
-    text = ""
-    if candidate_path.suffix.lower() == ".pdf":
-        text, pdf_warnings = _extract_pdf_text(candidate_path)
-        warnings.extend(pdf_warnings)
-        if text:
-            title = _guess_title_from_text(text, _guess_local_title(candidate_path))
-            abstract_excerpt = _extract_abstract_excerpt(text)
-            # Look up arXiv ID in order: filename -> metadata -> page-0 text -> S2 title search
-            arxiv_id = _extract_arxiv_id(path.name)
-            if not arxiv_id:
-                arxiv_id = _extract_arxiv_id_from_pdf_metadata(candidate_path)
-            if not arxiv_id:
-                arxiv_id = _extract_arxiv_id(text[:1000])
-            if not arxiv_id:
-                arxiv_id = _recover_arxiv_id_by_title(title)
-            if arxiv_id:
-                source_dir = raw_root / "tmp" / "papers" / f"{_path_slug(path.relative_to(raw_root))}-arxiv-src"
-                dl_result = _download_arxiv_source(arxiv_id, source_dir)
-                if dl_result["success"]:
-                    source_meta = _extract_arxiv_source_metadata(source_dir)
-                    if source_meta["source_title"]:
-                        title = source_meta["source_title"]
-                    if source_meta["source_abstract"]:
-                        abstract_excerpt = source_meta["source_abstract"][:1200]
-                    prepared_path = _relative_to_project(source_dir, raw_root)
-                    canonical_path = prepared_path
-                    warnings.append(
-                        f"recovered arXiv ID {arxiv_id}; using fetched TeX source"
-                    )
-                else:
-                    out_path = raw_root / "tmp" / "papers" / f"{_path_slug(path.relative_to(raw_root))}.tex"
-                    _write_text(out_path, _build_synthetic_tex(title, text))
-                    prepared_path = _relative_to_project(out_path, raw_root)
-                    canonical_path = prepared_path
-                    warnings.append(
-                        f"recovered arXiv ID {arxiv_id} but TeX source download failed; "
-                        f"falling back to synthetic tex ({dl_result.get('error', 'unknown error')})"
-                    )
-            else:
-                out_path = raw_root / "tmp" / "papers" / f"{_path_slug(path.relative_to(raw_root))}.tex"
-                _write_text(out_path, _build_synthetic_tex(title, text))
-                prepared_path = _relative_to_project(out_path, raw_root)
-                canonical_path = prepared_path
-        else:
-            title = _guess_local_title(candidate_path)
-            canonical_path = resolved_source_path
-    else:
-        text = _read_text(candidate_path, limit=120000)
-        title = _guess_local_title(candidate_path)
-        arxiv_id = _extract_arxiv_id(f"{candidate_path.name} {title} {text[:2000]}")
-        abstract_excerpt = _extract_abstract_excerpt(text)
-        canonical_path = resolved_source_path
-
-    if not arxiv_id:
-        arxiv_id = _extract_arxiv_id(f"{path.name} {title} {abstract_excerpt}")
-    candidate_id = f"local:{slugify(title)}"
-    return {
-        "entry_id": candidate_id,
-        "candidate_id": candidate_id,
-        "source_kind": "paper",
-        "source_path": source_rel,
-        "resolved_source_path": resolved_source_path,
-        "prepared_path": prepared_path or None,
-        "canonical_ingest_path": canonical_path,
-        "original_format": original_format or candidate_path.suffix.lower().lstrip(".") or "file",
-        "ingest_format": _ingest_format_from_path(canonical_path),
-        "title": title,
-        "abstract_excerpt": abstract_excerpt,
-        "arxiv_id": arxiv_id,
-        "warnings": warnings,
-        "usable": usable,
-    }
+def _prepare_paper_entry(path: Path, raw_root: Path, title: str = "", arxiv_id: str = "") -> dict[str, Any]:
+    return paper_source.prepare_paper_source(path, raw_root, title=title, arxiv_id=arxiv_id)
 
 
-def prepare_inputs(raw_root: Path) -> dict[str, Any]:
+def prepare_inputs(
+    raw_root: Path,
+    pdf_titles: dict[str, Any] | None = None,
+    warning_sink: list[str] | None = None,
+) -> dict[str, Any]:
     raw_root = raw_root.resolve()
     tmp_root = raw_root / "tmp"
     (tmp_root / "papers").mkdir(parents=True, exist_ok=True)
     paper_entries: list[dict[str, Any]] = []
     other_entries: list[dict[str, Any]] = []
+    normalized_handoffs, original_title_keys = _normalize_pdf_titles_map(raw_root, pdf_titles, warning_sink=warning_sink)
+    seen_title_keys: set[str] = set()
 
     papers_root = raw_root / "papers"
     if papers_root.exists():
         for entry in sorted(papers_root.iterdir()):
             if entry.name == ".gitkeep":
                 continue
-            paper_entries.append(_prepare_paper_entry(entry, raw_root))
+            source_rel = _relative_to_project(entry, raw_root)
+            recovered = normalized_handoffs.get(source_rel, {})
+            recovered_title = recovered.get("title", "")
+            recovered_arxiv_id = recovered.get("arxiv_id", "")
+            if recovered_title or recovered_arxiv_id:
+                seen_title_keys.add(source_rel)
+            paper_entries.append(
+                _prepare_paper_entry(entry, raw_root, title=recovered_title, arxiv_id=recovered_arxiv_id)
+            )
 
     deduped_papers: dict[str, dict[str, Any]] = {}
-    title_index: dict[str, str] = {}
     for entry in paper_entries:
-        key = entry["candidate_id"]
-        arxiv_id, title_key = _paper_entry_match_key(entry)
-        if arxiv_id:
-            key = f"arxiv:{arxiv_id}"
-        elif title_key in title_index:
-            key = title_index[title_key]
+        arxiv_id, _title_key = _paper_entry_match_key(entry)
+        key = f"arxiv:{arxiv_id}" if arxiv_id else entry["candidate_id"]
 
         existing = deduped_papers.get(key)
         if existing is None:
             deduped_papers[key] = entry
-            title_index[title_key] = key
             continue
 
         if _paper_entry_preference(entry) > _paper_entry_preference(existing):
@@ -713,7 +680,11 @@ def prepare_inputs(raw_root: Path) -> dict[str, Any]:
             + list(dropped.get("warnings", []))
             + [f"duplicate local source skipped in favor of preferred source: {kept['source_path']}"]
         ))
-        title_index[title_key] = key
+
+    if warning_sink is not None:
+        for source_rel, original_key in sorted(original_title_keys.items()):
+            if source_rel not in seen_title_keys:
+                warning_sink.append(f"ignored unknown PDF title mapping: {original_key}")
 
     for kind in ("notes", "web"):
         base = raw_root / kind
@@ -804,7 +775,7 @@ def scan_local_papers(raw_root: Path, prepared_manifest: dict[str, Any] | None =
         title = _guess_local_title(candidate_path)
         arxiv_id = _extract_arxiv_id(f"{entry.name} {title} {_read_text(candidate_path, 2000)}")
         results.append({
-            "candidate_id": f"local:{slugify(title)}",
+            "candidate_id": _local_candidate_id(entry, raw_root),
             "title": title,
             "arxiv_id": arxiv_id,
             "path": str(candidate_path.relative_to(raw_root.parent)),
@@ -1657,6 +1628,7 @@ def main() -> None:
 
     p_prepare = sub.add_parser("prepare", help="Prepare local raw inputs into raw/tmp/ and emit a manifest")
     p_prepare.add_argument("--raw-root", default="raw")
+    p_prepare.add_argument("--pdf-titles-json")
     p_prepare.add_argument("--output-manifest", required=True)
 
     p_plan = sub.add_parser("plan", help="Build a deterministic discovery plan for /init")
@@ -1684,10 +1656,19 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.command == "prepare":
-        manifest = prepare_inputs(Path(args.raw_root))
+        pdf_titles = None
+        if args.pdf_titles_json:
+            try:
+                pdf_titles = _load_pdf_titles_json(Path(args.pdf_titles_json))
+            except (OSError, ValueError, json.JSONDecodeError) as exc:
+                parser.error(f"--pdf-titles-json: {exc}")
+        warnings: list[str] = []
+        manifest = prepare_inputs(Path(args.raw_root), pdf_titles=pdf_titles, warning_sink=warnings)
         output_path = Path(args.output_manifest)
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+        for warning in warnings:
+            print(f"warning: {warning}", file=sys.stderr)
         _print_json(manifest)
         return
 

--- a/tools/prepare_paper_source.py
+++ b/tools/prepare_paper_source.py
@@ -1,0 +1,758 @@
+#!/usr/bin/env python3
+"""Prepare one local paper source for ingest.
+
+Usage:
+    python3 tools/prepare_paper_source.py --raw-root raw --source raw/papers/example.pdf
+    python3 tools/prepare_paper_source.py --raw-root raw --source raw/papers/example.pdf --title "Recovered Paper Title"
+    python3 tools/prepare_paper_source.py --raw-root raw --source raw/papers/example.pdf --title "Recovered Paper Title" --arxiv-id 2401.00001
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import tarfile
+import zipfile
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+import requests
+
+from fetch_s2 import search as s2_search
+from research_wiki import slugify
+
+try:
+    import fitz
+
+    HAS_PYMUPDF = True
+except ImportError:
+    fitz = None
+    HAS_PYMUPDF = False
+
+STOP_WORDS = {
+    "a", "an", "and", "are", "as", "at", "be", "by", "for", "from",
+    "has", "have", "in", "into", "is", "it", "of", "on", "or", "that",
+    "the", "their", "this", "to", "we", "with", "you", "your",
+}
+TOKEN_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9.+/_-]*|[\u4e00-\u9fff]{2,}")
+ARXIV_NEW_ID_PATTERN = re.compile(r"(?<!\d)(\d{4}\.\d{4,5}(?:v\d+)?)(?!\d)", re.IGNORECASE)
+ARXIV_OLD_ID_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9])([a-z\-]+(?:\.[A-Z]{2})?/\d{7}(?:v\d+)?)(?!\d)",
+    re.IGNORECASE,
+)
+MAX_SOURCE_ARCHIVE_BYTES = 250_000_000
+LATEX_UNWRAP_COMMANDS = (
+    "emph",
+    "textbf",
+    "textit",
+    "textsc",
+    "textrm",
+    "textsf",
+    "texttt",
+    "underline",
+    "mbox",
+    "mathbf",
+    "mathit",
+    "mathrm",
+    "mathsf",
+    "mathtt",
+    "Large",
+    "LARGE",
+    "huge",
+    "Huge",
+    "large",
+    "normalsize",
+)
+LATEX_DROP_WITH_ARG_COMMANDS = (
+    "vspace",
+    "hspace",
+    "vskip",
+    "hskip",
+    "thanks",
+    "footnote",
+    "footnotemark",
+    "footnotetext",
+    "label",
+    "rule",
+    "raisebox",
+)
+LATEX_DROP_SIMPLE_COMMANDS = (
+    "newline",
+    "linebreak",
+    "pagebreak",
+    "smallskip",
+    "medskip",
+    "bigskip",
+    "noindent",
+    "centering",
+    "raggedright",
+    "raggedleft",
+    "hfill",
+    "vfill",
+    "quad",
+    "qquad",
+)
+
+
+def _project_root(raw_root: Path) -> Path:
+    return raw_root.resolve().parent
+
+
+def _relative_to_project(path: Path, raw_root: Path) -> str:
+    return str(path.resolve().relative_to(_project_root(raw_root)))
+
+
+def _resolve_project_path(raw_root: Path, rel_path: str) -> Path:
+    return _project_root(raw_root) / rel_path
+
+
+def _read_text(path: Path, limit: int = 20000) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="ignore")[:limit]
+    except OSError:
+        return ""
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _normalize_text(text: str) -> str:
+    text = re.sub(r"[^0-9A-Za-z\u4e00-\u9fff\s.+/_-]", " ", text.lower())
+    return " ".join(text.split())
+
+
+def _normalize_space(text: str) -> str:
+    return " ".join(str(text or "").split())
+
+
+def _tokenize(text: str) -> list[str]:
+    tokens = []
+    for token in TOKEN_PATTERN.findall(_normalize_text(text)):
+        token = token.strip("._/+ -")
+        if not token:
+            continue
+        if re.fullmatch(r"[a-z0-9]+", token) and len(token) < 3:
+            continue
+        if token in STOP_WORDS:
+            continue
+        tokens.append(token)
+    return tokens
+
+
+def _normalize_arxiv_id(arxiv_id: str) -> str:
+    arxiv_id = str(arxiv_id or "").strip()
+    if not arxiv_id:
+        return ""
+    return re.sub(r"v\d+$", "", arxiv_id, flags=re.IGNORECASE)
+
+
+def _extract_arxiv_id(text: str) -> str:
+    for pattern in (ARXIV_NEW_ID_PATTERN, ARXIV_OLD_ID_PATTERN):
+        match = pattern.search(text)
+        if match:
+            return _normalize_arxiv_id(match.group(1))
+    return ""
+
+
+def _recover_arxiv_id_by_title(title: str) -> str:
+    """Try to recover an arXiv ID by searching Semantic Scholar with a title."""
+    if not title or len(title) < 8:
+        return ""
+    try:
+        results = s2_search(title, limit=5)
+    except Exception:
+        return ""
+    normalized_title = _normalize_text(title)
+    title_tokens = set(_tokenize(normalized_title))
+    for result in results:
+        result_title = _normalize_text(str(result.get("title") or ""))
+        if not result_title:
+            continue
+        arxiv_id = (result.get("externalIds") or {}).get("ArXiv", "")
+        if not arxiv_id:
+            continue
+        if result_title == normalized_title:
+            return _normalize_arxiv_id(str(arxiv_id))
+        result_tokens = set(_tokenize(result_title))
+        if result_tokens and title_tokens:
+            overlap = len(result_tokens & title_tokens)
+            min_len = min(len(result_tokens), len(title_tokens))
+            if min_len > 0 and overlap / min_len >= 0.8:
+                return _normalize_arxiv_id(str(arxiv_id))
+    return ""
+
+
+def _download_arxiv_source(arxiv_id: str, dest_dir: Path) -> dict[str, Any]:
+    arxiv_id = _normalize_arxiv_id(arxiv_id)
+    headers = {"User-Agent": "OmegaWiki-prepare-paper-source/1.0"}
+    try:
+        src_resp = requests.get(f"https://arxiv.org/e-print/{arxiv_id}", timeout=30, headers=headers)
+        if src_resp.ok and src_resp.content:
+            with NamedTemporaryFile(suffix=".tar", delete=False) as tmp:
+                tmp.write(src_resp.content)
+                tmp_path = Path(tmp.name)
+            try:
+                dest_dir.mkdir(parents=True, exist_ok=True)
+                _safe_extract_tar(tmp_path, dest_dir)
+                if not any(path.is_file() for path in dest_dir.rglob("*")):
+                    raise ValueError("source archive extracted no files")
+                return {"success": True, "format": "directory", "error": None}
+            except (tarfile.TarError, OSError, ValueError) as exc:
+                shutil.rmtree(dest_dir, ignore_errors=True)
+                return {"success": False, "format": "", "error": str(exc)}
+            finally:
+                tmp_path.unlink(missing_ok=True)
+    except requests.RequestException as exc:
+        return {"success": False, "format": "", "error": str(exc)}
+    return {"success": False, "format": "", "error": "empty response"}
+
+
+def _extract_pdf_metadata(path: Path) -> dict[str, str]:
+    if not HAS_PYMUPDF:
+        return {}
+    try:
+        doc = fitz.open(path)
+        meta = doc.metadata or {}
+        doc.close()
+        return {key: str(meta.get(key) or "") for key in ("subject", "keywords", "title")}
+    except Exception:
+        return {}
+
+
+def _extract_pdf_metadata_title(path: Path) -> str:
+    meta = _extract_pdf_metadata(path)
+    title = _normalize_space(meta.get("title", ""))
+    if title and not _extract_arxiv_id(title):
+        return title[:300]
+    return ""
+
+
+def _strip_latex_comments(text: str) -> str:
+    return "\n".join(re.sub(r"(?<!\\)%.*$", "", line) for line in text.splitlines())
+
+
+def _sanitize_latex_fragment(text: str, *, strip_edge_punctuation: bool = False) -> str:
+    cleaned = str(text or "")
+    if not cleaned:
+        return ""
+    cleaned = _strip_latex_comments(cleaned)
+    cleaned = cleaned.replace("\\\\", " ")
+    cleaned = cleaned.replace("~", " ")
+    cleaned = cleaned.replace("$", "")
+    cleaned = cleaned.replace(r"\&", "&")
+    cleaned = cleaned.replace(r"\%", "%")
+    cleaned = cleaned.replace(r"\_", "_")
+    cleaned = cleaned.replace(r"\#", "#")
+
+    unwrap_pattern = re.compile(
+        rf"\\(?:{'|'.join(LATEX_UNWRAP_COMMANDS)})\*?(?:\[[^\]]*\])?\{{([^{{}}]*)\}}"
+    )
+    drop_with_arg_pattern = re.compile(
+        rf"\\(?:{'|'.join(LATEX_DROP_WITH_ARG_COMMANDS)})\*?(?:\[[^\]]*\])?\{{[^{{}}]*\}}"
+    )
+    previous = None
+    while cleaned != previous:
+        previous = cleaned
+        cleaned = unwrap_pattern.sub(r"\1", cleaned)
+        cleaned = drop_with_arg_pattern.sub(" ", cleaned)
+
+    cleaned = re.sub(
+        rf"\\(?:{'|'.join(LATEX_DROP_SIMPLE_COMMANDS)})\b",
+        " ",
+        cleaned,
+    )
+    cleaned = cleaned.replace(r"\LaTeX", "LaTeX").replace(r"\TeX", "TeX")
+    cleaned = re.sub(r"\\[A-Za-z@]+", " ", cleaned)
+    cleaned = cleaned.replace("\\", " ")
+    cleaned = cleaned.replace("{", " ").replace("}", " ")
+    cleaned = _normalize_space(cleaned)
+    if strip_edge_punctuation:
+        cleaned = cleaned.strip(" -,:;")
+    return cleaned
+
+
+def _is_usable_pdf_title(title: str) -> bool:
+    normalized = _normalize_space(title)
+    if len(normalized) < 8:
+        return False
+    if not re.search(r"[A-Za-z\u4e00-\u9fff]{4}", normalized):
+        return False
+    if normalized.endswith((":", "-", "/", "|")):
+        return False
+    return True
+
+
+def _sanitize_source_title(text: str) -> str:
+    cleaned = _sanitize_latex_fragment(text, strip_edge_punctuation=True)
+    if not _is_usable_pdf_title(cleaned):
+        return ""
+    return cleaned[:300]
+
+
+def _sanitize_source_abstract(text: str) -> str:
+    return _sanitize_latex_fragment(text)[:1200]
+
+
+def _find_tex_file_with_title(source_dir: Path) -> tuple[Path | None, str]:
+    for tex_file in sorted(source_dir.rglob("*.tex")):
+        try:
+            text = tex_file.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if text and re.search(r"\\[a-z]*title[a-z]*\{", text, re.IGNORECASE):
+            return tex_file, text
+    return None, ""
+
+
+def _extract_arxiv_source_metadata(source_dir: Path) -> dict[str, str]:
+    _tex_file, source_text = _find_tex_file_with_title(source_dir)
+    if not source_text:
+        return {"source_title": "", "source_abstract": ""}
+
+    source_title = ""
+    title_match = re.search(r"\\[a-z]*title[a-z]*\{", source_text, re.IGNORECASE)
+    if title_match:
+        start = title_match.end()
+        depth = 1
+        chars = []
+        idx = start
+        while idx < len(source_text) and depth > 0:
+            ch = source_text[idx]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+            if depth > 0:
+                chars.append(ch)
+            idx += 1
+        source_title = _sanitize_source_title("".join(chars))
+
+    source_abstract = ""
+    match = re.search(r"\\begin\{abstract\}(.+?)\\end\{abstract\}", source_text, re.DOTALL | re.IGNORECASE)
+    if match:
+        source_abstract = _sanitize_source_abstract(match.group(1))
+
+    return {"source_title": source_title, "source_abstract": source_abstract}
+
+
+def _guess_title_from_tex(text: str, fallback: str) -> str:
+    match = re.search(r"\\title\{(.+?)\}", text, re.DOTALL)
+    if match:
+        title = _sanitize_source_title(match.group(1))
+        if title:
+            return title
+    return fallback
+
+
+def _extract_abstract_excerpt(text: str, limit: int = 1200) -> str:
+    if not text.strip():
+        return ""
+    match = re.search(
+        r"(?is)(?:^|\n)\s*(?:abstract|摘要)\s*[:：]?\s*(.+?)(?:\n\s*(?:1\.?|i\.?|introduction|引言|keywords?|关键词)\b|\Z)",
+        text,
+    )
+    if match:
+        return re.sub(r"\s+", " ", match.group(1)).strip()[:limit]
+    first_paragraphs = re.split(r"\n\s*\n", text.strip())
+    for paragraph in first_paragraphs:
+        paragraph = re.sub(r"\s+", " ", paragraph).strip()
+        if len(paragraph) >= 40:
+            return paragraph[:limit]
+    return re.sub(r"\s+", " ", text).strip()[:limit]
+
+
+def _scan_paper_dir(path: Path) -> Path | None:
+    tex_files = sorted(path.rglob("*.tex"))
+    if tex_files:
+        return tex_files[0]
+    pdf_files = sorted(path.rglob("*.pdf"))
+    if pdf_files:
+        return pdf_files[0]
+    return None
+
+
+def _is_archive(path: Path) -> bool:
+    lower = path.name.lower()
+    return lower.endswith(".tar.gz") or lower.endswith(".tgz") or path.suffix.lower() == ".zip"
+
+
+def _path_slug(path: Path) -> str:
+    return slugify("-".join(path.parts)) or "item"
+
+
+def _latex_escape(text: str) -> str:
+    replacements = {
+        "\\": r"\textbackslash{}",
+        "&": r"\&",
+        "%": r"\%",
+        "$": r"\$",
+        "#": r"\#",
+        "_": r"\_",
+        "{": r"\{",
+        "}": r"\}",
+    }
+    return "".join(replacements.get(ch, ch) for ch in text)
+
+
+def _safe_extract_tar(archive: Path, dest_dir: Path) -> None:
+    dest_root = dest_dir.resolve()
+    total_size = 0
+    with tarfile.open(archive, mode="r:*") as tar:
+        members = tar.getmembers()
+        for member in members:
+            if member.issym() or member.islnk():
+                raise ValueError("archive contains link entries")
+            target = (dest_root / member.name).resolve()
+            if os.path.commonpath([str(dest_root), str(target)]) != str(dest_root):
+                raise ValueError(f"archive entry escapes destination: {member.name}")
+            total_size += max(member.size, 0)
+            if total_size > MAX_SOURCE_ARCHIVE_BYTES:
+                raise ValueError("archive exceeds extraction size limit")
+        tar.extractall(dest_dir, members=members)
+
+
+def _safe_extract_zip(archive: Path, dest_dir: Path) -> None:
+    dest_root = dest_dir.resolve()
+    total_size = 0
+    with zipfile.ZipFile(archive) as zf:
+        for member in zf.infolist():
+            target = (dest_root / member.filename).resolve()
+            if os.path.commonpath([str(dest_root), str(target)]) != str(dest_root):
+                raise ValueError(f"archive entry escapes destination: {member.filename}")
+            total_size += max(member.file_size, 0)
+            if total_size > MAX_SOURCE_ARCHIVE_BYTES:
+                raise ValueError("archive exceeds extraction size limit")
+        zf.extractall(dest_dir)
+
+
+def _extract_archive_to_tmp(source_path: Path, dest_dir: Path) -> list[str]:
+    warnings: list[str] = []
+    shutil.rmtree(dest_dir, ignore_errors=True)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        if source_path.suffix.lower() == ".zip":
+            _safe_extract_zip(source_path, dest_dir)
+        else:
+            _safe_extract_tar(source_path, dest_dir)
+    except (OSError, ValueError, tarfile.TarError, zipfile.BadZipFile) as exc:
+        shutil.rmtree(dest_dir, ignore_errors=True)
+        warnings.append(f"archive extraction failed: {exc}")
+    return warnings
+
+
+def _extract_pdf_text(path: Path) -> tuple[str, list[str]]:
+    warnings: list[str] = []
+    if not HAS_PYMUPDF:
+        warnings.append("PyMuPDF unavailable; cannot decode PDF during prepare")
+        return "", warnings
+    try:
+        doc = fitz.open(path)
+        try:
+            text_parts = [page.get_text("text") for page in doc]
+        finally:
+            doc.close()
+        text = "\n".join(part.strip() for part in text_parts if part.strip()).strip()
+        if not text:
+            warnings.append("PDF decode produced empty text")
+        return text[:120000], warnings
+    except Exception as exc:
+        warnings.append(f"PDF decode failed: {exc}")
+        return "", warnings
+
+
+def _build_synthetic_tex(title: str, text: str) -> str:
+    abstract = _extract_abstract_excerpt(text, limit=1500)
+    body = re.sub(r"\s+\n", "\n", text).strip()
+    if not body:
+        body = title
+    title_line = _latex_escape(title or "Untitled")
+    abstract_block = _latex_escape(abstract or body[:800])
+    body_block = _latex_escape(body[:60000])
+    return (
+        "\\title{" + title_line + "}\n"
+        "\\begin{document}\n"
+        "\\maketitle\n\n"
+        "\\begin{abstract}\n"
+        + abstract_block
+        + "\n\\end{abstract}\n\n"
+        "\\section{Recovered Text}\n"
+        + body_block
+        + "\n\\end{document}\n"
+    )
+
+
+def _ingest_format_from_path(path_str: str) -> str:
+    path = Path(path_str)
+    if path.suffix.lower() == ".tex":
+        return "tex"
+    if path.suffix.lower() == ".pdf":
+        return "pdf"
+    return "directory"
+
+
+def _base_title_from_path(path: Path) -> str:
+    return path.stem.replace("_", " ").replace("-", " ").strip() or "Untitled"
+
+
+def _local_candidate_id(path: Path, raw_root: Path) -> str:
+    return f"local:{_path_slug(path.relative_to(raw_root))}"
+
+
+def _metadata_path_for(path: Path, raw_root: Path) -> Path:
+    return raw_root / "tmp" / "papers" / f"{_path_slug(path.relative_to(raw_root))}.prepare.json"
+
+
+def _load_prepare_metadata(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    if payload.get("arxiv_id"):
+        payload["arxiv_id"] = _normalize_arxiv_id(str(payload["arxiv_id"]))
+    if payload.get("title"):
+        payload["title"] = _normalize_space(str(payload["title"]))
+    return payload
+
+
+def _write_prepare_metadata(path: Path, arxiv_id: str, title: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"arxiv_id": _normalize_arxiv_id(arxiv_id)}
+    if title:
+        payload["title"] = _normalize_space(title)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _replace_tex_title(tex_text: str, title: str) -> str:
+    replacement = "\\" + "title" + "{" + _latex_escape(title or "Untitled") + "}"
+    match = re.search(r"\\([A-Za-z@]*title[A-Za-z@]*)\{", tex_text, re.IGNORECASE)
+    if not match:
+        return replacement + "\n" + tex_text.lstrip()
+
+    command = match.group(1)
+    open_brace = match.end() - 1
+    depth = 1
+    idx = open_brace + 1
+    while idx < len(tex_text) and depth > 0:
+        ch = tex_text[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        idx += 1
+    if depth != 0:
+        return replacement + "\n" + tex_text.lstrip()
+
+    replacement = "\\" + command + "{" + _latex_escape(title or "Untitled") + "}"
+    return tex_text[:match.start()] + replacement + tex_text[idx:]
+
+
+def _rewrite_source_dir_title(source_dir: Path, title: str) -> None:
+    if not title:
+        return
+    tex_file, tex_text = _find_tex_file_with_title(source_dir)
+    if tex_file is None or not tex_text:
+        return
+    rewritten = _replace_tex_title(tex_text, title)
+    if rewritten != tex_text:
+        _write_text(tex_file, rewritten)
+
+
+def _refresh_synthetic_tex(path: Path, title: str, pdf_text: str) -> None:
+    if pdf_text:
+        _write_text(path, _build_synthetic_tex(title, pdf_text))
+        return
+    if path.exists():
+        existing = _read_text(path, limit=120000)
+        if existing:
+            _write_text(path, _replace_tex_title(existing, title))
+
+
+def prepare_paper_source(path: Path, raw_root: Path, title: str = "", arxiv_id: str = "") -> dict[str, Any]:
+    raw_root = raw_root.resolve()
+    path = path.resolve()
+    warnings: list[str] = []
+    source_rel = _relative_to_project(path, raw_root)
+    working_entry = path
+    original_format = "directory" if path.is_dir() else path.suffix.lower().lstrip(".")
+    prepared_path = ""
+    canonical_path = ""
+    resolved_source_path = source_rel
+    title = re.sub(r"\s+", " ", title).strip()
+    arxiv_id = _normalize_arxiv_id(arxiv_id)
+    authoritative_title = ""
+    abstract_excerpt = ""
+    usable = True
+    candidate_id = _local_candidate_id(path, raw_root)
+    metadata_path = _metadata_path_for(path, raw_root)
+    prepared_metadata = _load_prepare_metadata(metadata_path)
+
+    if path.is_file() and _is_archive(path):
+        extract_dir = raw_root / "tmp" / "papers" / f"{_path_slug(path.relative_to(raw_root))}-src"
+        warnings.extend(_extract_archive_to_tmp(path, extract_dir))
+        if extract_dir.exists():
+            working_entry = extract_dir
+            prepared_path = _relative_to_project(extract_dir, raw_root)
+            original_format = "archive"
+
+    candidate_path = _scan_paper_dir(working_entry) if working_entry.is_dir() else working_entry
+
+    if candidate_path is None:
+        usable = False
+        fallback_title = title or _base_title_from_path(path)
+        warnings.append("no parseable .tex or .pdf found for local paper source")
+        return {
+            "entry_id": candidate_id,
+            "candidate_id": candidate_id,
+            "source_kind": "paper",
+            "source_path": source_rel,
+            "resolved_source_path": source_rel,
+            "prepared_path": prepared_path or None,
+            "canonical_ingest_path": source_rel,
+            "original_format": original_format,
+            "ingest_format": _ingest_format_from_path(source_rel),
+            "title": fallback_title,
+            "abstract_excerpt": "",
+            "arxiv_id": "",
+            "warnings": warnings,
+            "usable": usable,
+        }
+
+    resolved_source_path = _relative_to_project(candidate_path, raw_root)
+    path_slug = _path_slug(path.relative_to(raw_root))
+    source_dir = raw_root / "tmp" / "papers" / f"{path_slug}-arxiv-src"
+    out_path = raw_root / "tmp" / "papers" / f"{path_slug}.tex"
+
+    if candidate_path.suffix.lower() == ".pdf":
+        text, pdf_warnings = _extract_pdf_text(candidate_path)
+        warnings.extend(pdf_warnings)
+        metadata_title = _extract_pdf_metadata_title(candidate_path)
+        stored_authoritative_title = _normalize_space(str(prepared_metadata.get("title") or ""))
+        authoritative_title = title or stored_authoritative_title
+        provisional_title = authoritative_title or metadata_title or _base_title_from_path(candidate_path)
+        abstract_excerpt = _extract_abstract_excerpt(text) if text else ""
+        stored_arxiv_id = _normalize_arxiv_id(str(prepared_metadata.get("arxiv_id") or ""))
+        arxiv_id = arxiv_id or _extract_arxiv_id(f"{path.name} {source_rel}")
+        if not arxiv_id and authoritative_title:
+            arxiv_id = _recover_arxiv_id_by_title(authoritative_title)
+        if not arxiv_id:
+            arxiv_id = stored_arxiv_id
+
+        if source_dir.exists() and any(source_dir.rglob("*")):
+            _rewrite_source_dir_title(source_dir, authoritative_title)
+            source_meta = _extract_arxiv_source_metadata(source_dir)
+            title = authoritative_title or source_meta["source_title"] or provisional_title
+            if source_meta["source_abstract"]:
+                abstract_excerpt = source_meta["source_abstract"][:1200]
+            prepared_path = _relative_to_project(source_dir, raw_root)
+            canonical_path = prepared_path
+        elif arxiv_id:
+            dl_result = _download_arxiv_source(arxiv_id, source_dir)
+            if dl_result["success"]:
+                _rewrite_source_dir_title(source_dir, authoritative_title)
+                source_meta = _extract_arxiv_source_metadata(source_dir)
+                title = authoritative_title or source_meta["source_title"] or provisional_title
+                if source_meta["source_abstract"]:
+                    abstract_excerpt = source_meta["source_abstract"][:1200]
+                prepared_path = _relative_to_project(source_dir, raw_root)
+                canonical_path = prepared_path
+                warnings.append(f"recovered arXiv ID {arxiv_id}; using fetched TeX source")
+            else:
+                if text or out_path.exists():
+                    if authoritative_title or not out_path.exists():
+                        _refresh_synthetic_tex(out_path, authoritative_title or provisional_title, text)
+                    if out_path.exists():
+                        prepared_path = _relative_to_project(out_path, raw_root)
+                        canonical_path = prepared_path
+                        title = authoritative_title or provisional_title
+                        if not abstract_excerpt:
+                            abstract_excerpt = _extract_abstract_excerpt(_read_text(out_path, limit=120000))
+                    else:
+                        canonical_path = resolved_source_path
+                        title = authoritative_title or provisional_title
+                else:
+                    canonical_path = resolved_source_path
+                    title = authoritative_title or provisional_title
+                warnings.append(
+                    f"recovered arXiv ID {arxiv_id} but TeX source download failed; "
+                    f"falling back to synthetic tex ({dl_result.get('error', 'unknown error')})"
+                )
+        else:
+            if text or out_path.exists():
+                if authoritative_title or not out_path.exists():
+                    _refresh_synthetic_tex(out_path, authoritative_title or provisional_title, text)
+                if out_path.exists():
+                    prepared_path = _relative_to_project(out_path, raw_root)
+                    canonical_path = prepared_path
+                    title = authoritative_title or provisional_title
+                    if not abstract_excerpt:
+                        abstract_excerpt = _extract_abstract_excerpt(_read_text(out_path, limit=120000))
+                else:
+                    canonical_path = resolved_source_path
+                    title = authoritative_title or provisional_title
+            else:
+                canonical_path = resolved_source_path
+                title = authoritative_title or provisional_title
+    else:
+        text = _read_text(candidate_path, limit=120000)
+        fallback_title = _base_title_from_path(candidate_path)
+        if working_entry.is_dir():
+            title = _guess_title_from_tex(text, fallback_title)
+        elif candidate_path.suffix.lower() == ".tex":
+            title = _guess_title_from_tex(text, fallback_title)
+        else:
+            title = fallback_title
+        arxiv_id = arxiv_id or _extract_arxiv_id(f"{candidate_path.name} {title} {text[:2000]}")
+        abstract_excerpt = _extract_abstract_excerpt(text)
+        canonical_path = resolved_source_path
+
+    if not arxiv_id:
+        arxiv_id = _extract_arxiv_id(f"{path.name} {title} {abstract_excerpt}")
+    if candidate_path.suffix.lower() == ".pdf" and prepared_path:
+        _write_prepare_metadata(metadata_path, arxiv_id, title=authoritative_title)
+    return {
+        "entry_id": candidate_id,
+        "candidate_id": candidate_id,
+        "source_kind": "paper",
+        "source_path": source_rel,
+        "resolved_source_path": resolved_source_path,
+        "prepared_path": prepared_path or None,
+        "canonical_ingest_path": canonical_path,
+        "original_format": original_format or candidate_path.suffix.lower().lstrip(".") or "file",
+        "ingest_format": _ingest_format_from_path(canonical_path),
+        "title": title,
+        "abstract_excerpt": abstract_excerpt,
+        "arxiv_id": arxiv_id,
+        "warnings": warnings,
+        "usable": usable,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw-root", required=True)
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--title", default="")
+    parser.add_argument("--arxiv-id", default="")
+    args = parser.parse_args()
+
+    raw_root = Path(args.raw_root)
+    source = Path(args.source)
+    if not source.is_absolute():
+        source = _resolve_project_path(raw_root, args.source)
+
+    result = prepare_paper_source(source, raw_root, title=args.title, arxiv_id=args.arxiv_id)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
… init and ingest.

## Summary

Agent-first PDF title extraction —— deterministic tools struggles to infer correct titles.

Refactor `/init` skill. Added level 3 references. It's no longer a single verbose SKILL.md. 

## Checklist

- [ ] `python -m pytest tests/ -v` passes
- [ ] Both `i18n/en/` and `i18n/zh/` updated (if modifying skills/CLAUDE.md/shared-references)
- [ ] `./setup.sh` run to sync active files (if i18n files changed)
- [ ] [`docs/extending.md`](docs/extending.md) checklist followed (if adding new module)
- [ ] No `src/` packages created (this is a Claude Code skill project)
