### PR TITLE
  fix(visualize): render LaTeX math in SPA reader via marked-katex-extension

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>OmegaWiki</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
   <link rel="stylesheet" href="/app.css">
 </head>
 <body>

--- a/app/index.html
+++ b/app/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>OmegaWiki</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
   <link rel="stylesheet" href="/app.css">
 </head>
 <body>

--- a/app/modules/reader.js
+++ b/app/modules/reader.js
@@ -12,7 +12,7 @@ import { showToast } from "./ui.js";
 import { triggerIntent } from "./intent.js";
 
 marked.use({ gfm: true, breaks: false });
-marked.use(markedKatex({ throwOnError: false, output: "html", nonStandard: true }));
+marked.use(markedKatex({ throwOnError: false, nonStandard: true }));
 
 // --- viewIndex --------------------------------------------------------------
 

--- a/app/modules/reader.js
+++ b/app/modules/reader.js
@@ -3,6 +3,7 @@
 
 import { marked } from "https://cdn.jsdelivr.net/npm/marked@14.1.4/lib/marked.esm.js";
 import yaml from "https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/+esm";
+import markedKatex from "https://cdn.jsdelivr.net/npm/marked-katex-extension@5.1.4/+esm";
 import { getEntity, patchEntity, postEdge, postCitation, getGraph } from "./api.js";
 import { resolveWikilinks } from "./wikilink.js";
 import { state } from "./state.js";
@@ -11,6 +12,7 @@ import { showToast } from "./ui.js";
 import { triggerIntent } from "./intent.js";
 
 marked.use({ gfm: true, breaks: false });
+marked.use(markedKatex({ throwOnError: false, output: "html", nonStandard: true }));
 
 // --- viewIndex --------------------------------------------------------------
 


### PR DESCRIPTION
## Motivation 

  our SPA reader (`app/modules/reader.js`) imported only `marked` with no math-rendering plugin. Failures resulted on every paper containing math. That is,`$$...$$` survived as literal text — no block-math typesetting. See the screenshot below:

  我们的SPA reader 只引入了 `marked`，没装任何数学渲染插件，导致在`/visualize`的浏览器界面中：所有`$$...$$` 被当成纯文本输出，块级公式无法渲染。见下方的截图：

<img width="770" height="177" alt="image" src="https://github.com/user-attachments/assets/951ff0d5-10c9-454a-b65c-646766e1e738" />

## Changes

  - **`app/index.html`** — Add KaTeX stylesheet (`katex@0.16.11/dist/katex.min.css`).
  - **`app/modules/reader.js`**
    - Import `marked-katex-extension@5.1.4` and register via `marked.use(...)`, so math is tokenized at the `marked` lexer level (before emphasis parsing).
    - Pass `nonStandard: true`. Rationale: the extension's default inline regex requires the closing `$` to be followed by `\s ? ! . , :` or end-of-line. Source like `(range $[0,1]$),` violates this (closing `$` followed by `)`), causing the regex to **backtrack and greedily merge the failed span with the next `$...$` pair** into one invalid KaTeX input (which renders as red error text). `nonStandard: true` removes the lookahead and resolves the issue.

## test plans

  tested using wiki files that contain LaTeX math block. Successfully rendered.

 ## Notes
  
  - Direct PR to `main` `origin/dev` was deleted after the v1.5.0 release; this change is small/hotfix-level and self-contained.
  - This PR was assisted by Claude Code and human-reviewed.


