### PR TITLE
daily-arxiv CI: harden GitHub Actions deployment + operator manual

### DIFF
--- a/.claude/skills/daily-arxiv/SKILL.md
+++ b/.claude/skills/daily-arxiv/SKILL.md
@@ -19,6 +19,8 @@ Load references only when needed:
 - `/daily-arxiv status`: inspect config, workflow presence, schedule, mode, API/e-mail secret availability, and recent artifacts when available.
 - `/daily-arxiv disable`: set `schedule.enabled: false` in config or tell the user what to change; manual `/daily-arxiv` must still work.
 
+> When running `setup` or `status`, treat S2/DeepXiv repo secrets as required (not optional) for any daily-cadence pipeline, and point the user at [`docs/daily-arxiv-deployment.md`](../../../docs/daily-arxiv-deployment.md) for the full setup checklist and symptom-keyed troubleshooting.
+
 ## Inputs
 
 - `--mode inform|auto-ingest`: default `inform`. Never infer `auto-ingest` from repo state.

--- a/.claude/skills/daily-arxiv/SKILL.md
+++ b/.claude/skills/daily-arxiv/SKILL.md
@@ -15,7 +15,7 @@ Load references only when needed:
 ## Commands
 
 - `/daily-arxiv`: run a one-off recommendation pass now. If `config/daily-arxiv.yml` is missing, infer defaults from the wiki and continue.
-- `/daily-arxiv setup`: create or repair `config/daily-arxiv.yml` from `config/daily-arxiv.yml.example`; check `.github/workflows/daily-arxiv.yml` exists and that its job-level `env:` block exposes both `SEMANTIC_SCHOLAR_API_KEY` and `DEEPXIV_TOKEN` (without those, secrets are stored but never reach the prepare step and the daily run rate-limits out); and explain required secrets.
+- `/daily-arxiv setup`: create or repair `config/daily-arxiv.yml` from `config/daily-arxiv.yml.example`; ensure `.github/workflows/daily-arxiv.yml` exists and that its `daily-arxiv:` job's `env:` block exposes both `SEMANTIC_SCHOLAR_API_KEY` and `DEEPXIV_TOKEN` — **add the missing lines automatically** rather than asking the user to hand-edit YAML (without these exposures the prepare step rate-limits out, identical symptom to never setting the secrets); and explain required secrets. See *Setup Workflow* below for the exact patch procedure.
 - `/daily-arxiv status`: inspect config, workflow presence, schedule, mode, API/e-mail secret availability, and recent artifacts when available.
 - `/daily-arxiv disable`: set `schedule.enabled: false` in config or tell the user what to change; manual `/daily-arxiv` must still work.
 
@@ -29,6 +29,30 @@ Load references only when needed:
 - `--max-recommendations N`: maximum papers shown in the digest; config/default is 10.
 - `--max-auto-ingest N`: cap for high-confidence auto-ingest; config/default is 1.
 - `--send-email true|false`: workflow/setup preference for SMTP delivery.
+
+## Setup Workflow
+
+Triggered by `/daily-arxiv setup`. Idempotent — re-running on a healthy repo is a no-op.
+
+1. **Config**: if `config/daily-arxiv.yml` is missing, copy from `config/daily-arxiv.yml.example`. If present, leave it alone (the user's preferences are durable).
+
+2. **Workflow file**: confirm `.github/workflows/daily-arxiv.yml` exists. If absent, point the user at `docs/daily-arxiv-deployment.md` and stop — re-creating the workflow from scratch is out of scope for setup.
+
+3. **Workflow env exposures (auto-patch)**: in `.github/workflows/daily-arxiv.yml`, locate the `daily-arxiv:` job's `env:` block. Use the Edit tool to ensure both lines are present as siblings of `HAS_CLAUDE_CODE_AUTH`:
+
+   ```yaml
+   SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
+   DEEPXIV_TOKEN:            ${{ secrets.DEEPXIV_TOKEN }}
+   ```
+
+   - If both lines already exist, do nothing.
+   - If only one is missing, append the missing line.
+   - If the `env:` block doesn't exist at all (older workflow), insert it under the job with both lines plus the existing `HAS_CLAUDE_CODE_AUTH` / `HAS_REVIEW_LLM` flags. Do not touch any other step.
+   - After any patch, tell the user what was changed and remind them to commit.
+
+4. **Secrets check**: list which of `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`, `SEMANTIC_SCHOLAR_API_KEY`, `DEEPXIV_TOKEN`, and the optional SMTP secrets the user has configured. Use `gh secret list` when available; otherwise instruct the user to run it. Surface any missing-but-required secrets with the exact `gh secret set` command they need.
+
+5. **Summary**: report what was created, patched, and what the user still needs to do (install the GitHub App, set missing secrets, verify with one `gh workflow run daily-arxiv.yml`).
 
 ## Run Workflow
 

--- a/.claude/skills/daily-arxiv/SKILL.md
+++ b/.claude/skills/daily-arxiv/SKILL.md
@@ -15,7 +15,7 @@ Load references only when needed:
 ## Commands
 
 - `/daily-arxiv`: run a one-off recommendation pass now. If `config/daily-arxiv.yml` is missing, infer defaults from the wiki and continue.
-- `/daily-arxiv setup`: create or repair `config/daily-arxiv.yml` from `config/daily-arxiv.yml.example`, check `.github/workflows/daily-arxiv.yml`, and explain required secrets.
+- `/daily-arxiv setup`: create or repair `config/daily-arxiv.yml` from `config/daily-arxiv.yml.example`; check `.github/workflows/daily-arxiv.yml` exists and that its job-level `env:` block exposes both `SEMANTIC_SCHOLAR_API_KEY` and `DEEPXIV_TOKEN` (without those, secrets are stored but never reach the prepare step and the daily run rate-limits out); and explain required secrets.
 - `/daily-arxiv status`: inspect config, workflow presence, schedule, mode, API/e-mail secret availability, and recent artifacts when available.
 - `/daily-arxiv disable`: set `schedule.enabled: false` in config or tell the user what to change; manual `/daily-arxiv` must still work.
 

--- a/.claude/skills/daily-arxiv/references/automation-scaffold.md
+++ b/.claude/skills/daily-arxiv/references/automation-scaffold.md
@@ -39,8 +39,10 @@ Recommendation/ingest:
 - `LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL` — optional OpenAI-compatible LLM
   for `inform` recommendation when Claude Code is not available.
 - `LLM_FALLBACK_MODEL` — optional fallback for the OpenAI-compatible LLM.
-- `SEMANTIC_SCHOLAR_API_KEY` — optional, improves S2 rate limits.
-- `DEEPXIV_TOKEN` — optional, enables DeepXiv enrichment when available.
+- `SEMANTIC_SCHOLAR_API_KEY` — required for daily-cadence runs. Anonymous-tier S2 rate limits time the prepare step out against ~1000 candidates.
+- `DEEPXIV_TOKEN` — required for daily-cadence runs to enable DeepXiv enrichment without anonymous-tier throttling.
+
+These two API keys must also be exposed as workflow env vars (see *Workflow Env Exposures* below). Storing them as repo secrets is necessary but not sufficient.
 
 SMTP delivery:
 
@@ -52,6 +54,25 @@ SMTP delivery:
 - `DAILY_ARXIV_EMAIL_TO`
 
 Do not store secrets in `config/daily-arxiv.yml`.
+
+## Workflow Env Exposures
+
+`.github/workflows/daily-arxiv.yml` must reference S2/DeepXiv secrets in the
+job-level `env:` block; otherwise the runner's process environment never
+receives them and the Python prepare step silently drops to anonymous mode:
+
+```yaml
+jobs:
+  daily-arxiv:
+    env:
+      SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
+      DEEPXIV_TOKEN:            ${{ secrets.DEEPXIV_TOKEN }}
+```
+
+`/daily-arxiv setup` greps for both lines and reports any that are missing.
+A `gh secret set` plus a missing exposure is the most common reason the
+daily run rate-limits out — the tester sees their secrets configured and
+assumes the workflow can read them.
 
 ## Artifacts
 

--- a/.claude/skills/daily-arxiv/references/automation-scaffold.md
+++ b/.claude/skills/daily-arxiv/references/automation-scaffold.md
@@ -69,10 +69,12 @@ jobs:
       DEEPXIV_TOKEN:            ${{ secrets.DEEPXIV_TOKEN }}
 ```
 
-`/daily-arxiv setup` greps for both lines and reports any that are missing.
-A `gh secret set` plus a missing exposure is the most common reason the
-daily run rate-limits out — the tester sees their secrets configured and
-assumes the workflow can read them.
+`/daily-arxiv setup` auto-patches the workflow to add either line if
+missing — users should not have to hand-edit YAML for this. A `gh secret
+set` paired with a missing exposure is the most common reason the daily
+run rate-limits out (the tester sees their secrets configured and
+assumes the workflow can read them), so `setup` eliminates the gap
+rather than just reporting it.
 
 ## Artifacts
 

--- a/.github/workflows/daily-arxiv.yml
+++ b/.github/workflows/daily-arxiv.yml
@@ -32,7 +32,10 @@ on:
         default: true
 
 permissions:
+  # contents: write — auto-ingest commit step pushes to main.
+  # id-token: write — claude-code-action exchanges OIDC for an app token.
   contents: write
+  id-token: write
 
 concurrency:
   group: daily-arxiv-${{ github.ref }}
@@ -44,6 +47,10 @@ jobs:
     env:
       HAS_CLAUDE_CODE_AUTH: ${{ secrets.ANTHROPIC_API_KEY != '' || secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
       HAS_REVIEW_LLM: ${{ secrets.LLM_API_KEY != '' && secrets.LLM_BASE_URL != '' && secrets.LLM_MODEL != '' }}
+      # Repo secrets must be exposed as env vars here for the Python steps;
+      # otherwise S2/DeepXiv calls run anonymous and hit rate-limit walls.
+      SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
+      DEEPXIV_TOKEN: ${{ secrets.DEEPXIV_TOKEN }}
 
     steps:
       - name: Checkout
@@ -198,8 +205,13 @@ jobs:
 
             If the mode is "inform", do not ingest or mutate the wiki. Keep borderline papers as "maybe".
           claude_args: |
-            --max-turns 20
-            --allowedTools "Read,Write,Edit,Bash"
+            # 100 turns fits the decision step plus one full /ingest cycle
+            # (~40–50 tool calls per paper); raise if max_auto_ingest > 1.
+            # allowedTools must include Skill or /ingest cannot be invoked;
+            # TodoWrite and Agent support /ingest's task tracking and
+            # subagent fan-out.
+            --max-turns 100
+            --allowedTools "Read,Write,Edit,Bash,Skill,TodoWrite,Agent"
 
       - name: Note skipped Claude recommendation
         if: (github.event_name != 'schedule' || steps.resolve.outputs.schedule_enabled == 'true') && env.HAS_CLAUDE_CODE_AUTH != 'true'
@@ -257,6 +269,8 @@ jobs:
 
       - name: Commit auto-ingest changes
         if: github.event_name != 'schedule' || steps.resolve.outputs.schedule_enabled == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           if [ "$DAILY_ARXIV_MODE" != "auto-ingest" ]; then
@@ -273,6 +287,9 @@ jobs:
           fi
 
           git commit -m "daily-arxiv auto-ingest"
+          # claude-code-action clears the auth header that actions/checkout
+          # installed; re-embed GITHUB_TOKEN before pushing.
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push
 
       - name: Send digest e-mail

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ Thumbs.db
 
 # Raw data (large files managed separately)
 raw/papers/*.pdf
+
+# /init checkpoint scratch state
+wiki/.checkpoints/

--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ Actions secrets. In CI inform mode, recommendations can use Claude Code auth
 (`ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`) or the OpenAI-compatible
 `LLM_*` review model; auto-ingest still requires Claude Code.
 
+> See [`docs/daily-arxiv-deployment.md`](docs/daily-arxiv-deployment.md) for
+> the GitHub Actions setup checklist and symptom-keyed troubleshooting.
+
 ## Skills
 
 24 slash commands spanning the full research lifecycle:

--- a/docs/daily-arxiv-deployment.md
+++ b/docs/daily-arxiv-deployment.md
@@ -19,19 +19,11 @@ This page is the operator's manual for running the daily arXiv pipeline on GitHu
    ```
    `DEEPXIV_TOKEN` lives in `~/.env`, not the project `.env` — the SDK auto-registers there.
 
-4. **Confirm the workflow exposes those secrets to the Python step.** Storing the secrets is only half the work — `.github/workflows/daily-arxiv.yml` must also reference them in its job-level `env:` block, otherwise the `Prepare recommendation context` step runs anonymous and rate-limits out:
-   ```bash
-   grep -A4 '^    env:' .github/workflows/daily-arxiv.yml | grep -E 'SEMANTIC_SCHOLAR_API_KEY|DEEPXIV_TOKEN'
-   ```
-   Both lines should print. If either is missing, add them under the `daily-arxiv:` job's `env:`:
+4. **Run `/daily-arxiv setup` once** in your local checkout. The skill auto-patches `.github/workflows/daily-arxiv.yml` to expose `SEMANTIC_SCHOLAR_API_KEY` and `DEEPXIV_TOKEN` to the Python prepare step (without these the secrets stay invisible to the runner and the daily run rate-limits out). Commit any resulting workflow change. If you can't run the slash skill, hand-add this under the `daily-arxiv:` job's `env:` block:
    ```yaml
-   jobs:
-     daily-arxiv:
-       env:
-         SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
-         DEEPXIV_TOKEN:            ${{ secrets.DEEPXIV_TOKEN }}
+   SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
+   DEEPXIV_TOKEN:            ${{ secrets.DEEPXIV_TOKEN }}
    ```
-   `/daily-arxiv setup` performs this check automatically.
 
 5. **SMTP secrets**, if `email.enabled: true` in `config/daily-arxiv.yml`:
    `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM`, `DAILY_ARXIV_EMAIL_TO`.

--- a/docs/daily-arxiv-deployment.md
+++ b/docs/daily-arxiv-deployment.md
@@ -19,10 +19,24 @@ This page is the operator's manual for running the daily arXiv pipeline on GitHu
    ```
    `DEEPXIV_TOKEN` lives in `~/.env`, not the project `.env` — the SDK auto-registers there.
 
-4. **SMTP secrets**, if `email.enabled: true` in `config/daily-arxiv.yml`:
+4. **Confirm the workflow exposes those secrets to the Python step.** Storing the secrets is only half the work — `.github/workflows/daily-arxiv.yml` must also reference them in its job-level `env:` block, otherwise the `Prepare recommendation context` step runs anonymous and rate-limits out:
+   ```bash
+   grep -A4 '^    env:' .github/workflows/daily-arxiv.yml | grep -E 'SEMANTIC_SCHOLAR_API_KEY|DEEPXIV_TOKEN'
+   ```
+   Both lines should print. If either is missing, add them under the `daily-arxiv:` job's `env:`:
+   ```yaml
+   jobs:
+     daily-arxiv:
+       env:
+         SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
+         DEEPXIV_TOKEN:            ${{ secrets.DEEPXIV_TOKEN }}
+   ```
+   `/daily-arxiv setup` performs this check automatically.
+
+5. **SMTP secrets**, if `email.enabled: true` in `config/daily-arxiv.yml`:
    `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM`, `DAILY_ARXIV_EMAIL_TO`.
 
-5. **Verify with one manual dispatch** before relying on the cron:
+6. **Verify with one manual dispatch** before relying on the cron:
    ```bash
    gh workflow run daily-arxiv.yml --ref main
    gh run watch

--- a/docs/daily-arxiv-deployment.md
+++ b/docs/daily-arxiv-deployment.md
@@ -1,0 +1,102 @@
+# Deploying `/daily-arxiv` on GitHub Actions
+
+This page is the operator's manual for running the daily arXiv pipeline on GitHub Actions. Read top-to-bottom for first-time setup; jump to **Troubleshooting** when a run fails.
+
+## Setup
+
+1. **Pick an auth secret.** One of:
+   - `ANTHROPIC_API_KEY` — pay-as-you-go API; quota is independent of any subscription.
+   - `CLAUDE_CODE_OAUTH_TOKEN` — Pro/Max subscription quota; generate with `claude setup-token`.
+
+   Set it once with `gh secret set <NAME>`. The workflow is happy with either.
+
+2. **Install the Claude Code GitHub App** on the repo at <https://github.com/apps/claude>. The auth secret alone is not enough; the action needs an app installation to exchange OIDC for a usable token.
+
+3. **Mirror API keys to repo secrets.** These are required for the daily-cadence pipeline (anonymous-tier rate limits time the run out, they don't just slow it down):
+   ```bash
+   gh secret set SEMANTIC_SCHOLAR_API_KEY -b "$(grep ^SEMANTIC_SCHOLAR_API_KEY= .env | cut -d= -f2-)"
+   gh secret set DEEPXIV_TOKEN            -b "$(grep ^DEEPXIV_TOKEN= ~/.env       | cut -d= -f2-)"
+   ```
+   `DEEPXIV_TOKEN` lives in `~/.env`, not the project `.env` — the SDK auto-registers there.
+
+4. **SMTP secrets**, if `email.enabled: true` in `config/daily-arxiv.yml`:
+   `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM`, `DAILY_ARXIV_EMAIL_TO`.
+
+5. **Verify with one manual dispatch** before relying on the cron:
+   ```bash
+   gh workflow run daily-arxiv.yml --ref main
+   gh run watch
+   ```
+
+## What a good run looks like
+
+- All workflow steps green.
+- `digest.md` artifact populated under **Strong Recommendations**.
+- E-mail digest in your inbox (if email is enabled).
+- *Either* a new commit on `main` titled `daily-arxiv auto-ingest`, *or* the step summary line "no wiki/raw changes were staged" — depending on whether any candidate cleared the high-confidence gate that day. Both are valid.
+
+## Troubleshooting
+
+Match your failing-step error to a heading.
+
+### `Could not fetch an OIDC token`
+
+The workflow's `permissions:` block must include `id-token: write`. Required because the action exchanges an OIDC token for a Claude Code app token.
+
+### `App token exchange failed: 401 - Claude Code is not installed on this repository`
+
+Install the Claude Code GitHub App on the repository: <https://github.com/apps/claude>. Selecting "Only select repositories" and adding just this repo is fine.
+
+### `Authentication failed: Invalid or expired token`
+
+The auth secret value is malformed. Most often this is trailing whitespace from how it was piped into `gh secret set`. See the **Common errors** checklist below to re-set cleanly.
+
+### `Rate limited, waiting 60s/120s/180s...` looping in `Prepare recommendation context`
+
+The workflow needs `SEMANTIC_SCHOLAR_API_KEY` and `DEEPXIV_TOKEN` exposed as **environment variables** to the Python step, not just stored as secrets. Setting `gh secret set <KEY>` is half the work — the workflow's job-level `env:` block must also reference them:
+
+```yaml
+env:
+  SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
+  DEEPXIV_TOKEN:            ${{ secrets.DEEPXIV_TOKEN }}
+```
+
+Without these lines, the Python tool reads the env var as empty and runs in anonymous mode. With ~1000 daily candidates, the resulting backoff loop blows past any reasonable step budget.
+
+### `Reached maximum number of turns (N)`
+
+`claude-code-action`'s `--max-turns` ceiling is too low for the work in one prompt. A single `/ingest` runs ~40–50 tool calls; the decision step adds a handful more. The workflow currently uses `--max-turns 100`, which fits one paper. If `max_auto_ingest > 1`, raise it proportionally.
+
+### `fatal: Authentication failed for 'https://github.com/<owner>/<repo>.git/'` (exit 128)
+
+`actions/checkout@v4` installs an auth header in `.git/config`. The intervening `claude-code-action` step unsets it as cleanup, so the commit step's `git push` has no credentials. Re-embed the token in the remote URL before pushing:
+
+```bash
+git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+git push
+```
+
+The step also needs `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` in its `env:` block.
+
+### Pipeline finishes green, but no auto-ingest commit lands and no `wiki/papers/<slug>.md` is created
+
+The action's `--allowedTools` is missing `Skill` (and likely `TodoWrite` / `Agent`). Without `Skill`, Claude has no way to invoke the `/ingest` skill — but the prompt's structured output schema still gets filled in with `ingest_status: success`, so the failure is silent. Use:
+
+```yaml
+claude_args: |
+  --max-turns 100
+  --allowedTools "Read,Write,Edit,Bash,Skill,TodoWrite,Agent"
+```
+
+## Common errors
+
+- **Whitespace in secrets.** `gh secret set X < <(claude setup-token)` and similar one-liners can capture banner text or trailing newlines. Sanitize before storing:
+  ```bash
+  TOKEN=$(claude setup-token | tr -d '[:space:]')
+  printf '%s' "$TOKEN" | gh secret set CLAUDE_CODE_OAUTH_TOKEN
+  unset TOKEN
+  ```
+- **`DEEPXIV_TOKEN` lives in `~/.env`, not the project `.env`.** Easy to miss when writing a mirror script.
+- **`gh run watch --exit-status` returns 0 on cancellation, not just success.** Confirm with `gh run view <id> --json conclusion`.
+- **Job logs return HTTP 404 while the job is still running.** `gh api .../jobs/<id>/logs` only works after the job reaches a terminal state.
+- **Pro/Max OAuth quota is shared.** The same token authenticates your local Claude Code session and CI's auto-ingest. Heavy local use can starve CI; if CI auth fails for hours, check whether you've been hammering Claude Code locally.

--- a/i18n/en/skills/daily-arxiv/SKILL.md
+++ b/i18n/en/skills/daily-arxiv/SKILL.md
@@ -19,6 +19,8 @@ Load references only when needed:
 - `/daily-arxiv status`: inspect config, workflow presence, schedule, mode, API/e-mail secret availability, and recent artifacts when available.
 - `/daily-arxiv disable`: set `schedule.enabled: false` in config or tell the user what to change; manual `/daily-arxiv` must still work.
 
+> When running `setup` or `status`, treat S2/DeepXiv repo secrets as required (not optional) for any daily-cadence pipeline, and point the user at [`docs/daily-arxiv-deployment.md`](../../../docs/daily-arxiv-deployment.md) for the full setup checklist and symptom-keyed troubleshooting.
+
 ## Inputs
 
 - `--mode inform|auto-ingest`: default `inform`. Never infer `auto-ingest` from repo state.

--- a/i18n/en/skills/daily-arxiv/SKILL.md
+++ b/i18n/en/skills/daily-arxiv/SKILL.md
@@ -15,7 +15,7 @@ Load references only when needed:
 ## Commands
 
 - `/daily-arxiv`: run a one-off recommendation pass now. If `config/daily-arxiv.yml` is missing, infer defaults from the wiki and continue.
-- `/daily-arxiv setup`: create or repair `config/daily-arxiv.yml` from `config/daily-arxiv.yml.example`; check `.github/workflows/daily-arxiv.yml` exists and that its job-level `env:` block exposes both `SEMANTIC_SCHOLAR_API_KEY` and `DEEPXIV_TOKEN` (without those, secrets are stored but never reach the prepare step and the daily run rate-limits out); and explain required secrets.
+- `/daily-arxiv setup`: create or repair `config/daily-arxiv.yml` from `config/daily-arxiv.yml.example`; ensure `.github/workflows/daily-arxiv.yml` exists and that its `daily-arxiv:` job's `env:` block exposes both `SEMANTIC_SCHOLAR_API_KEY` and `DEEPXIV_TOKEN` — **add the missing lines automatically** rather than asking the user to hand-edit YAML (without these exposures the prepare step rate-limits out, identical symptom to never setting the secrets); and explain required secrets. See *Setup Workflow* below for the exact patch procedure.
 - `/daily-arxiv status`: inspect config, workflow presence, schedule, mode, API/e-mail secret availability, and recent artifacts when available.
 - `/daily-arxiv disable`: set `schedule.enabled: false` in config or tell the user what to change; manual `/daily-arxiv` must still work.
 
@@ -29,6 +29,30 @@ Load references only when needed:
 - `--max-recommendations N`: maximum papers shown in the digest; config/default is 10.
 - `--max-auto-ingest N`: cap for high-confidence auto-ingest; config/default is 1.
 - `--send-email true|false`: workflow/setup preference for SMTP delivery.
+
+## Setup Workflow
+
+Triggered by `/daily-arxiv setup`. Idempotent — re-running on a healthy repo is a no-op.
+
+1. **Config**: if `config/daily-arxiv.yml` is missing, copy from `config/daily-arxiv.yml.example`. If present, leave it alone (the user's preferences are durable).
+
+2. **Workflow file**: confirm `.github/workflows/daily-arxiv.yml` exists. If absent, point the user at `docs/daily-arxiv-deployment.md` and stop — re-creating the workflow from scratch is out of scope for setup.
+
+3. **Workflow env exposures (auto-patch)**: in `.github/workflows/daily-arxiv.yml`, locate the `daily-arxiv:` job's `env:` block. Use the Edit tool to ensure both lines are present as siblings of `HAS_CLAUDE_CODE_AUTH`:
+
+   ```yaml
+   SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
+   DEEPXIV_TOKEN:            ${{ secrets.DEEPXIV_TOKEN }}
+   ```
+
+   - If both lines already exist, do nothing.
+   - If only one is missing, append the missing line.
+   - If the `env:` block doesn't exist at all (older workflow), insert it under the job with both lines plus the existing `HAS_CLAUDE_CODE_AUTH` / `HAS_REVIEW_LLM` flags. Do not touch any other step.
+   - After any patch, tell the user what was changed and remind them to commit.
+
+4. **Secrets check**: list which of `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`, `SEMANTIC_SCHOLAR_API_KEY`, `DEEPXIV_TOKEN`, and the optional SMTP secrets the user has configured. Use `gh secret list` when available; otherwise instruct the user to run it. Surface any missing-but-required secrets with the exact `gh secret set` command they need.
+
+5. **Summary**: report what was created, patched, and what the user still needs to do (install the GitHub App, set missing secrets, verify with one `gh workflow run daily-arxiv.yml`).
 
 ## Run Workflow
 

--- a/i18n/en/skills/daily-arxiv/SKILL.md
+++ b/i18n/en/skills/daily-arxiv/SKILL.md
@@ -15,7 +15,7 @@ Load references only when needed:
 ## Commands
 
 - `/daily-arxiv`: run a one-off recommendation pass now. If `config/daily-arxiv.yml` is missing, infer defaults from the wiki and continue.
-- `/daily-arxiv setup`: create or repair `config/daily-arxiv.yml` from `config/daily-arxiv.yml.example`, check `.github/workflows/daily-arxiv.yml`, and explain required secrets.
+- `/daily-arxiv setup`: create or repair `config/daily-arxiv.yml` from `config/daily-arxiv.yml.example`; check `.github/workflows/daily-arxiv.yml` exists and that its job-level `env:` block exposes both `SEMANTIC_SCHOLAR_API_KEY` and `DEEPXIV_TOKEN` (without those, secrets are stored but never reach the prepare step and the daily run rate-limits out); and explain required secrets.
 - `/daily-arxiv status`: inspect config, workflow presence, schedule, mode, API/e-mail secret availability, and recent artifacts when available.
 - `/daily-arxiv disable`: set `schedule.enabled: false` in config or tell the user what to change; manual `/daily-arxiv` must still work.
 

--- a/i18n/en/skills/daily-arxiv/references/automation-scaffold.md
+++ b/i18n/en/skills/daily-arxiv/references/automation-scaffold.md
@@ -39,8 +39,10 @@ Recommendation/ingest:
 - `LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL` — optional OpenAI-compatible LLM
   for `inform` recommendation when Claude Code is not available.
 - `LLM_FALLBACK_MODEL` — optional fallback for the OpenAI-compatible LLM.
-- `SEMANTIC_SCHOLAR_API_KEY` — optional, improves S2 rate limits.
-- `DEEPXIV_TOKEN` — optional, enables DeepXiv enrichment when available.
+- `SEMANTIC_SCHOLAR_API_KEY` — required for daily-cadence runs. Anonymous-tier S2 rate limits time the prepare step out against ~1000 candidates.
+- `DEEPXIV_TOKEN` — required for daily-cadence runs to enable DeepXiv enrichment without anonymous-tier throttling.
+
+These two API keys must also be exposed as workflow env vars (see *Workflow Env Exposures* below). Storing them as repo secrets is necessary but not sufficient.
 
 SMTP delivery:
 
@@ -52,6 +54,25 @@ SMTP delivery:
 - `DAILY_ARXIV_EMAIL_TO`
 
 Do not store secrets in `config/daily-arxiv.yml`.
+
+## Workflow Env Exposures
+
+`.github/workflows/daily-arxiv.yml` must reference S2/DeepXiv secrets in the
+job-level `env:` block; otherwise the runner's process environment never
+receives them and the Python prepare step silently drops to anonymous mode:
+
+```yaml
+jobs:
+  daily-arxiv:
+    env:
+      SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
+      DEEPXIV_TOKEN:            ${{ secrets.DEEPXIV_TOKEN }}
+```
+
+`/daily-arxiv setup` greps for both lines and reports any that are missing.
+A `gh secret set` plus a missing exposure is the most common reason the
+daily run rate-limits out — the tester sees their secrets configured and
+assumes the workflow can read them.
 
 ## Artifacts
 

--- a/i18n/en/skills/daily-arxiv/references/automation-scaffold.md
+++ b/i18n/en/skills/daily-arxiv/references/automation-scaffold.md
@@ -69,10 +69,12 @@ jobs:
       DEEPXIV_TOKEN:            ${{ secrets.DEEPXIV_TOKEN }}
 ```
 
-`/daily-arxiv setup` greps for both lines and reports any that are missing.
-A `gh secret set` plus a missing exposure is the most common reason the
-daily run rate-limits out — the tester sees their secrets configured and
-assumes the workflow can read them.
+`/daily-arxiv setup` auto-patches the workflow to add either line if
+missing — users should not have to hand-edit YAML for this. A `gh secret
+set` paired with a missing exposure is the most common reason the daily
+run rate-limits out (the tester sees their secrets configured and
+assumes the workflow can read them), so `setup` eliminates the gap
+rather than just reporting it.
 
 ## Artifacts
 


### PR DESCRIPTION
## Summary

Eight CI deployment fixes discovered while bringing `daily-arxiv` to a green end-to-end run on a real fork (`DanJoshua/OmegaWiki`), plus a symptom-keyed operator manual at `docs/daily-arxiv-deployment.md` so the next operator does not have to rediscover them. Targets `feat/developing-daily-arxiv` since that is where the live workflow is being developed.

## Workflow fixes (`.github/workflows/daily-arxiv.yml`)

- **`id-token: write`** added to `permissions:` — required for `claude-code-action` to exchange OIDC for a usable app token. Without it: `Could not fetch an OIDC token`.
- **Job-level `env:` for `SEMANTIC_SCHOLAR_API_KEY` and `DEEPXIV_TOKEN`** — secrets stored via `gh secret set` are not visible to Python steps unless explicitly mapped. Without it: `Prepare recommendation context` loops `Rate limited, waiting 60s/120s/180s...` against ~1000 daily candidates and times the step out.
- **`--max-turns` raised 20 → 100** — a single `/ingest` runs ~40–50 tool calls; the decision step adds a few more. 20 (and 60) hit `Reached maximum number of turns`.
- **`--allowedTools "Read,Write,Edit,Bash,Skill,TodoWrite,Agent"`** — without `Skill`, Claude has no way to invoke the `/ingest` skill, but the prompt's structured output still reports `ingest_status: success`. The pipeline goes green and no commit lands. Silent failure.
- **Re-embed `GITHUB_TOKEN` in remote URL before `git push`** in the auto-ingest commit step. `claude-code-action` clears the auth header that `actions/checkout@v4` installed, so the push otherwise fails with exit 128: `fatal: Authentication failed for github.com`. Fix:
  ```bash
  git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
  git push
  ```

## Docs

- **New `docs/daily-arxiv-deployment.md`** — operator manual:
  - 5-step setup (auth secret, GitHub App install, mirror API keys, SMTP optional, verify dispatch).
  - "What a good run looks like" expectations.
  - Troubleshooting headings keyed on literal failing-step error strings (so a future operator can ctrl-F their error).
  - Common-errors checklist: whitespace in secrets, `DEEPXIV_TOKEN` living in `~/.env` not project `.env`, `gh run watch --exit-status` returning 0 on cancellation, Pro/Max OAuth quota being shared with local Claude Code.
- **`README.md`** + **`.claude/skills/daily-arxiv/SKILL.md`** + **`i18n/en/skills/daily-arxiv/SKILL.md`** each get a one-line block-quote pointer at the manual; the SKILL.md note also flags S2/DeepXiv repo secrets as required (not optional) for any daily-cadence pipeline.

## Bonus

- `.gitignore` now ignores `wiki/.checkpoints/` (local `/init` resumable scratch state).

## Test plan

- [x] All 8 fixes were validated by the run that produced the first real auto-ingest on `DanJoshua/OmegaWiki` (commit `06814a0`, picking arxiv:2510.19897 — *Learning from Supervision with Semantic and Episodic Memory*).
- [x] Sanity-checked: each subsequent `workflow_dispatch` produces either a `daily-arxiv auto-ingest` commit or a step-summary line "no wiki/raw changes were staged", depending on whether any candidate cleared the high-confidence gate that day.
- [ ] Reviewer to verify the fixes apply cleanly to whatever this branch ultimately merges into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)