### PR TITLE
Add SciDAG: DAG-based multi-agent augmentation module

### DIFF
--- a/.claude/skills/exp-design-dag/SKILL.md
+++ b/.claude/skills/exp-design-dag/SKILL.md
@@ -1,0 +1,113 @@
+---
+description: SciDAG-augmented experiment design — design an experiment suite through a multi-agent operator DAG (method candidates + parallel reliability/test checks + consolidation) instead of a single pass, then write experiment pages using the same contract as /exp-design. Use for hard designs where one-shot planning is risky.
+argument-hint: "<idea-slug> [--complexity 1-5] [--dag <name>] [--mock]"
+---
+
+# /exp-design-dag
+
+> SciDAG augmentation of `/exp-design` (paper §5). The experimentation stage's
+> priority is **reliability** — experiments are the most expensive step, so the
+> design must be sound and runnable one-shot. This skill runs a **DAG of
+> reusable operators** from the **experiment DAG library**, where the `test`
+> (feasibility/logic) operator is prominent and appears on parallel branches, to
+> stress the design before any compute is spent. It returns the result to the
+> **same artifact contract as `/exp-design`** — `wiki/experiments/{exp-slug}.md`
+> pages, a master design doc, and `tested_by` edges — so nothing downstream
+> changes.
+>
+> This is an **additive** skill. It does **not** modify `/exp-design`; use
+> `/exp-design` for the standard pipeline and `/exp-design-dag` when a design is
+> hard or costly enough to warrant multi-agent reliability checking.
+
+## Inputs
+
+- `idea-slug` (required): the idea to design experiments for
+  (`wiki/ideas/{slug}.md`).
+- `--complexity 1-5` (optional): DAG size, scaled to design difficulty. Omit to
+  use the **paper-figure architecture** (`candidate-doubletest-refine`).
+- `--dag <name>` (optional): run a specific architecture from the experiment
+  library (overrides `--complexity`). See `scidag/templates/experiment/`.
+- `--mock` (optional): offline deterministic LLM (wiring test only).
+
+## Outputs
+
+Identical contract to `/exp-design`:
+- `wiki/experiments/{exp-slug}.md` — one page per experiment block
+  (`status: planned`, `linked_idea` set)
+- `experiments/designs/{slug}-master.md` — master design document
+- `wiki/graph/edges.jsonl` — `tested_by` edges (idea → each experiment)
+- `wiki/ideas/{slug}.md` — updated `linked_experiments`
+- `wiki/graph/context_brief.md`, `open_questions.md` — rebuilt
+- **DESIGN_REPORT** (terminal) — plus the DAG architecture used
+
+## How it relates to /exp-design
+
+`/exp-design` Phase 2 (method candidate generation) and its iterative-ablation
+loop are the parts this skill expresses as a DAG: parallel candidate designs,
+each gated by a `test`, consolidated by `refine` (and `debate` for ablation
+comparison in the larger architectures). Phases 1 (load context), 3 (benchmark
+selection), and the persistence rules are **reused unchanged** from `/exp-design`.
+Read the `/exp-design` SKILL.md "Outputs", "Wiki Interaction", and Phase 1–3
+sections and apply them verbatim.
+
+## Workflow
+
+**Precondition**: working directory is the wiki project root (contains `wiki/`,
+`raw/`, `tools/`, `scidag/`).
+
+### Phase 1 — Load context (reuse /exp-design Phase 1)
+
+Follow `/exp-design` Phase 1: read `wiki/ideas/{slug}.md` (hypothesis, approach,
+risks, novelty), the pilot report if present, related `methods`/`papers`, and
+existing experiments. Add benchmark/baseline context from `/exp-design` Phase 3.
+Compress into a single **task brief** describing the idea, its hypothesis, the
+hardware/compute budget, and the candidate method directions. This is the DAG's
+task input.
+
+### Phase 2 — Run the experiment DAG (replaces /exp-design Phase 2 + ablation loop)
+
+1. **Pick the architecture**:
+   ```bash
+   python3 -m scidag.cli select --stage experiment [--complexity N]
+   ```
+   Use `--dag <name>` if the user named one. Larger architectures
+   (`iterative-ablation`, `full-reliability-suite`) suit designs with many
+   factors to ablate or high run cost.
+
+2. **Run the DAG** with the task brief:
+   ```bash
+   python3 -m scidag.cli run --stage experiment --dag <name> \
+       --task-file /tmp/expdesign_dag_task.md [--mock] --show-dag
+   ```
+   Extract the artifact (a consolidated experiment design) from between the
+   `===SCIDAG-ARTIFACT-BEGIN/END===` markers. The design enumerates method
+   candidate(s), benchmark + baselines + metrics, and the experiment blocks
+   (main, ablation, sensitivity), each with a feasibility note from the DAG's
+   `test` operator(s).
+
+### Phase 3 — Benchmark finalization (reuse /exp-design Phase 3)
+
+Reconcile the DAG's proposed benchmark/metrics with `/exp-design` Phase 3
+standards (use field-standard datasets/metrics; verify baselines exist in the
+wiki). Adjust the design if the DAG picked a non-standard benchmark.
+
+### Phase 4 — Write to wiki (reuse /exp-design persistence)
+
+Split the consolidated design into one `wiki/experiments/{exp-slug}.md` per block
+(`status: planned`, `linked_idea: {idea-slug}`) following
+`runtime/templates/experiments.md.tmpl`; write `experiments/designs/{slug}-master.md`;
+add `tested_by` edges via `tools/research_wiki.py add-edge`; update the idea's
+`linked_experiments`; rebuild `context_brief` / `open_questions`; append a
+`wiki/log.md` entry noting `/exp-design-dag` with architecture `<name>`.
+
+### Report
+
+Emit the standard DESIGN_REPORT, adding:
+`SciDAG: ran experiment architecture <name> (complexity c<N>, <k> LLM calls)`.
+
+## Notes
+
+- Calls the SciDAG engine in `scidag/`; same LLM config as `llm-review`
+  (`LLM_API_KEY` / `LLM_BASE_URL` / `LLM_MODEL` in `.env`).
+- The DAG `test` operator checks design **feasibility/logic** (oracle-free); it
+  does not run real experiments. Actual execution remains `/exp-run`.

--- a/.claude/skills/ideate-dag/SKILL.md
+++ b/.claude/skills/ideate-dag/SKILL.md
@@ -1,0 +1,116 @@
+---
+description: SciDAG-augmented ideation — generate research ideas through a multi-agent operator DAG (diverse generation + debate + feasibility screen) instead of a single brainstorm pass, then write the surviving idea(s) to the wiki using the same contract as /ideate. Use for hard or high-stakes ideation where one pass is not enough.
+argument-hint: "[research-direction-or-topic] [--complexity 1-5] [--dag <name>] [--max-ideas N] [--mock]"
+---
+
+# /ideate-dag
+
+> SciDAG augmentation of `/ideate` (paper §5). Instead of a single dual-model
+> brainstorm, this skill runs a **directed acyclic graph of reusable research
+> operators** (generate / variation / debate / refine / test / ensemble) from
+> the **ideation DAG library**, then returns the result to the **same artifact
+> contract as `/ideate`** — `wiki/ideas/{slug}.md` pages plus graph edges — so
+> nothing downstream changes. The DAG recovers the error-correction and
+> iteration that a linear brainstorm lacks: ideas are explored, debated, and
+> feasibility-screened before they are written.
+>
+> This is an **additive** skill. It does **not** modify `/ideate`; use `/ideate`
+> for the standard linear pipeline and `/ideate-dag` when a direction is hard
+> enough to warrant multi-agent search.
+
+## Inputs
+
+- `direction` (optional): research direction / keywords / problem statement.
+  If omitted, pick the most valuable direction from `wiki/graph/open_questions.md`
+  (same rule as `/ideate`).
+- `--complexity 1-5` (optional): how large a DAG to run, scaled to task
+  difficulty. Omit to use the **paper-figure architecture** (`explore-debate-test`).
+- `--dag <name>` (optional): run a specific architecture from the ideation
+  library (overrides `--complexity`). See `scidag/templates/ideation/`.
+- `--max-ideas N` (optional, default 3): max idea pages to write.
+- `--mock` (optional): run the DAG with the offline deterministic LLM (wiring
+  test only; produces placeholder ideas).
+
+## Outputs
+
+Identical contract to `/ideate`:
+- `wiki/ideas/{slug}.md` — one page per idea (`status: proposed`)
+- `wiki/graph/edges.jsonl` — `addresses_gap` / `inspired_by` edges
+- `wiki/graph/context_brief.md`, `wiki/graph/open_questions.md` — rebuilt
+- **IDEA_REPORT** (terminal) — plus a note of which DAG architecture ran
+
+## How it relates to /ideate
+
+`/ideate` Phase 2 ("dual-model brainstorm") is the step this skill replaces with
+a DAG. Phases 1 (landscape scan), 3 (novelty/feasibility validation), and 4
+(write to wiki) are **reused unchanged**: this skill produces the candidate
+idea(s) via the DAG, then follows `/ideate`'s own "Write ideas to wiki" rules to
+persist them. Read the `/ideate` SKILL.md "Outputs", "Wiki Interaction", and
+Phase 4 sections and apply them verbatim for persistence.
+
+## Workflow
+
+**Precondition**: working directory is the wiki project root (contains `wiki/`,
+`raw/`, `tools/`, `scidag/`).
+
+### Phase 1 — Landscape scan (reuse /ideate Phase 1)
+
+Follow `/ideate` Phase 1 to assemble the context for the target direction:
+wiki internal context (`context_brief.md`, `open_questions.md`, relevant
+`papers`/`concepts`/`methods`/`topics`) + external search (WebSearch + S2 +
+DeepXiv). Compress this into a single **task brief** — a few paragraphs naming
+the direction, the known gaps, and the most relevant prior work. This brief is
+the DAG's task input.
+
+### Phase 2 — Run the ideation DAG (replaces /ideate Phase 2)
+
+1. **Pick the architecture**:
+   ```bash
+   # default = paper-figure architecture; or pass --complexity / --dag
+   python3 -m scidag.cli select --stage ideation [--complexity N]
+   ```
+   If the user passed `--dag <name>`, use that name directly. Otherwise use the
+   `select` result (a heuristic: larger DAG for harder/broader directions).
+
+2. **Run the DAG** with the task brief from Phase 1:
+   ```bash
+   # write the task brief to a file to avoid shell-quoting issues
+   python3 -m scidag.cli run --stage ideation --dag <name> \
+       --task-file /tmp/ideate_dag_task.md [--mock] --show-dag
+   ```
+   The artifact (a research idea following the Title / Motivation / Hypothesis /
+   Approach / Why / Risks format) is printed between
+   `===SCIDAG-ARTIFACT-BEGIN===` and `===SCIDAG-ARTIFACT-END===`. Extract it.
+
+3. **For multiple ideas** (`--max-ideas N > 1`): run the DAG N times (or run a
+   broader architecture once and treat each leaf candidate as an idea). Keep the
+   N strongest distinct ideas.
+
+### Phase 3 — Validation (reuse /ideate Phase 3, optional)
+
+The chosen DAG already includes a feasibility `test` operator. For high-stakes
+ideas, additionally run `/novelty` (and `/review`) on each surviving idea exactly
+as `/ideate` Phase 3 does, and drop ideas that fail.
+
+### Phase 4 — Write to wiki (reuse /ideate Phase 4)
+
+Persist each surviving idea using `/ideate`'s Phase 4 rules: map the DAG
+artifact's sections onto `runtime/templates/ideas.md.tmpl` + `entities.yaml`,
+create `wiki/ideas/{slug}.md` (`status: proposed`), add `addresses_gap` /
+`inspired_by` edges via `tools/research_wiki.py add-edge`, then rebuild
+`context_brief` and `open_questions`. Append a `wiki/log.md` entry noting that
+ideas were produced by `/ideate-dag` with architecture `<name>`.
+
+### Report
+
+Emit the standard IDEA_REPORT, adding one line:
+`SciDAG: ran ideation architecture <name> (complexity c<N>, <k> LLM calls)`.
+
+## Notes
+
+- This skill calls the SciDAG engine in `scidag/` (operators + DAG executor).
+  The engine uses the same LLM config as the `llm-review` MCP server
+  (`LLM_API_KEY` / `LLM_BASE_URL` / `LLM_MODEL` in `.env`).
+- Conditional-edge pruning and a learned architecture controller are not yet
+  implemented; architecture choice is via `--complexity` / `--dag` / the
+  paper-figure default.

--- a/.claude/skills/paper-plan-dag/SKILL.md
+++ b/.claude/skills/paper-plan-dag/SKILL.md
@@ -1,0 +1,109 @@
+---
+description: SciDAG-augmented paper planning — compile a paper outline through a multi-agent operator DAG (draft + review + refine + polish) instead of a single pass, then write PAPER_PLAN using the same contract as /paper-plan. Use for hard or high-stakes outlines where one drafting pass is not enough.
+argument-hint: "<idea-slugs...> --venue <ICLR|NeurIPS|ICML|ACL|CVPR|IEEE> [--complexity 1-5] [--dag <name>] [--title <t>] [--mock]"
+---
+
+# /paper-plan-dag
+
+> SciDAG augmentation of `/paper-plan` (paper §5). The writing stage's priority
+> is **evidence fidelity and refinement**: the plan must faithfully express the
+> ideas and their evidence. This skill runs a **DAG of reusable operators** from
+> the **writing DAG library**, built around the **review→polish** pair (a draft
+> is independently reviewed and refined in parallel, then polished), to catch
+> unsupported claims and structural gaps before the outline is committed. It
+> returns the result to the **same artifact contract as `/paper-plan`** — a
+> `PAPER_PLAN.md` in `wiki/outputs/`, a manuscript record, and `derived_from`
+> edges — so nothing downstream changes.
+>
+> This is an **additive** skill. It does **not** modify `/paper-plan`; use
+> `/paper-plan` for the standard pipeline and `/paper-plan-dag` when an outline
+> is hard or high-stakes enough to warrant multi-agent review.
+
+## Inputs
+
+- `ideas` (required): target idea slugs (space-separated); same eligibility
+  rules as `/paper-plan` (`validated`, or `in_progress` with a succeeded
+  experiment).
+- `--venue` (required): target venue (ICLR / NeurIPS / ICML / ACL / CVPR / IEEE).
+- `--complexity 1-5` (optional): DAG size. Omit to use the **paper-figure
+  architecture** (`review-polish`).
+- `--dag <name>` (optional): run a specific architecture from the writing
+  library (overrides `--complexity`). See `scidag/templates/writing/`.
+- `--title <t>` (optional): working title.
+- `--mock` (optional): offline deterministic LLM (wiring test only).
+
+## Outputs
+
+Identical contract to `/paper-plan`:
+- `wiki/outputs/paper-plan-{slug}-{date}.md` — the PAPER_PLAN
+- `wiki/manuscripts/{slug}.md` — manuscript record (`status: drafting`)
+- `wiki/graph/edges.jsonl` — `derived_from` edges (plan → ideas/papers)
+- `wiki/graph/context_brief.md` — rebuilt
+- **PAPER_PLAN_REPORT** (terminal) — plus the DAG architecture used
+
+## How it relates to /paper-plan
+
+`/paper-plan` makes Review LLM review **mandatory**; this skill makes review a
+first-class DAG operator and pairs it with refine + polish. The DAG produces the
+outline core (narrative structure + section plan); `/paper-plan`'s Step 1
+(load idea graph), Step 2 (evidence map), the figure/citation planning, and the
+persistence rules are **reused unchanged**. Read the `/paper-plan` SKILL.md
+"Outputs", "Wiki Interaction", and Step 1–2 sections and apply them verbatim.
+
+## Workflow
+
+**Precondition**: working directory is the wiki project root (contains `wiki/`,
+`raw/`, `tools/`, `scidag/`).
+
+### Phase 1 — Load idea graph + evidence map (reuse /paper-plan Steps 1–2)
+
+Follow `/paper-plan` Step 1 (read target ideas, their `linked_experiments`,
+`origin_gaps` concepts/topics, approach-sketch methods/papers) and Step 2
+(compile the evidence map: ideas → evidence → sections). Compress this into a
+single **task brief** containing the venue + page limit, the evidence map, and
+the candidate narrative thrust. This is the DAG's task input.
+
+### Phase 2 — Run the writing DAG (replaces /paper-plan drafting + review)
+
+1. **Pick the architecture**:
+   ```bash
+   python3 -m scidag.cli select --stage writing [--complexity N]
+   ```
+   Use `--dag <name>` if the user named one. Larger architectures
+   (`full-review-suite`) suit multi-idea papers needing several review lenses.
+
+2. **Run the DAG** with the task brief:
+   ```bash
+   python3 -m scidag.cli run --stage writing --dag <name> \
+       --task-file /tmp/paperplan_dag_task.md [--mock] --show-dag
+   ```
+   Extract the artifact (the outline: narrative structure + section plan, already
+   reviewed and polished) from between the `===SCIDAG-ARTIFACT-BEGIN/END===`
+   markers.
+
+### Phase 3 — Figure + citation plan (reuse /paper-plan)
+
+The DAG produces narrative + sections; add the **figure plan** and **citation
+plan** following `/paper-plan` (each section → figures/tables it needs; each
+claim → wiki evidence + verified BibTeX). Keep `/paper-plan`'s citation
+discipline (`citation-verification.md`).
+
+### Phase 4 — Write PAPER_PLAN (reuse /paper-plan persistence)
+
+Assemble the full PAPER_PLAN.md (narrative + sections from the DAG, plus figure
+and citation plans) and write it to `wiki/outputs/paper-plan-{slug}-{date}.md`;
+create/update `wiki/manuscripts/{slug}.md` (`status: drafting`); add
+`derived_from` edges via `tools/research_wiki.py add-edge`; rebuild
+`context_brief`; append a `wiki/log.md` entry noting `/paper-plan-dag` with
+architecture `<name>`.
+
+### Report
+
+Emit the standard PAPER_PLAN_REPORT, adding:
+`SciDAG: ran writing architecture <name> (complexity c<N>, <k> LLM calls)`.
+
+## Notes
+
+- Calls the SciDAG engine in `scidag/`; same LLM config as `llm-review`
+  (`LLM_API_KEY` / `LLM_BASE_URL` / `LLM_MODEL` in `.env`). The DAG's `review`
+  operator is the in-engine analogue of `/paper-plan`'s mandatory Review LLM step.

--- a/scidag/README.md
+++ b/scidag/README.md
@@ -1,0 +1,132 @@
+# SciDAG — DAG-Based Multi-Agent Augmentation
+
+Implementation of the **SciDAG** module from the AutoSci paper (Agent4S @ BAAI
+2026, §5). SciDAG lets a hard SciFlow skill call a directed acyclic graph of
+reusable research operators as a tool: given a stage task `z`, it runs an
+operator graph `G = (V, E)` and returns **one research idea** under the same
+artifact contract, so the calling skill is unchanged.
+
+The operator and DAG-execution logic is adapted from the MaAS repository
+(`MaAS-main`); the LLM call layer is rewired to AutoSci's OpenAI-compatible
+endpoint and the artifacts are reframed from code to **research ideas (text)**.
+
+> Status: **step 2 — full 9-operator library + DAG executor.** No MetaGPT
+> dependency. The learned controller (architecture-layer selection),
+> conditional-edge routing (execution-layer pruning), and the trace/experience
+> repository come in later steps.
+
+## Layout
+
+| Path | Role | Paper mapping |
+|---|---|---|
+| `operators/` | the 7 reusable operators + prompts + registry | §1 operator library |
+| `dag.py` | `SampledDAG` / `DAGNode` graph data structure | §1 operator graph |
+| `executor.py` | `DAGExecutor` — topological run, lanes, merge vote | §1 adaptive operator graph |
+| `builder.py` | build a DAG from a spec; load/list stage libraries | §2 stage templates |
+| `templates/<stage>/` | per-module DAG library (5 architectures each) | §2 stage specialization |
+| `llm.py` | thin async OpenAI-compatible client (+ mock) | (runtime) |
+| `examples/` | runnable demo / offline smoke | — |
+
+## Operators (the paper's full 9, reframed code → research idea)
+
+| Operator | Calls | Role | Inputs → Output | Source |
+|---|---|---|---|---|
+| `Generate` | 1 | producer | task → idea | MaAS Generate |
+| `GenerateCoT` | 1 | producer (reasoning) | task → idea | MaAS GenerateCoT |
+| `MultiGenerate` | N (3) | producer (fan-out) | task → N idea lanes | MaAS MultiGenerateCoT |
+| `Variation` | 1 | consumer (explore) | task, idea → different idea | MaAS Variation |
+| `Refine` | 1 | consumer (improve) | task, idea → sharpened idea | MaAS SelfRefine |
+| `Debate` | 4 | consumer (two experts A→B→A→B) | task, idea → refined idea | MaAS Debate |
+| `Test` | 1 (+≤1 repair) | verifier (feasibility/logic, oracle-free) | task, idea → {result, solution} | MaAS Test (re-adapted) |
+| `Review` | 1 | consumer (scored critique) | task, idea → {response=idea+feedback, score, verdict} | new |
+| `Polish` | 1 | consumer (review-guided edit) | task, idea → polished idea | new |
+| `Ensemble` | 1 | aggregator (never sampled) | task, ideas → strongest idea | MaAS ScEnsemble |
+| `EarlyStop` | 0 | control signal | — | MaAS EarlyStop |
+
+`Review` produces an independent, scored critique (novelty / soundness /
+feasibility / clarity + an overall `Score: N/10` and `Verdict`) and appends it
+to the idea as a `## Review feedback` block; `Polish` consumes that block,
+applies the presentational suggestions, and returns a clean write-up — the
+paper's writing-stage critique→edit pair. `Ensemble` is used only for
+multi-parent merge and the final leaf vote; `EarlyStop` is a control action for
+branch pruning, never executed as a node.
+
+### Prompt adaptation
+
+All operator prompts (`operators/prompts.py`) are written for the **research**
+task, not MaAS's code task. The key adaptation: MaAS prompts optimize a single
+axis — code *correctness* — whereas research ideas are judged on **novelty,
+specificity, and falsifiability**. Generation/transformation prompts therefore
+push for concrete, non-obvious ideas with a testable hypothesis and honest
+risks; `Test` checks feasibility/logic instead of running code; `Ensemble` and
+`Review` score on research criteria rather than pass/fail. Every idea follows a
+shared `IDEA_FORMAT` (Title / Motivation / Hypothesis / Approach / Why / Risks)
+so SciFlow skills can map it onto a wiki entity page.
+
+## Execution model (carried over from MaAS)
+
+- **Lanes**: a node's output is a list of candidate ideas. `MultiGenerate`
+  emits N lanes; a 1-lane parent broadcasts to a wider child; lanes propagate.
+- **Multi-parent merge**: when several parent ideas feed one lane slot, they are
+  voted by `Ensemble` into one before the operator runs.
+- **Final aggregation**: ideas across all leaves are voted into one delivered
+  idea (single leaf → passthrough, no extra call).
+- Producers ignore parents (layer 0); consumers share `(task, idea)` shape.
+
+## Run
+
+```bash
+# from the AutoSci repo root (AutoSci_contest/)
+# list a stage's DAG library (simple → complex; ★ = paper-figure architecture)
+python3 -m scidag.examples.run --stage ideation --list
+
+# run one architecture — real LLM needs LLM_API_KEY / LLM_BASE_URL / LLM_MODEL in .env
+python3 -m scidag.examples.run --stage ideation --dag explore-debate-test "improve RLHF"
+
+# offline smoke — deterministic mock LLM, no API key
+python3 -m scidag.examples.run --stage writing --dag review-polish --mock
+```
+
+## Stage DAG libraries
+
+Each stage has its own library of 4–6 reusable architectures (simple → complex,
+all genuine DAGs, each including the paper-figure architecture). See
+[`templates/README.md`](templates/README.md).
+
+| Library | Augmented by skill | Emphasis | Paper-figure DAG |
+|---|---|---|---|
+| `templates/ideation/` | `/ideate-dag` (augments `/ideate`) | diverse generation + debate | `explore-debate-test` |
+| `templates/experiment/` | `/exp-design-dag` (augments `/exp-design`) | reliability checks (test) | `candidate-doubletest-refine` |
+| `templates/writing/` | `/paper-plan-dag` (augments `/paper-plan`) | evidence fidelity + review→polish | `review-polish` |
+
+## Skill integration (additive)
+
+Three **new** skills wire the libraries into SciFlow without touching the
+existing skills (paper §5: SciDAG is an optional augmentation that returns to
+the same artifact contract):
+
+| New skill | Augments | Replaces that skill's | Returns the same artifact |
+|---|---|---|---|
+| `/ideate-dag` | `/ideate` | dual-model brainstorm (Phase 2) | `wiki/ideas/{slug}.md` + edges |
+| `/exp-design-dag` | `/exp-design` | candidate generation + ablation loop | `wiki/experiments/*` + master doc |
+| `/paper-plan-dag` | `/paper-plan` | drafting + review | `PAPER_PLAN.md` + manuscript record |
+
+Each skill gathers context like the original, runs a DAG via the CLI, then reuses
+the original skill's persistence rules — so downstream stages are unchanged.
+
+## CLI (how skills call the engine)
+
+```bash
+python3 -m scidag.cli list   --stage ideation
+python3 -m scidag.cli select --stage experiment --complexity 3   # -> architecture name
+python3 -m scidag.cli run    --stage writing --dag review-polish \
+        --task-file task.md [--mock] --show-dag
+```
+`run` prints the artifact between `===SCIDAG-ARTIFACT-BEGIN/END===` on stdout
+(DAG/diagnostics go to stderr), so a skill extracts it cleanly. `select` with
+no `--complexity` returns the paper-figure architecture.
+
+## Configuration
+
+Reads `.env` (project root or `~/.env`), same keys as `mcp-servers/llm-review`:
+`LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL`, `LLM_FALLBACK_MODEL`.

--- a/scidag/__init__.py
+++ b/scidag/__init__.py
@@ -1,0 +1,36 @@
+"""SciDAG — DAG-based multi-agent augmentation for AutoSci.
+
+SciDAG represents a hard skill's execution as a directed acyclic graph of
+reusable research operators. Given a stage task `z`, it runs an operator graph
+G = (V, E) and returns a single artifact (a research idea / scheme as text),
+so the calling SciFlow skill keeps its artifact contract unchanged.
+
+This package is self-contained Python (no MetaGPT dependency). The operator
+and DAG-execution logic is adapted from the user's MaAS repository; the LLM
+call layer is rewired to AutoSci's OpenAI-compatible endpoint
+(LLM_API_KEY / LLM_BASE_URL / LLM_MODEL, the same env the llm-review MCP uses).
+
+Three sub-repositories mirror the paper's three SciDAG method modules:
+  - operators/   §1  the operator library (reusable agents)
+  - templates/   §2  stage-specific DAG architectures (ideation / experiment / writing)
+  - traces/      §1+§3  evaluated DAG samples + quality scores (added later)
+
+Current scope: the 7 operators ported from MaAS
+(generate[+cot/multi], variation, refine, debate, test, ensemble, early-stop),
+the DAG data structure, and the topological executor. The learned controller
+and the review / polish operators come in later steps.
+"""
+
+from .dag import DAGNode, SampledDAG
+from .llm import LLMClient, MockLLMClient
+from .executor import DAGExecutor
+
+__all__ = [
+    "DAGNode",
+    "SampledDAG",
+    "LLMClient",
+    "MockLLMClient",
+    "DAGExecutor",
+]
+
+__version__ = "0.1.0"

--- a/scidag/builder.py
+++ b/scidag/builder.py
@@ -1,0 +1,181 @@
+"""Build SampledDAGs from specs, and load stage DAG libraries.
+
+A DAG template is a YAML doc with light metadata plus a `nodes:` list in layer
+order:
+
+    name: explore-debate-test
+    stage: ideation
+    complexity: 3            # 1 (simple) .. 5 (complex)
+    paper_figure: true       # the architecture shown in the paper figure
+    description: "..."
+    nodes:
+      - op: MultiGenerate
+        parents: [root]      # "root" or 0-based indices of earlier nodes
+      - op: Variation
+        parents: [0]
+      - op: Debate
+        parents: [0]
+      - op: Test
+        parents: [1, 2]
+
+`parents` entries are either the literal "root" or integer indices of earlier
+nodes in the spec (0-based, in spec order). Each module keeps its own library
+directory under `scidag/templates/<stage>/`, with one file per architecture
+(filename prefixed `1-`..`5-` so listing is simple→complex).
+"""
+from __future__ import annotations
+
+import os
+from typing import List, Optional
+
+from .dag import SampledDAG
+
+# Stage libraries live here. A "stage" is one of: ideation, experiment, writing.
+TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
+STAGES = ("ideation", "experiment", "writing")
+
+
+# ---------------------------------------------------------------- build
+
+def build_dag(spec) -> SampledDAG:
+    """Build a SampledDAG from a node list (or a doc dict carrying `nodes`)."""
+    nodes_spec = spec["nodes"] if isinstance(spec, dict) else spec
+    dag = SampledDAG()
+    root = dag.add_root()
+    spec_to_nid = {}  # spec index -> node id
+
+    for i, node_spec in enumerate(nodes_spec):
+        op = node_spec["op"]
+        raw_parents = node_spec.get("parents", ["root"])
+        parent_ids = []
+        for p in raw_parents:
+            if p == "root":
+                parent_ids.append(root)
+            else:
+                parent_ids.append(spec_to_nid[int(p)])
+        # layer = 1 + max parent layer (root is -1, so producers land at layer 0)
+        layer = 1 + max(dag.nodes[pid].layer_idx for pid in parent_ids)
+        nid = dag.add_node(op_name=op, layer_idx=layer, parent_ids=parent_ids)
+        spec_to_nid[i] = nid
+
+    dag.finalize_leaves()
+    return dag
+
+
+def is_nonlinear(dag: SampledDAG) -> bool:
+    """True if the DAG genuinely branches (some fan-out or fan-in), i.e. it is
+    not a pure chain. A node with >=2 children (fan-out) or >=2 parents (fan-in)
+    — counting the root's children — makes it a real DAG rather than linear."""
+    for nid in dag.nodes:
+        if len(dag.get_children(nid)) >= 2:
+            return True
+        if len(dag.nodes[nid].parent_ids) >= 2:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------- load docs
+
+def read_doc(path: str) -> dict:
+    """Read a template YAML into a dict {name, stage, complexity, paper_figure,
+    description, nodes}. Falls back to a tiny parser if PyYAML is missing."""
+    try:
+        import yaml  # type: ignore
+        with open(path) as f:
+            doc = yaml.safe_load(f)
+        if "nodes" not in doc:
+            raise ValueError(f"template {path} has no `nodes`")
+        return doc
+    except ImportError:
+        return _parse_doc_no_yaml(path)
+
+
+def load_template(path: str) -> SampledDAG:
+    """Load a single template file into a SampledDAG."""
+    return build_dag(read_doc(path))
+
+
+def _parse_doc_no_yaml(path: str) -> dict:
+    """Minimal parser for the template subset (scalars + a `nodes:` list)."""
+    doc: dict = {"nodes": []}
+    in_nodes = False
+    cur: Optional[dict] = None
+    with open(path) as f:
+        for line in f:
+            raw = line.rstrip("\n")
+            s = raw.strip()
+            if not s or s.startswith("#"):
+                continue
+            if s == "nodes:":
+                in_nodes = True
+                continue
+            if not in_nodes:
+                if ":" in s:
+                    k, v = s.split(":", 1)
+                    v = v.strip().strip('"').strip("'")
+                    if v.lower() in ("true", "false"):
+                        doc[k.strip()] = (v.lower() == "true")
+                    elif v.isdigit():
+                        doc[k.strip()] = int(v)
+                    else:
+                        doc[k.strip()] = v
+                continue
+            # inside nodes
+            if s.startswith("- "):
+                if cur is not None:
+                    doc["nodes"].append(cur)
+                cur = {}
+                s = s[2:].strip()
+            if cur is None:
+                continue
+            if s.startswith("op:"):
+                cur["op"] = s.split(":", 1)[1].strip().strip('"').strip("'")
+            elif s.startswith("parents:"):
+                val = s.split(":", 1)[1].strip().strip("[]")
+                parts = [p.strip().strip('"').strip("'") for p in val.split(",") if p.strip()]
+                cur["parents"] = [p if p == "root" else int(p) for p in parts]
+    if cur is not None:
+        doc["nodes"].append(cur)
+    return doc
+
+
+# ---------------------------------------------------------------- library
+
+def _stage_dir(stage: str, base_dir: Optional[str] = None) -> str:
+    return os.path.join(base_dir or TEMPLATES_DIR, stage)
+
+
+def list_library(stage: str, base_dir: Optional[str] = None) -> List[dict]:
+    """List a module's DAG library, sorted simple→complex (by filename prefix).
+
+    Returns one dict per architecture:
+    {name, path, complexity, paper_figure, n_nodes, description}.
+    """
+    sdir = _stage_dir(stage, base_dir)
+    if not os.path.isdir(sdir):
+        raise FileNotFoundError(f"no DAG library for stage {stage!r} at {sdir}")
+    out = []
+    for fname in sorted(os.listdir(sdir)):
+        if not fname.endswith((".yaml", ".yml")):
+            continue
+        path = os.path.join(sdir, fname)
+        doc = read_doc(path)
+        out.append({
+            "name": doc.get("name", os.path.splitext(fname)[0]),
+            "path": path,
+            "complexity": doc.get("complexity"),
+            "paper_figure": bool(doc.get("paper_figure", False)),
+            "n_nodes": len(doc.get("nodes", [])),
+            "description": doc.get("description", ""),
+        })
+    return out
+
+
+def load_from_library(stage: str, name: str, base_dir: Optional[str] = None) -> SampledDAG:
+    """Load one architecture from a module's library by `name` (or filename stem)."""
+    for entry in list_library(stage, base_dir):
+        stem = os.path.splitext(os.path.basename(entry["path"]))[0]
+        if name in (entry["name"], stem):
+            return load_template(entry["path"])
+    available = ", ".join(e["name"] for e in list_library(stage, base_dir))
+    raise KeyError(f"no DAG named {name!r} in {stage} library. Available: {available}")

--- a/scidag/cli.py
+++ b/scidag/cli.py
@@ -1,0 +1,154 @@
+"""Command-line entry point for SciDAG, used by the SciDAG-augmented skills.
+
+A SciFlow skill shells out to this CLI to run an operator DAG as a tool and get
+back one artifact, keeping the skill's own contract unchanged. Subcommands:
+
+    list   --stage S                       list a module's DAG library
+    select --stage S [--complexity N]      pick an architecture (default: paper-figure)
+    run    --stage S --dag NAME --task "…" run an architecture, print the artifact
+
+`run` reads the task from --task or --task-file, runs the chosen DAG via the
+configured LLM (LLM_API_KEY/BASE_URL/MODEL in .env), and prints the final
+artifact between explicit markers so the caller can extract it. With --mock it
+uses the deterministic offline LLM (no network), for wiring tests.
+
+Examples:
+    python3 -m scidag.cli list --stage ideation
+    python3 -m scidag.cli select --stage experiment --complexity 3
+    python3 -m scidag.cli run --stage writing --dag review-polish --task "RLHF survey" --mock
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+
+from .builder import list_library, load_from_library, is_nonlinear, STAGES
+from .executor import DAGExecutor
+from .llm import LLMClient, MockLLMClient
+
+ARTIFACT_BEGIN = "===SCIDAG-ARTIFACT-BEGIN==="
+ARTIFACT_END = "===SCIDAG-ARTIFACT-END==="
+
+
+def _select(stage: str, complexity=None) -> dict:
+    """Pick one architecture from a stage library.
+
+    Default: the paper-figure architecture (the module's canonical DAG). If
+    --complexity N is given, pick the architecture whose complexity is closest
+    to N (ties → the simpler one), so a skill can scale graph size to task
+    difficulty without a learned controller.
+    """
+    lib = list_library(stage)
+    if complexity is None:
+        for e in lib:
+            if e["paper_figure"]:
+                return e
+        return lib[0]
+    return min(lib, key=lambda e: (abs(e["complexity"] - complexity), e["complexity"]))
+
+
+def cmd_list(args) -> int:
+    lib = list_library(args.stage)
+    if args.json:
+        print(json.dumps(lib, indent=2))
+        return 0
+    print(f"# {args.stage} DAG library (simple → complex)  — replaces {_REPLACES[args.stage]}\n")
+    for e in lib:
+        star = "  ★paper-figure" if e["paper_figure"] else ""
+        print(f"  [c{e['complexity']}] {e['name']} ({e['n_nodes']} nodes){star}")
+        print(f"        {e['description']}")
+    return 0
+
+
+def cmd_select(args) -> int:
+    e = _select(args.stage, args.complexity)
+    if args.json:
+        print(json.dumps(e, indent=2))
+    else:
+        print(e["name"])
+    return 0
+
+
+async def _run(args) -> int:
+    dag = load_from_library(args.stage, args.dag)
+    if args.task_file:
+        with open(args.task_file) as f:
+            task = f.read().strip()
+    else:
+        task = args.task or ""
+    if not task:
+        print("error: provide --task or --task-file", file=sys.stderr)
+        return 2
+
+    llm = MockLLMClient(_mock()) if args.mock else LLMClient()
+    if not args.mock and not llm.is_configured():
+        print("error: LLM_API_KEY not configured (.env). Use --mock for an offline test.",
+              file=sys.stderr)
+        return 3
+
+    if args.show_dag:
+        print(dag.pretty_print(), file=sys.stderr)
+        print(f"non-linear DAG: {is_nonlinear(dag)}", file=sys.stderr)
+
+    result = await DAGExecutor(llm).run(dag, task=task)
+    print(f"[scidag] stage={args.stage} dag={args.dag} llm_calls={result['n_calls']}",
+          file=sys.stderr)
+    # artifact to stdout, fenced for easy extraction by the calling skill
+    print(ARTIFACT_BEGIN)
+    print(result["idea"])
+    print(ARTIFACT_END)
+    return 0
+
+
+def cmd_run(args) -> int:
+    return asyncio.run(_run(args))
+
+
+def _mock():
+    from .examples.mock import mock_responder
+    return mock_responder
+
+
+_REPLACES = {
+    "ideation": "/ideate",
+    "experiment": "/exp-design",
+    "writing": "/paper-plan",
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="scidag", description="SciDAG operator-DAG runner")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pl = sub.add_parser("list", help="list a stage's DAG library")
+    pl.add_argument("--stage", choices=STAGES, required=True)
+    pl.add_argument("--json", action="store_true")
+    pl.set_defaults(func=cmd_list)
+
+    ps = sub.add_parser("select", help="pick an architecture from a stage library")
+    ps.add_argument("--stage", choices=STAGES, required=True)
+    ps.add_argument("--complexity", type=int, default=None,
+                    help="1..5; default picks the paper-figure architecture")
+    ps.add_argument("--json", action="store_true")
+    ps.set_defaults(func=cmd_select)
+
+    pr = sub.add_parser("run", help="run an architecture and print the artifact")
+    pr.add_argument("--stage", choices=STAGES, required=True)
+    pr.add_argument("--dag", required=True, help="architecture name from the stage library")
+    pr.add_argument("--task", default=None, help="the stage task text")
+    pr.add_argument("--task-file", default=None, help="read the task text from a file")
+    pr.add_argument("--mock", action="store_true", help="offline deterministic LLM")
+    pr.add_argument("--show-dag", action="store_true", help="print the DAG to stderr")
+    pr.set_defaults(func=cmd_run)
+    return p
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scidag/dag.py
+++ b/scidag/dag.py
@@ -1,0 +1,144 @@
+"""DAG data structure for SciDAG.
+
+Adapted from MaAS `maas/ext/maas/models/dag.py`. The graph algorithms
+(add_node / topological_order / get_children / get_ancestors / leaves) are
+kept verbatim in spirit; the torch dependency is removed so the executor runs
+without a learned controller. `LayerDecision` keeps the per-parent
+credit-assignment slots (log_prob / entropy / value) as plain optional floats,
+so a controller can be bolted on later without changing this module.
+
+A node names an operator; a directed edge means "information flows from parent
+to child". Conditional edges are not stored here — they are realized at run
+time by a router over execution state (see executor.py / routing, later step).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+
+
+@dataclass
+class DAGNode:
+    node_id: int
+    op_name: str
+    layer_idx: int
+    parent_ids: List[int] = field(default_factory=list)
+    is_root: bool = False
+    is_leaf: bool = False
+
+
+@dataclass
+class LayerDecision:
+    """One per-parent sampling decision (atomic credit-assignment unit).
+
+    Covers the K children spawned for one parent at one layer; those children
+    share this decision's log_prob / entropy / value. Filled by a controller;
+    left as None on hand-built / controller-less DAGs.
+    """
+    layer_idx: int
+    parent_id: int
+    op_names: List[str]
+    log_prob: Optional[float] = None
+    entropy: Optional[float] = None
+    value: Optional[float] = None
+
+
+@dataclass
+class SampledDAG:
+    nodes: Dict[int, DAGNode] = field(default_factory=dict)
+    decisions: List[LayerDecision] = field(default_factory=list)
+    truncated_decisions: int = 0  # merge nodes dropped due to max_nodes cap
+    root_id: int = -1
+
+    # ---- construction ---------------------------------------------------
+
+    def add_root(self, op_name: str = "ROOT") -> int:
+        """Add the virtual root (layer -1). Producers attach to it at layer 0."""
+        nid = len(self.nodes)
+        self.nodes[nid] = DAGNode(node_id=nid, op_name=op_name, layer_idx=-1, is_root=True)
+        self.root_id = nid
+        return nid
+
+    def add_node(self, op_name: str, layer_idx: int, parent_ids: List[int]) -> int:
+        nid = len(self.nodes)
+        self.nodes[nid] = DAGNode(
+            node_id=nid, op_name=op_name, layer_idx=layer_idx, parent_ids=list(parent_ids)
+        )
+        return nid
+
+    def add_decision(
+        self,
+        layer_idx: int,
+        parent_id: int,
+        op_names: List[str],
+        log_prob: Optional[float] = None,
+        entropy: Optional[float] = None,
+        value: Optional[float] = None,
+    ) -> None:
+        self.decisions.append(
+            LayerDecision(layer_idx, parent_id, list(op_names), log_prob, entropy, value)
+        )
+
+    # ---- queries --------------------------------------------------------
+
+    def get_children(self, node_id: int) -> List[int]:
+        return [n.node_id for n in self.nodes.values() if node_id in n.parent_ids]
+
+    def get_ancestors(self, node_id: int) -> Set[int]:
+        result: Set[int] = set()
+        stack = list(self.nodes[node_id].parent_ids)
+        while stack:
+            cur = stack.pop()
+            if cur in result:
+                continue
+            result.add(cur)
+            stack.extend(self.nodes[cur].parent_ids)
+        return result
+
+    def has_ancestor_with_name(self, node_id: int, op_name: str) -> bool:
+        return any(self.nodes[aid].op_name == op_name for aid in self.get_ancestors(node_id))
+
+    def topological_order(self) -> List[int]:
+        """Kahn's algorithm over parent_ids. Returns node ids in execution order."""
+        in_degree = {nid: len(node.parent_ids) for nid, node in self.nodes.items()}
+        queue = [nid for nid, d in in_degree.items() if d == 0]
+        order: List[int] = []
+        while queue:
+            nid = queue.pop(0)
+            order.append(nid)
+            for cid in self.get_children(nid):
+                in_degree[cid] -= 1
+                if in_degree[cid] == 0:
+                    queue.append(cid)
+        return order
+
+    def finalize_leaves(self) -> None:
+        for nid, node in self.nodes.items():
+            if node.is_root:
+                continue
+            if len(self.get_children(nid)) == 0:
+                node.is_leaf = True
+
+    def leaves(self) -> List[int]:
+        return [nid for nid, n in self.nodes.items() if n.is_leaf]
+
+    def nodes_by_layer(self) -> Dict[int, List[int]]:
+        out: Dict[int, List[int]] = {}
+        for nid, node in self.nodes.items():
+            if node.is_root:
+                continue
+            out.setdefault(node.layer_idx, []).append(nid)
+        return out
+
+    # ---- debug ----------------------------------------------------------
+
+    def pretty_print(self) -> str:
+        lines = [f"SampledDAG ({len(self.nodes)} nodes incl. root)"]
+        for nid in self.topological_order():
+            n = self.nodes[nid]
+            tags = " ".join(t for t, on in (("ROOT", n.is_root), ("LEAF", n.is_leaf)) if on)
+            parents = ",".join(str(p) for p in n.parent_ids) if n.parent_ids else "-"
+            lines.append(
+                f"  #{nid:>2d}  L{n.layer_idx:>2d}  {n.op_name:<16s}  parents=[{parents:<8s}] {tags}"
+            )
+        return "\n".join(lines)

--- a/scidag/examples/mock.py
+++ b/scidag/examples/mock.py
@@ -1,0 +1,49 @@
+"""Shared deterministic mock LLM responder for offline smoke tests.
+
+Returns short, distinguishable canned text per operator, and well-formed
+structured replies for Ensemble (a choice letter), Test (a JSON verdict), and
+Review (a scored critique with `Score:` / `Verdict:` lines), so every operator's
+parser exercises a real path without any network call.
+"""
+from __future__ import annotations
+
+
+def mock_responder(prompt: str, system=None) -> str:
+    p = prompt.lower()
+    # Ensemble: pick a candidate letter
+    if "selecting the single strongest" in p:
+        return '{"thought": "A is sharpest", "solution_letter": "A"}'
+    # Test: feasibility verdict as JSON
+    if "stress-test a research idea" in p or '"verdict"' in p and "feasibility" in p:
+        return '{"verdict": "pass", "risks": ["compute cost"]}'
+    # Review: scored critique
+    if "independent, rigorous peer reviewer" in p:
+        return (
+            "Novelty: 7/10 — fresh angle.\n"
+            "Soundness: 6/10 — mechanism mostly holds.\n"
+            "Feasibility: 8/10 — runnable.\n"
+            "Clarity: 5/10 — approach is vague.\n"
+            "Strengths: clear hypothesis.\n"
+            "Weaknesses: approach under-specified.\n"
+            "Concrete suggestions: spell out the steps.\n"
+            "Score: 7/10\nVerdict: revise"
+        )
+    # Polish
+    if "final, polished version" in p:
+        return "Title: Polished idea\nHypothesis: H (sharpened).\nApproach: step 1, step 2.\nRisks: R."
+    # Debate
+    if "expert a" in p and "expert b" not in p:
+        return "Title: Expert-A idea\nHypothesis: H.\nApproach: do X.\nRisks: R."
+    if "expert b" in p or "final round of a debate" in p:
+        return "Title: Expert-B idea\nHypothesis: H'.\nApproach: do Y.\nRisks: R."
+    # Variation
+    if "different line of attack" in p:
+        return "Title: Variation idea\nHypothesis: alt.\nApproach: do Z.\nRisks: R."
+    # Refine
+    if "refine a research idea" in p:
+        return "Title: Refined idea\nHypothesis: H (tighter).\nApproach: do X+.\nRisks: R."
+    # Feasibility repair (Test repair round)
+    if "blocking feasibility" in p:
+        return "Title: Repaired idea\nHypothesis: H.\nApproach: do X (fixed).\nRisks: R."
+    # Generators (Generate / GenerateCoT / MultiGenerate)
+    return "Title: Generated idea\nHypothesis: base.\nApproach: do base.\nRisks: R."

--- a/scidag/examples/run.py
+++ b/scidag/examples/run.py
@@ -1,0 +1,66 @@
+"""Run any SciDAG stage architecture from its module library.
+
+List a module's library:
+    python -m scidag.examples.run --stage ideation --list
+
+Run one architecture (real LLM — needs LLM_API_KEY/BASE_URL/MODEL in .env):
+    python -m scidag.examples.run --stage ideation --dag explore-debate-test "your task"
+
+Offline smoke (deterministic mock LLM, no API key):
+    python -m scidag.examples.run --stage writing --dag review-polish --mock
+
+Stages: ideation (replaces /ideate), experiment (replaces /exp-design),
+writing (replaces /paper-plan).
+"""
+import argparse
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from scidag.builder import list_library, load_from_library, is_nonlinear, STAGES  # noqa: E402
+from scidag.executor import DAGExecutor  # noqa: E402
+from scidag.llm import LLMClient, MockLLMClient  # noqa: E402
+from scidag.examples.mock import mock_responder  # noqa: E402
+
+
+def print_library(stage: str):
+    print(f"# {stage} DAG library (simple → complex)\n")
+    for e in list_library(stage):
+        star = " ★paper-figure" if e["paper_figure"] else ""
+        print(f"  [{e['complexity']}] {e['name']}{star}  ({e['n_nodes']} nodes)")
+        print(f"        {e['description']}")
+
+
+async def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--stage", choices=STAGES, default="ideation")
+    ap.add_argument("--dag", help="architecture name from the stage library")
+    ap.add_argument("--list", action="store_true", help="list the stage library and exit")
+    ap.add_argument("--mock", action="store_true", help="use the offline mock LLM")
+    ap.add_argument("task", nargs="?", default="improve sample efficiency of RLHF for small models")
+    args = ap.parse_args()
+
+    if args.list or not args.dag:
+        print_library(args.stage)
+        return
+
+    dag = load_from_library(args.stage, args.dag)
+    print(dag.pretty_print())
+    print(f"\nnon-linear DAG: {is_nonlinear(dag)}")
+
+    llm = MockLLMClient(responder=mock_responder) if args.mock else LLMClient()
+    if not args.mock and not llm.is_configured():
+        print("\nNo LLM_API_KEY configured; re-run with --mock for an offline smoke test.")
+        return
+
+    print("\n--- running ---\n")
+    result = await DAGExecutor(llm).run(dag, task=args.task)
+    print(f"LLM calls: {result['n_calls']}")
+    print("\n=== Final artifact ===\n")
+    print(result["idea"])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scidag/executor.py
+++ b/scidag/executor.py
@@ -1,0 +1,126 @@
+"""DAG executor for SciDAG.
+
+Adapted from MaAS `.../MBPP/train/graph.py` (the `Workflow` class). Runs a
+SampledDAG in topological order and returns one research idea, so a calling
+SciFlow skill keeps its artifact contract. Carries over the MaAS execution
+mechanics, reframed from code to research ideas:
+
+  - **Lane mechanism**: a node's output is a list of candidate ideas (lanes).
+    MultiGenerate emits N lanes; lanes broadcast/propagate to children. A 1-lane
+    parent broadcasts to every lane of a wider child.
+  - **Multi-parent merge**: when a consumer has several parents (or several
+    lanes feeding one lane slot), their ideas are voted by Ensemble into one
+    before the operator runs.
+  - **Final aggregation**: ideas across all leaves are voted by Ensemble into a
+    single delivered idea (single leaf -> passthrough, no extra call).
+
+Producers ignore parent inputs; consumers (Variation / Refine / Debate / Test)
+share the (task, idea) -> {"response"|"solution": str} shape. Conditional-edge
+routing / early-stop pruning is a later step; this executor runs the full
+sampled graph.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from .dag import SampledDAG
+from .operators.registry import OPERATOR_MAPPING, PRODUCER_OPERATORS
+
+
+class DAGExecutor:
+    def __init__(self, llm, operator_mapping: Optional[dict] = None):
+        self.llm = llm
+        mapping = operator_mapping or OPERATOR_MAPPING
+        # one shared instance per operator name (built as cls(llm), MaAS style)
+        self.operators = {name: cls(llm) for name, cls in mapping.items()}
+        self.ensemble = self.operators["Ensemble"]  # merge / final vote aggregator
+
+    async def run(self, dag: SampledDAG, task: str) -> dict:
+        """Execute the DAG for `task`. Returns a result dict:
+
+        {"idea": str, "n_calls": int, "node_outputs": {nid: [idea, ...]}}.
+        """
+        dag.finalize_leaves()
+        node_outputs: Dict[int, List[str]] = {}
+        calls_before = self.llm.n_calls
+
+        for nid in dag.topological_order():
+            node = dag.nodes[nid]
+            if node.is_root:
+                node_outputs[nid] = []
+                continue
+            try:
+                node_outputs[nid] = await self._execute_node(node, dag, task, node_outputs)
+            except Exception:  # noqa: BLE001 — a dead node should not kill the graph
+                node_outputs[nid] = []
+
+        leaf_outputs: List[str] = []
+        for leaf_id in dag.leaves():
+            leaf_outputs.extend(node_outputs.get(leaf_id, []))
+        final_idea = await self._aggregate(leaf_outputs, task)
+
+        return {
+            "idea": final_idea,
+            "n_calls": self.llm.n_calls - calls_before,
+            "node_outputs": node_outputs,
+        }
+
+    async def _aggregate(self, ideas: List[str], task: str) -> str:
+        """Final leaf vote: single -> passthrough, >=2 -> Ensemble."""
+        ideas = [i for i in ideas if i and i.strip()]
+        if not ideas:
+            return ""
+        if len(ideas) == 1:
+            return ideas[0]
+        return (await self.ensemble(task=task, solutions=ideas)).get("response", "")
+
+    async def _vote_lane_inputs(self, lane_inputs: List[str], task: str) -> str:
+        """Collapse several parent ideas feeding one lane slot into one idea."""
+        lane_inputs = [i for i in lane_inputs if i and i.strip()]
+        if not lane_inputs:
+            return ""
+        if len(lane_inputs) == 1:
+            return lane_inputs[0]
+        return (await self.ensemble(task=task, solutions=lane_inputs)).get("response", "")
+
+    async def _execute_node(self, node, dag: SampledDAG, task: str, node_outputs) -> List[str]:
+        op_name = node.op_name
+        op = self.operators[op_name]
+
+        # MultiGenerate: producer, ignores parents, 1 logical op -> N lanes.
+        if op_name == "MultiGenerate":
+            result = await op(task=task)
+            resp = result.get("response", [])
+            return [r for r in resp] if isinstance(resp, list) else [resp]
+
+        # Other producers ignore parents -> single lane.
+        if op_name in PRODUCER_OPERATORS:
+            return [(await op(task=task)).get("response", "")]
+
+        # Consumers: gather parent lanes (skip virtual root).
+        parent_outputs = [
+            node_outputs.get(pid, [])
+            for pid in node.parent_ids
+            if not dag.nodes[pid].is_root
+        ]
+        lane_count = max([len(po) for po in parent_outputs] + [1])
+
+        outputs: List[str] = []
+        for k in range(lane_count):
+            lane_inputs: List[str] = []
+            for po in parent_outputs:
+                if not po:
+                    continue
+                lane_inputs.append(po[k] if len(po) >= lane_count else po[0])  # broadcast 1-lane
+            idea_in = await self._vote_lane_inputs(lane_inputs, task)
+
+            if op_name == "Test":
+                # Test returns {"result", "solution", ...}; downstream takes the idea.
+                outputs.append((await op(task=task, idea=idea_in)).get("solution", ""))
+            else:
+                # Variation / Refine / Debate / Review / Polish all share
+                # (task, idea) -> {"response": str}. (Review also carries
+                # score/verdict, but the idea+feedback bundle is in "response".)
+                outputs.append((await op(task=task, idea=idea_in)).get("response", ""))
+
+        return outputs

--- a/scidag/llm.py
+++ b/scidag/llm.py
@@ -1,0 +1,155 @@
+"""Thin async LLM client for SciDAG operators.
+
+Replaces MaAS's MetaGPT `llm.aask` with a dependency-free client that speaks
+the OpenAI chat-completions protocol against AutoSci's configured endpoint.
+Reads the same environment variables the llm-review MCP server uses:
+
+    LLM_API_KEY        required to enable real calls
+    LLM_BASE_URL       default https://api.openai.com/v1
+    LLM_MODEL          model name
+    LLM_FALLBACK_MODEL optional fallback on primary failure
+
+The async surface is `await client.aask(prompt, system=...)`, matching the
+shape MaAS operators expect, so operator bodies port over with minimal edits.
+Network I/O (urllib) runs in a worker thread via asyncio.to_thread so many
+operator nodes can be awaited concurrently without blocking the event loop.
+
+`MockLLMClient` provides a deterministic, network-free implementation for
+smoke-testing the DAG executor without an API key.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Callable, List, Optional
+
+
+def _load_dotenv() -> None:
+    """Populate os.environ from project-root .env and ~/.env (minimal parser).
+
+    Mirrors mcp-servers/llm-review/server.py so SciDAG reads the same config
+    without requiring the user to export keys in every shell.
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    candidates = [
+        os.environ.get("SCIDAG_ENV_FILE"),
+        os.path.join(here, "..", ".env"),  # AutoSci project root (scidag/ is one level down)
+        os.path.join(os.path.expanduser("~"), ".env"),
+    ]
+    for path in candidates:
+        if path and os.path.isfile(path):
+            try:
+                with open(path) as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line or line.startswith("#") or "=" not in line:
+                            continue
+                        k, v = line.split("=", 1)
+                        os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+            except Exception:
+                pass
+
+
+class LLMClient:
+    """OpenAI-compatible chat client. One instance is shared by all operators.
+
+    Tracks `n_calls` (the cost-manager equivalent from MaAS) so the executor /
+    controller can measure per-layer call budgets for conditional pruning.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        model: Optional[str] = None,
+        fallback_model: Optional[str] = None,
+        temperature: float = 0.7,
+        timeout: int = 180,
+    ) -> None:
+        _load_dotenv()
+        self.api_key = api_key or os.environ.get("LLM_API_KEY", "")
+        self.base_url = (base_url or os.environ.get("LLM_BASE_URL", "https://api.openai.com/v1")).rstrip("/")
+        self.model = model or os.environ.get("LLM_MODEL", "")
+        self.fallback_model = fallback_model or os.environ.get("LLM_FALLBACK_MODEL", "")
+        self.temperature = temperature
+        self.timeout = timeout
+        self.n_calls = 0  # total completions issued (cost proxy)
+
+    def _chat_once(self, messages: List[dict], model: str, temperature: float) -> str:
+        payload = {"messages": messages, "model": model, "temperature": temperature}
+        req = urllib.request.Request(
+            self.base_url + "/chat/completions",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+        return body["choices"][0]["message"]["content"] or ""
+
+    def _chat_blocking(self, prompt: str, system: Optional[str], temperature: float) -> str:
+        messages = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+        models = [m for m in (self.model, self.fallback_model) if m] or [""]
+        last_err = ""
+        for model in models:
+            for _attempt in range(2):  # one retry on transient error
+                try:
+                    return self._chat_once(messages, model, temperature)
+                except urllib.error.HTTPError as e:
+                    last_err = f"HTTP {e.code}: {e.read().decode('utf-8', 'ignore')[:200]}"
+                except Exception as e:  # noqa: BLE001 — surface any transport error
+                    last_err = f"{type(e).__name__}: {e}"
+        raise RuntimeError(f"LLM call failed after retries/fallback: {last_err}")
+
+    async def aask(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        temperature: Optional[float] = None,
+        stream: bool = False,  # accepted for signature parity; unused (no streaming)
+    ) -> str:
+        """Async chat call. Returns the assistant message text."""
+        self.n_calls += 1
+        temp = self.temperature if temperature is None else temperature
+        return await asyncio.to_thread(self._chat_blocking, prompt, system, temp)
+
+    def is_configured(self) -> bool:
+        return bool(self.api_key)
+
+
+class MockLLMClient:
+    """Deterministic, network-free LLM for smoke tests.
+
+    Pass a `responder(prompt, system) -> str` to control output; the default
+    echoes a short stub plus a hash of the prompt so distinct calls differ.
+    Honors the same `aask` surface and `n_calls` counter as LLMClient.
+    """
+
+    def __init__(self, responder: Optional[Callable[[str, Optional[str]], str]] = None) -> None:
+        self.responder = responder
+        self.n_calls = 0
+
+    async def aask(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        temperature: Optional[float] = None,
+        stream: bool = False,
+    ) -> str:
+        self.n_calls += 1
+        await asyncio.sleep(0)  # yield, so concurrency is real
+        if self.responder is not None:
+            return self.responder(prompt, system)
+        return f"[mock idea #{self.n_calls}] " + prompt.strip().splitlines()[0][:80]
+
+    def is_configured(self) -> bool:
+        return True

--- a/scidag/operators/__init__.py
+++ b/scidag/operators/__init__.py
@@ -1,0 +1,32 @@
+"""SciDAG operator library (§1 of the paper's SciDAG method).
+
+The full 9 operators from the paper (Table 5), reframed for research ideas:
+generate (+cot/multi), variation, refine, debate, test, review, polish,
+ensemble, early-stop. Seven are ported from MaAS; review and polish are the
+writing-stage critique→edit pair.
+"""
+from .base import Operator
+from .generate import Generate, GenerateCoT, MultiGenerate
+from .variation import Variation
+from .refine import Refine
+from .debate import Debate
+from .test_op import Test
+from .review import Review
+from .polish import Polish
+from .ensemble import Ensemble
+from .early_stop import EarlyStop
+from .registry import (
+    OPERATOR_MAPPING,
+    SELECTABLE_OPERATORS,
+    PRODUCER_OPERATORS,
+    OPERATOR_DESCRIPTIONS,
+)
+
+__all__ = [
+    "Operator",
+    "Generate", "GenerateCoT", "MultiGenerate",
+    "Variation", "Refine", "Debate", "Test", "Review", "Polish",
+    "Ensemble", "EarlyStop",
+    "OPERATOR_MAPPING", "SELECTABLE_OPERATORS",
+    "PRODUCER_OPERATORS", "OPERATOR_DESCRIPTIONS",
+]

--- a/scidag/operators/base.py
+++ b/scidag/operators/base.py
@@ -1,0 +1,115 @@
+"""Operator base class + lightweight output parsing.
+
+Replaces MaAS's `Operator` + ActionNode/pydantic machinery. Because SciDAG
+artifacts are free-form research text (not code), most operators just return
+the model's text. Only `ensemble` and `test` need to parse structured fields,
+handled by the small helpers below (tolerant of markdown fences and reasoning
+preambles, like the MaAS parsers were).
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import List, Optional
+
+from .prompts import RESEARCH_SYSTEM
+
+
+class Operator:
+    """Base operator. Holds the shared LLM client and a name.
+
+    Subclasses implement `async def __call__(...)`. The constructor signature
+    `(llm, name)` matches MaAS so the registry can build every operator the
+    same way: `operator_mapping[name](llm)`.
+    """
+
+    #: operators that produce an artifact without reading parents (layer-0 only)
+    is_producer = False
+    #: operators never sampled as a node; used only for merge / final vote
+    is_aggregator = False
+    #: pure control signal, no LLM call
+    is_control = False
+
+    def __init__(self, llm, name: str):
+        self.llm = llm
+        self.name = name
+
+    async def __call__(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def _ask(self, prompt: str, temperature: Optional[float] = None) -> str:
+        return await self.llm.aask(prompt, system=RESEARCH_SYSTEM, temperature=temperature)
+
+
+# ---------------- parsing helpers ----------------
+
+def extract_letter(raw: str, valid: str) -> Optional[str]:
+    """Pull a single choice letter (A, B, C, ...) from an ensemble response.
+
+    Looks for an explicit `solution_letter` field first (JSON or `key: value`),
+    then falls back to the first standalone valid letter. Returns None if none
+    found, so the caller can default safely.
+    """
+    if not raw:
+        return None
+    valid_set = set(valid)
+    # JSON-ish: "solution_letter": "B"
+    m = re.search(r'"?solution_letter"?\s*[:=]\s*"?([A-Za-z])"?', raw)
+    if m and m.group(1).upper() in valid_set:
+        return m.group(1).upper()
+    # last resort: first standalone valid letter
+    for ch in re.findall(r"\b([A-Za-z])\b", raw):
+        if ch.upper() in valid_set:
+            return ch.upper()
+    return None
+
+
+def extract_json_object(raw: str) -> Optional[dict]:
+    """Grab the outermost {...} and json-load it; tolerant of fences/prose."""
+    if not raw:
+        return None
+    m = re.search(r"\{.*\}", raw, re.DOTALL)
+    if not m:
+        return None
+    try:
+        obj = json.loads(m.group(0))
+        return obj if isinstance(obj, dict) else None
+    except Exception:
+        return None
+
+
+def normalize_risks(risks) -> List[str]:
+    if isinstance(risks, list):
+        return [str(r).strip() for r in risks if str(r).strip()]
+    if isinstance(risks, str) and risks.strip():
+        return [risks.strip()]
+    return []
+
+
+def extract_score(raw: str, lo: float = 1, hi: float = 10) -> Optional[float]:
+    """Pull an overall review score from a review response.
+
+    Looks for `Score: N/10` first, then a bare `Score: N`. Returns None if no
+    in-range number is found, so the caller can treat the score as unknown.
+    """
+    if not raw:
+        return None
+    for pat in (r"score\s*[:=]?\s*([0-9]+(?:\.[0-9]+)?)\s*/\s*10",
+                r"score\s*[:=]\s*([0-9]+(?:\.[0-9]+)?)"):
+        m = re.search(pat, raw, re.IGNORECASE)
+        if m:
+            try:
+                v = float(m.group(1))
+            except ValueError:
+                continue
+            if lo <= v <= hi:
+                return v
+    return None
+
+
+def extract_verdict(raw: str) -> Optional[str]:
+    """Pull a review verdict (accept / revise / reject) from a review response."""
+    if not raw:
+        return None
+    m = re.search(r"verdict\s*[:=]?\s*(accept|revise|reject)", raw, re.IGNORECASE)
+    return m.group(1).lower() if m else None

--- a/scidag/operators/debate.py
+++ b/scidag/operators/debate.py
@@ -1,0 +1,55 @@
+"""Debate operator (two domain experts, sequential A->B->A->B). 4 LLM calls.
+
+Ported from MaAS Debate. Expert A is a rigorous defender, Expert B a skeptical
+challenger. B speaks last and sees one extra round, so B's final idea is taken
+as the refined result — matching the paper's `debate` operator ("two experts
+debate over multiple rounds to iteratively improve the idea"), no judge.
+
+Signature (task, idea) -> {"response": str}, slot-compatible with refine/variation.
+"""
+from __future__ import annotations
+
+from .base import Operator
+from .prompts import (
+    DEBATER_A_INIT_PROMPT,
+    DEBATER_B_INIT_PROMPT,
+    DEBATER_UPDATE_PROMPT,
+    IDEA_FORMAT,
+)
+
+
+class Debate(Operator):
+    def __init__(self, llm, name: str = "Debate"):
+        super().__init__(llm, name)
+        self._traces = None  # smoke runner may set a list to capture rounds
+
+    async def __call__(self, task: str, idea: str, **_ignore) -> dict:
+        # Round 1: A sees the initial idea
+        a0 = (await self._ask(
+            DEBATER_A_INIT_PROMPT.format(task=task, idea=idea, idea_format=IDEA_FORMAT)
+        ))
+        # Round 1: B sees idea + A
+        b0 = (await self._ask(
+            DEBATER_B_INIT_PROMPT.format(
+                task=task, idea=idea, response_a=a0, idea_format=IDEA_FORMAT
+            )
+        ))
+        # Round 2: A updates given B
+        a1 = (await self._ask(
+            DEBATER_UPDATE_PROMPT.format(
+                role="A", task=task, own_response=a0, opponent_response=b0,
+                idea_format=IDEA_FORMAT,
+            )
+        ))
+        # Round 2: B produces the final idea
+        b1 = (await self._ask(
+            DEBATER_UPDATE_PROMPT.format(
+                role="B", task=task, own_response=b0, opponent_response=a1,
+                idea_format=IDEA_FORMAT,
+            )
+        ))
+
+        if self._traces is not None:
+            self._traces.append({"input": idea, "A_0": a0, "B_0": b0, "A_1": a1, "B_1": b1})
+
+        return {"response": b1}

--- a/scidag/operators/early_stop.py
+++ b/scidag/operators/early_stop.py
@@ -1,0 +1,23 @@
+"""EarlyStop operator — control signal, 0 LLM calls.
+
+Ported from MaAS EarlyStop. When a controller selects EarlyStop for a parent,
+that parent's branch is terminated (no child node is created), so EarlyStop
+never executes as a real node. It exists as a selectable control action and as
+the conceptual basis for the paper's conditional-edge pruning ("cut a branch
+once it has converged or the node budget is reached"). The executor never calls
+it; it is handled at sampling / routing time.
+"""
+from __future__ import annotations
+
+from .base import Operator
+
+
+class EarlyStop(Operator):
+    is_control = True
+
+    def __init__(self, llm=None, name: str = "EarlyStop"):
+        super().__init__(llm, name)
+
+    async def __call__(self, *args, **kwargs):
+        # Control signal only; should never be executed as a node.
+        raise RuntimeError("EarlyStop is a control signal and must not be executed")

--- a/scidag/operators/ensemble.py
+++ b/scidag/operators/ensemble.py
@@ -1,0 +1,49 @@
+"""Ensemble operator (self-consistency vote / synthesis). 1 LLM call.
+
+Ported from MaAS ScEnsemble. Given several candidate ideas, pick the strongest
+one. Used as the multi-parent merge vote and the final leaf vote inside the
+executor (the paper's `ensemble` operator: "vote over / aggregate multiple
+candidate ideas into one"). Position-bias is mitigated by shuffling candidates
+before showing them, then mapping the chosen letter back to the original index.
+
+Marked is_aggregator: it is never sampled as a DAG node by a controller; the
+executor invokes it directly for merges / final vote.
+"""
+from __future__ import annotations
+
+import random
+from typing import List
+
+from .base import Operator, extract_letter
+from .prompts import SC_ENSEMBLE_PROMPT
+
+
+class Ensemble(Operator):
+    is_aggregator = True
+
+    def __init__(self, llm, name: str = "Ensemble"):
+        super().__init__(llm, name)
+
+    async def __call__(self, task: str, solutions: List[str], **_ignore) -> dict:
+        solutions = [s for s in (solutions or []) if s and s.strip()]
+        if not solutions:
+            return {"response": ""}
+        if len(solutions) == 1:
+            return {"response": solutions[0]}
+
+        # shuffle to mitigate position bias; map letter -> original index
+        n = len(solutions)
+        perm = list(range(n))
+        random.shuffle(perm)
+        valid = "".join(chr(65 + i) for i in range(n))
+        block = ""
+        mapping = {}
+        for shuf_idx, orig_idx in enumerate(perm):
+            letter = chr(65 + shuf_idx)
+            mapping[letter] = orig_idx
+            block += f"{letter}:\n{solutions[orig_idx]}\n\n\n"
+
+        prompt = SC_ENSEMBLE_PROMPT.format(task=task, solutions=block)
+        raw = await self._ask(prompt)
+        letter = extract_letter(raw, valid) or "A"
+        return {"response": solutions[mapping.get(letter, perm[0])]}

--- a/scidag/operators/generate.py
+++ b/scidag/operators/generate.py
@@ -1,0 +1,64 @@
+"""Generate operators (producers).
+
+Ported from MaAS Generate / GenerateCoT / MultiGenerateCoT. Producers ignore
+parent inputs and emit a fresh research idea from the task. MultiGenerate runs
+N independent generations to seed `N` parallel lanes downstream (diversity for
+ensemble / debate / final vote), mirroring MaAS's MultiGenerateCoT 3-lane fan-out.
+"""
+from __future__ import annotations
+
+from typing import List
+
+from .base import Operator
+from .prompts import GENERATE_PROMPT, GENERATE_COT_PROMPT, IDEA_FORMAT
+
+
+class Generate(Operator):
+    """Single-shot idea generation from the task (1 LLM call)."""
+
+    is_producer = True
+
+    def __init__(self, llm, name: str = "Generate"):
+        super().__init__(llm, name)
+
+    async def __call__(self, task: str, **_ignore) -> dict:
+        prompt = GENERATE_PROMPT.format(task=task, idea_format=IDEA_FORMAT)
+        return {"response": await self._ask(prompt)}
+
+
+class GenerateCoT(Operator):
+    """Chain-of-thought idea generation (1 LLM call).
+
+    Surveys obvious approaches and gaps before committing to one idea. Per the
+    paper's writing-stage emphasis on CoT, this is the reasoning-heavy producer.
+    """
+
+    is_producer = True
+
+    def __init__(self, llm, name: str = "GenerateCoT"):
+        super().__init__(llm, name)
+
+    async def __call__(self, task: str, **_ignore) -> dict:
+        prompt = GENERATE_COT_PROMPT.format(task=task, idea_format=IDEA_FORMAT)
+        return {"response": await self._ask(prompt)}
+
+
+class MultiGenerate(Operator):
+    """N independent generations -> N lanes (default 3). Cost = N LLM calls.
+
+    Returns {"response": [idea1, idea2, ...]}. The executor reads the list as
+    parallel lanes that propagate downstream (the MaAS lane mechanism).
+    """
+
+    is_producer = True
+
+    def __init__(self, llm, name: str = "MultiGenerate", n: int = 3):
+        super().__init__(llm, name)
+        self.n = n
+
+    async def __call__(self, task: str, **_ignore) -> dict:
+        prompt = GENERATE_COT_PROMPT.format(task=task, idea_format=IDEA_FORMAT)
+        ideas: List[str] = []
+        for _ in range(self.n):
+            ideas.append(await self._ask(prompt))
+        return {"response": ideas}

--- a/scidag/operators/polish.py
+++ b/scidag/operators/polish.py
@@ -1,0 +1,30 @@
+"""Polish operator — review-guided final editing. 1 LLM call.
+
+The paper's `polish` operator: "improve presentation, wording, formatting, or
+local organization according to review feedback." Polish edits expression, not
+substance: it tightens wording and structure and addresses presentational
+review suggestions, while preserving the hypothesis, approach, and risks.
+
+Polish is the consumer half of the review→polish pair. If its input idea carries
+a "## Review feedback" block (from an upstream Review node), Polish acts on the
+actionable parts of that feedback and strips the block from its output; if not,
+it simply produces a clean, well-organized version of the idea.
+
+Signature (task, idea) -> {"response": str}, slot-compatible with the other
+consumers in the DAG executor.
+"""
+from __future__ import annotations
+
+from .base import Operator
+from .prompts import POLISH_PROMPT, IDEA_FORMAT
+
+
+class Polish(Operator):
+    def __init__(self, llm, name: str = "Polish"):
+        super().__init__(llm, name)
+
+    async def __call__(self, task: str, idea: str, **_ignore) -> dict:
+        if not idea or not idea.strip():
+            return {"response": idea}
+        prompt = POLISH_PROMPT.format(task=task, idea=idea, idea_format=IDEA_FORMAT)
+        return {"response": await self._ask(prompt)}

--- a/scidag/operators/prompts.py
+++ b/scidag/operators/prompts.py
@@ -1,0 +1,326 @@
+"""Science-oriented operator prompts for SciDAG.
+
+Adapted from MaAS `op_prompt.py`. MaAS prompts optimize for a single axis —
+code *correctness* (does it pass tests). Research ideas need a different target:
+**novelty, specificity, and falsifiability**, not just "being right". So every
+generation/transformation prompt here pushes for concrete, non-obvious ideas
+with a testable hypothesis and an honest failure mode, and the selection /
+review prompts judge on those research criteria rather than pass/fail.
+
+The artifact `z` flowing through the DAG is a **research idea** in text: a
+concrete proposed approach (motivation/gap + hypothesis + approach sketch +
+mechanism + risks). The `review` operator appends a structured critique to an
+idea; the `polish` operator consumes that critique and returns a clean,
+improved write-up — mirroring the paper's writing-stage review→polish pair.
+
+Each idea stays self-contained and section-shaped so the calling SciFlow skill
+(e.g. /ideate, /paper-draft) can map it onto a wiki entity page.
+"""
+
+# ---------------- shared system prompt ----------------
+
+RESEARCH_SYSTEM = (
+    "You are a research scientist collaborating inside an automated research "
+    "system. You produce concrete, technically grounded research ideas — never "
+    "vague directions or generic restatements of the task. A good idea is "
+    "specific enough to implement, novel relative to the obvious approaches, "
+    "rests on a clear and testable hypothesis, and comes with an honest account "
+    "of why it might fail. Prefer depth and falsifiability over breadth."
+)
+
+# The artifact contract: every produced/transformed idea uses this shape so
+# downstream operators and skills can parse it. Sections may be brief, but all
+# should be present.
+IDEA_FORMAT = (
+    "Present the idea using exactly these sections (keep each tight and concrete):\n"
+    "- **Title**: a short, specific name.\n"
+    "- **Motivation / gap**: the precise problem or gap it addresses.\n"
+    "- **Hypothesis**: the central claim, stated so it could be falsified.\n"
+    "- **Approach sketch**: the concrete method, as ordered steps.\n"
+    "- **Why it could work**: the underlying mechanism / intuition.\n"
+    "- **Risks**: the most likely concrete reasons it could fail."
+)
+
+# ---------------- generate ----------------
+
+GENERATE_PROMPT = """## Research task
+{task}
+
+## Your job
+Propose ONE concrete research idea that addresses the task above. Aim for an
+idea that a domain expert would consider non-obvious and worth pursuing — avoid
+restating the task or proposing a generic, already-standard approach.
+
+{idea_format}
+"""
+
+GENERATE_COT_PROMPT = """## Research task
+{task}
+
+## Your job
+Propose ONE concrete research idea that addresses the task above.
+
+First reason step by step (briefly): what are the obvious approaches, where
+exactly do they fall short, and which specific gap is most worth attacking?
+THEN commit to a single, non-obvious idea and write it up. Do not hedge across
+multiple ideas — pick one and make it concrete.
+
+{idea_format}
+"""
+
+# ---------------- variation (explore) ----------------
+
+VARIATION_PROMPT = """You generate a NEW research idea for the task below, deliberately exploring a
+DIFFERENT line of attack from an existing idea. The goal is to widen the pool of
+genuinely distinct candidates, not to improve the existing one.
+
+## Research task
+{task}
+
+## Existing idea
+{idea}
+
+## Your task
+Produce a new idea that:
+
+1. **Genuinely addresses the task** — a real, defensible research idea, not a
+   strawman.
+2. **Takes a fundamentally different approach from the existing idea.** Do not
+   paraphrase, reorder, or tweak it. The underlying bet must differ. Diversify
+   along one or more dimensions:
+   - **Mechanism**: a different underlying lever (e.g. data-centric vs.
+     architecture-centric vs. objective/loss-centric vs. inference-time).
+   - **Framing**: reframe the problem (e.g. as optimization vs. retrieval vs.
+     control vs. a representation-learning problem).
+   - **Granularity**: a broad systemic redesign vs. a sharp targeted intervention.
+   - **Assumptions**: relax, invert, or drop an assumption the existing idea relies on.
+3. **Do not critique the existing idea.** This is exploration, not evaluation.
+   Both ideas may be valid; you are offering a genuinely different bet.
+4. **Be self-contained** — understandable without having read the existing idea.
+
+{idea_format}
+"""
+
+# ---------------- refine (self-refine) ----------------
+
+REFINE_PROMPT = """You refine a research idea to make it sharper, more rigorous, and more concrete,
+while preserving its core intent. This is improvement, not exploration — do not
+switch to a different idea.
+
+## Research task
+{task}
+
+## Current idea
+{idea}
+
+## Instruction
+Critically analyze the idea for weaknesses: a vague or hand-wavy mechanism, an
+untestable or trivially-true hypothesis, hidden assumptions, feasibility
+problems, weak novelty, or a mismatch between the hypothesis and the proposed
+evaluation. Then produce an improved version that fixes what you found: tighten
+the hypothesis into something falsifiable, make the approach concrete and
+step-wise, and name the real risks honestly. Keep the same underlying idea.
+
+{idea_format}
+"""
+
+# ---------------- debate (two domain experts, A<->B, B last) ----------------
+
+DEBATER_A_INIT_PROMPT = """You are Expert A, a careful and rigorous domain expert.
+
+A research idea for the task below has been proposed. Examine it on its research
+merits — soundness of the mechanism, testability of the hypothesis, feasibility,
+and novelty. If it is sound, defend it with stronger justification and a more
+concrete approach. If it has flaws, produce a corrected, improved idea. Reason
+step by step, then give your final idea.
+
+## Research task
+{task}
+
+## Proposed idea
+{idea}
+
+## Your response (as Expert A)
+First write your analysis, then present your final idea.
+
+{idea_format}
+"""
+
+DEBATER_B_INIT_PROMPT = """You are Expert B, a skeptical and creative domain expert.
+
+A research idea for the task below has been proposed, and Expert A has already
+weighed in. Critically examine both. Look for unstated assumptions, feasibility
+risks, weak novelty, or a stronger alternative framing. Do not simply agree with
+A — challenge the reasoning where it is weak. Reason step by step, then give your
+final idea.
+
+## Research task
+{task}
+
+## Proposed idea
+{idea}
+
+## Expert A's response
+{response_a}
+
+## Your response (as Expert B)
+First write your critique, then present your final idea.
+
+{idea_format}
+"""
+
+DEBATER_UPDATE_PROMPT = """You are Expert {role}, in the final round of a debate over a research idea for
+the task below.
+
+Read your opponent's latest response carefully and consider:
+  1. Are there valid points that should change your idea?
+  2. Are there flaws in their reasoning you should rebut?
+  3. Can you strengthen your own idea given this exchange?
+
+Reason step by step, then produce your final, definitive idea. It should be the
+strongest version you can defend — concrete, testable, and honest about risks.
+
+## Research task
+{task}
+
+## Your previous response
+{own_response}
+
+## Opponent's latest response
+{opponent_response}
+
+## Your final response (as Expert {role})
+First write your reasoning, then present your final idea.
+
+{idea_format}
+"""
+
+# ---------------- test (feasibility / logic stress check, oracle-free) ----------------
+
+FEASIBILITY_CHECK_PROMPT = """You stress-test a research idea for feasibility and internal logic. You have no
+ground-truth answer — judge ONLY the idea's own coherence and practicality, the
+way a careful reviewer would before any experiment is run.
+
+## Research task
+{task}
+
+## Idea to check
+{idea}
+
+## Your job
+Identify the {n_lo} to {n_hi} most serious feasibility or logic risks, focusing only
+on issues that would actually block the idea:
+- Does the hypothesis follow from the stated mechanism, or is there a logical gap?
+- Is the approach actually executable with realistic data, compute, and tools?
+- Are there hidden dependencies, circular assumptions, or undefined quantities?
+- Would the proposed evaluation actually test the stated hypothesis?
+
+## Output format
+Output ONLY a JSON object — no prose, no markdown fences:
+{{"verdict": "pass" | "fail",
+  "risks": ["short concrete risk 1", "short concrete risk 2", ...]}}
+
+Use "fail" only if at least one risk is a genuine blocker. If the risks are
+minor or readily addressable, use "pass".
+"""
+
+FEASIBILITY_REPAIR_PROMPT = """A research idea was found to have a blocking feasibility / logic problem. Revise
+the idea to remove the blocker while keeping its core intent and novelty.
+
+## Research task
+{task}
+
+## Current idea
+{idea}
+
+## Blocking risks found
+{risks}
+
+Produce a revised idea that resolves the blocking risks above. Stay concrete and
+do not water the idea down into a generic safe option.
+
+{idea_format}
+"""
+
+# ---------------- ensemble (self-consistency vote / synthesis) ----------------
+
+SC_ENSEMBLE_PROMPT = """You are selecting the single strongest research idea among several candidates
+for the task below.
+
+## Research task
+{task}
+
+## Candidate ideas
+{solutions}
+
+## Step 1 — what makes an idea strong here
+A strong idea is novel relative to the obvious approaches, rests on a clear and
+testable hypothesis, has a concrete and feasible approach, and a believable
+mechanism. Reject candidates that are vague, untestable, infeasible, or that
+merely restate the task.
+
+## Step 2 — choose
+Among the candidates that survive Step 1, pick the one most likely to lead to a
+real research contribution. If every candidate fails Step 1, pick the closest.
+
+## Output instructions
+- In the "thought" field: briefly assess each candidate (A, B, C, ...) on the
+  criteria above, then state which you choose and why.
+- In the "solution_letter" field: output ONLY the single letter ID (A, B, C, ...)
+  of the candidate you chose. No other text.
+"""
+
+# ---------------- review (structured critique before final editing) ----------------
+
+REVIEW_PROMPT = """You are an independent, rigorous peer reviewer. Critique the research idea below
+on its merits. Do NOT rewrite or edit the idea — your job is to assess it and
+give actionable feedback that a later editing pass can act on.
+
+## Research task
+{task}
+
+## Idea under review
+{idea}
+
+## Your review
+Assess the idea on four dimensions, each scored 1–10, with one or two sentences
+of concrete justification:
+- **Novelty**: is it non-obvious relative to standard approaches?
+- **Soundness**: does the hypothesis follow from the mechanism; is the logic valid?
+- **Feasibility**: can it realistically be executed and evaluated?
+- **Clarity**: is it specific, well-structured, and unambiguous?
+
+Then provide:
+- **Strengths**: the 1–3 things most worth keeping.
+- **Weaknesses**: the 1–3 most important problems.
+- **Concrete suggestions**: specific, actionable edits to improve the idea.
+
+End with a single summary line in EXACTLY this form:
+Score: N/10
+where N is your overall assessment (1–10), and a verdict line:
+Verdict: accept | revise | reject
+"""
+
+# ---------------- polish (review-guided final editing) ----------------
+
+POLISH_PROMPT = """You produce the final, polished version of a research idea. Improve presentation,
+wording, structure, and local organization. Make the writing precise and clean
+WITHOUT changing the idea's substance or inventing new claims.
+
+## Research task
+{task}
+
+## Idea to polish (may include a "## Review feedback" section)
+{idea}
+
+## Instruction
+- If the input contains review feedback, address its concrete, presentational
+  suggestions (clarity, structure, precision). Do not adopt feedback that would
+  require fabricating results or changing the core claim.
+- Tighten vague wording, fix structure, and ensure every section is clear.
+- Preserve the hypothesis, approach, and risks — polish the expression, not the science.
+- Output ONLY the polished idea. Do NOT include the review feedback, your notes,
+  or any meta-commentary.
+
+{idea_format}
+"""

--- a/scidag/operators/refine.py
+++ b/scidag/operators/refine.py
@@ -1,0 +1,21 @@
+"""Refine operator (self-refine). 1 LLM call.
+
+Ported from MaAS SelfRefine. Reads a parent idea and produces an improved
+version: sharpens the hypothesis, makes the approach concrete, removes vague
+mechanisms and hidden assumptions. Improvement, not exploration.
+
+Signature (task, idea) -> {"response": str}, slot-compatible with variation/debate.
+"""
+from __future__ import annotations
+
+from .base import Operator
+from .prompts import REFINE_PROMPT, IDEA_FORMAT
+
+
+class Refine(Operator):
+    def __init__(self, llm, name: str = "Refine"):
+        super().__init__(llm, name)
+
+    async def __call__(self, task: str, idea: str, **_ignore) -> dict:
+        prompt = REFINE_PROMPT.format(task=task, idea=idea, idea_format=IDEA_FORMAT)
+        return {"response": await self._ask(prompt)}

--- a/scidag/operators/registry.py
+++ b/scidag/operators/registry.py
@@ -1,0 +1,70 @@
+"""Operator registry for SciDAG.
+
+`OPERATOR_MAPPING`: name -> Operator class, all built as `cls(llm)` by the
+executor. `SELECTABLE_OPERATORS`: the operators a controller may place as DAG
+nodes, in a fixed order (a future policy head's logits align to this order).
+
+Following MaAS: Ensemble is NOT selectable (used only for merge / final vote),
+and EarlyStop is excluded from the selectable list (handled as a control signal
+at sampling / routing time). `OPERATOR_DESCRIPTIONS` seeds operator text
+embeddings for the learned controller added in a later step.
+
+This is the full 9-operator library from the paper (Table 5): the 7 ported from
+MaAS plus `review` and `polish` (the writing-stage critique→edit pair).
+"""
+from __future__ import annotations
+
+from .generate import Generate, GenerateCoT, MultiGenerate
+from .variation import Variation
+from .refine import Refine
+from .debate import Debate
+from .test_op import Test
+from .ensemble import Ensemble
+from .early_stop import EarlyStop
+from .review import Review
+from .polish import Polish
+
+OPERATOR_MAPPING = {
+    "Generate": Generate,
+    "GenerateCoT": GenerateCoT,
+    "MultiGenerate": MultiGenerate,
+    "Variation": Variation,
+    "Refine": Refine,
+    "Debate": Debate,
+    "Test": Test,
+    "Review": Review,
+    "Polish": Polish,
+    "Ensemble": Ensemble,
+    "EarlyStop": EarlyStop,
+}
+
+# Operators a controller may sample as nodes (Ensemble / EarlyStop excluded).
+SELECTABLE_OPERATORS = [
+    "Generate",
+    "GenerateCoT",
+    "MultiGenerate",
+    "Variation",
+    "Refine",
+    "Debate",
+    "Test",
+    "Review",
+    "Polish",
+]
+
+PRODUCER_OPERATORS = {"Generate", "GenerateCoT", "MultiGenerate"}
+
+# Short natural-language descriptions to initialize operator embeddings for the
+# learned controller (paper §3 architecture-layer selection; added later).
+OPERATOR_DESCRIPTIONS = {
+    "Generate": "Produce one concrete research idea directly from the task.",
+    "GenerateCoT": "Reason step by step about gaps, then produce one research idea.",
+    "MultiGenerate": "Produce several independent research ideas as parallel lanes.",
+    "Variation": "Given an idea, produce a different idea via a new line of attack (explore).",
+    "Refine": "Given an idea, sharpen its hypothesis and make the approach concrete (improve).",
+    "Debate": "Two domain experts debate an idea over rounds and return the refined idea.",
+    "Test": "Stress-test an idea's feasibility and logic; repair one blocking flaw.",
+    "Review": "Independently critique an idea (novelty/soundness/feasibility/clarity) and score it.",
+    "Polish": "Edit an idea's presentation per review feedback without changing its substance.",
+    "Ensemble": "Vote over multiple candidate ideas and return the strongest one.",
+    "EarlyStop": "Terminate a branch that has converged or hit the node budget.",
+}

--- a/scidag/operators/review.py
+++ b/scidag/operators/review.py
@@ -1,0 +1,41 @@
+"""Review operator — structured critique before final editing. 1 LLM call.
+
+The paper's `review` operator: "critique a candidate before final editing,
+focusing on correctness, evidence support, and coherence." Unlike Refine/Debate,
+Review does NOT rewrite the idea — it produces an independent, scored critique
+(novelty / soundness / feasibility / clarity + strengths / weaknesses /
+suggestions + an overall score and verdict).
+
+To fit the single-input DAG executor and pair naturally with Polish, Review
+bundles its output: `response` = the original idea with a "## Review feedback"
+block appended. A downstream Polish node then reads idea+feedback and applies it.
+The parsed `score` / `verdict` are also returned for skills / a future router.
+
+This is the AutoSci analogue of the cross-model `/review` skill; when wired into
+SciFlow it can run on the llm-review endpoint for an independent second opinion.
+
+Signature (task, idea) -> {"response": str, "review": str, "score": float|None,
+"verdict": str|None}. The executor takes `response`.
+"""
+from __future__ import annotations
+
+from .base import Operator, extract_score, extract_verdict
+from .prompts import REVIEW_PROMPT
+
+
+class Review(Operator):
+    def __init__(self, llm, name: str = "Review"):
+        super().__init__(llm, name)
+
+    async def __call__(self, task: str, idea: str, **_ignore) -> dict:
+        if not idea or not idea.strip():
+            return {"response": idea, "review": "", "score": None, "verdict": None}
+
+        critique = await self._ask(REVIEW_PROMPT.format(task=task, idea=idea))
+        bundled = f"{idea}\n\n## Review feedback\n{critique}"
+        return {
+            "response": bundled,
+            "review": critique,
+            "score": extract_score(critique),
+            "verdict": extract_verdict(critique),
+        }

--- a/scidag/operators/test_op.py
+++ b/scidag/operators/test_op.py
@@ -1,0 +1,59 @@
+"""Test operator — feasibility / logic stress check (oracle-free). 1 (+<=1 repair) LLM call.
+
+Adapted from MaAS's oracle-free structural Test. MaAS ran candidate *code* in a
+subprocess and checked it didn't crash. SciDAG artifacts are research ideas, not
+runnable code, so the structural check becomes a **feasibility / internal-logic
+check**: the LLM enumerates the idea's most serious feasibility or logic risks
+and returns a pass/fail verdict. If it fails (a blocking risk), exactly ONE
+repair round revises the idea. Like MaAS, there is no ground-truth oracle — the
+check judges only the idea's own coherence and practicality.
+
+Signature (task, idea) -> {"result": bool, "solution": str, "risks": [str]}.
+The executor takes `solution` as this node's output (revised idea if repaired,
+else the original), matching how MaAS's Test fed `solution` downstream.
+
+Named test_op.py (not test.py) so pytest does not collect it as a test module.
+"""
+from __future__ import annotations
+
+from typing import List
+
+from .base import Operator, extract_json_object, normalize_risks
+from .prompts import FEASIBILITY_CHECK_PROMPT, FEASIBILITY_REPAIR_PROMPT, IDEA_FORMAT
+
+
+class Test(Operator):
+    def __init__(self, llm, name: str = "Test"):
+        super().__init__(llm, name)
+
+    async def _check(self, task: str, idea: str) -> tuple[bool, List[str]]:
+        """Return (passed, risks). Degrades to pass if the verdict is unparseable."""
+        prompt = FEASIBILITY_CHECK_PROMPT.format(task=task, idea=idea, n_lo=2, n_hi=4)
+        try:
+            raw = await self.llm.aask(prompt, stream=False)
+        except Exception:
+            return True, []  # cannot check -> treat as structurally fine (MaAS behavior)
+        obj = extract_json_object(raw)
+        if not obj:
+            return True, []
+        verdict = str(obj.get("verdict", "pass")).strip().lower()
+        risks = normalize_risks(obj.get("risks"))
+        return (verdict != "fail"), risks
+
+    async def __call__(self, task: str, idea: str, **_ignore) -> dict:
+        if not idea or not idea.strip():
+            return {"result": False, "solution": idea, "risks": []}
+
+        passed, risks = await self._check(task, idea)
+        if passed:
+            return {"result": True, "solution": idea, "risks": risks}
+
+        # exactly one repair round, driven by the blocking risks
+        prompt = FEASIBILITY_REPAIR_PROMPT.format(
+            task=task, idea=idea, risks="\n".join(f"- {r}" for r in risks),
+            idea_format=IDEA_FORMAT,
+        )
+        revised = await self._ask(prompt)
+        revised = revised or idea
+        passed_after, _ = await self._check(task, revised)
+        return {"result": passed_after, "solution": revised, "risks": risks}

--- a/scidag/operators/variation.py
+++ b/scidag/operators/variation.py
@@ -1,0 +1,21 @@
+"""Variation operator (explore). 1 LLM call.
+
+Ported from MaAS Variation. Reads a parent idea and produces a NEW idea that
+deliberately takes a different line of attack, to widen the candidate pool's
+diversity for downstream ensemble / debate / vote. Exploration, not refinement.
+
+Signature (task, idea) -> {"response": str}, slot-compatible with refine/debate.
+"""
+from __future__ import annotations
+
+from .base import Operator
+from .prompts import VARIATION_PROMPT, IDEA_FORMAT
+
+
+class Variation(Operator):
+    def __init__(self, llm, name: str = "Variation"):
+        super().__init__(llm, name)
+
+    async def __call__(self, task: str, idea: str, **_ignore) -> dict:
+        prompt = VARIATION_PROMPT.format(task=task, idea=idea, idea_format=IDEA_FORMAT)
+        return {"response": await self._ask(prompt)}

--- a/scidag/templates/README.md
+++ b/scidag/templates/README.md
@@ -1,0 +1,86 @@
+# SciDAG Stage DAG Libraries (§2 — stage specialization)
+
+Each research stage keeps its **own DAG library** — a set of 4–6 reusable
+operator-graph architectures, ordered simple → complex. Every architecture is a
+genuine **DAG** (it branches: some node has multiple parents or multiple
+children), never a pure linear chain — even the complexity-1 templates fan out
+from the root and vote at the end. Each library contains **the architecture
+shown in the paper figure** (marked `paper_figure: true`).
+
+A SciFlow skill picks one architecture from the matching library and runs it via
+`DAGExecutor`, getting back one artifact under the skill's existing contract.
+
+| Library | Replaces | Stage emphasis (paper §2) | Paper-figure architecture |
+|---|---|---|---|
+| `ideation/` | `/ideate` | diverse generation + debate | `explore-debate-test` |
+| `experiment/` | `/exp-design` | reliability checks (test) | `candidate-doubletest-refine` |
+| `writing/` | `/paper-plan` | evidence fidelity + review→polish | `review-polish` |
+
+## Architecture format
+
+Each `*.yaml` is one architecture: light metadata (`name`, `stage`,
+`complexity` 1–5, `paper_figure`, `description`) + a `nodes:` list in layer
+order. A node's `parents` are `root` or 0-based indices of earlier nodes.
+Load via `scidag.builder.load_from_library(stage, name)` /
+`list_library(stage)`.
+
+## ideation/ — replaces `/ideate` (diverse generation + debate)
+
+`/ideate` = landscape scan → dual-model brainstorm (5 paths A–E) → novelty /
+feasibility screening. The library scales that from a two-draft vote to a
+broad parallel explore-debate-refine sweep:
+
+| c | name | shape |
+|---|---|---|
+| 1 | `dual-draft-vote` | root → {Generate, GenerateCoT} → vote |
+| 2 | `diamond-explore` | GenerateCoT → {Refine, Variation} → vote |
+| 2 | `debate-screen` | Generate → {Debate, Variation} → Test |
+| 3 | `explore-debate-test` ★ | MultiGenerate → {Variation, Debate} → Test |
+| 4 | `broad-explore-converge` | MultiGenerate → {Variation, Debate, Refine} → Test |
+
+## experiment/ — replaces `/exp-design` (reliability / test)
+
+`/exp-design` = method candidates → benchmark → iterative ablation. Per the
+paper's stage emphasis, this library is built on the experiment-stage **core
+operators {generate, test, refine}** — `Test` is prominent (reliability) and
+exploration operators are de-emphasized. **4 of 5 DAGs use core operators only**;
+one mixed DAG adds variation/debate for harder, exploratory designs.
+
+| c | name | core-only | shape |
+|---|---|:--:|---|
+| 1 | `dual-generate-test` | ✓ | {Generate, GenerateCoT} → Test |
+| 2 | `generate-refine-test` | ✓ | GenerateCoT → {Refine, Test} → Test |
+| 3 | `multigen-test-refine` ★ | ✓ | MultiGenerate → {Test, Refine→Test} → Refine |
+| 4 | `iterative-test-refine` | ✓ | GenCoT→Test→Refine→Test ∥ Gen→Test → Refine |
+| 4 | `candidate-variation-suite` | + Variation/Debate | MultiGenerate → {Variation→Test, Refine→Test} → Debate |
+
+## writing/ — replaces `/paper-plan` (evidence fidelity + review→polish)
+
+`/paper-plan` = evidence map → narrative structure → section/figure/citation
+plan, with **mandatory review**. Per the paper's stage emphasis, this library is
+built on the writing-stage **core operators {review, polish}** (plus a producer
+to draft). **3 of 5 DAGs use core operators only**; two mixed DAGs add
+refine / debate for harder outlines.
+
+| c | name | core-only | shape |
+|---|---|:--:|---|
+| 1 | `draft-dual-review-polish` | ✓ | Generate → {Review, Review} → Polish |
+| 2 | `dual-draft-review-polish` ★ | ✓ | {Generate, GenerateCoT} → Review each → Polish |
+| 3 | `review-polish-review` | ✓ | GenCoT → Review→Polish→Review ∥ Review → Polish |
+| 3 | `refine-review-polish` | + Refine | GenerateCoT → {Refine, Review} → Polish |
+| 4 | `debate-review-polish-suite` | + Variation/Debate | MultiGenerate → {Variation, Debate, Review} → Polish |
+
+> ★ = paper-figure architecture. "core-only" = uses only the stage's preferred
+> operators (experiment: generate/test/refine; writing: producers + review/polish).
+> This realizes the paper's claim that experiment and writing stages favor
+> different operator sets.
+
+★ = the architecture shown in the paper figure.
+
+## Try it
+
+```bash
+python3 -m scidag.examples.run --stage ideation --list
+python3 -m scidag.examples.run --stage experiment --dag candidate-doubletest-refine --mock
+python3 -m scidag.examples.run --stage writing --dag review-polish "your paper topic"
+```

--- a/scidag/templates/experiment/1-dual-generate-test.yaml
+++ b/scidag/templates/experiment/1-dual-generate-test.yaml
@@ -1,0 +1,20 @@
+name: dual-generate-test
+stage: experiment
+complexity: 1
+paper_figure: false
+description: "Simplest experiment-design DAG, core operators only (generate + test). Two parallel design drafts (direct + reasoned) are merged and reliability-checked. Non-linear via root fan-out + fan-in at Test."
+# Experiment stage emphasizes reliability (test), so even the minimal DAG ends
+# in a Test gate. Core operators only: {Generate, GenerateCoT} = generate family, Test.
+#
+#        root
+#        /  \
+#  Generate  GenerateCoT
+#        \  /
+#        Test                 (single leaf = reliability-checked design)
+nodes:
+  - op: Generate
+    parents: [root]
+  - op: GenerateCoT
+    parents: [root]
+  - op: Test
+    parents: [0, 1]

--- a/scidag/templates/experiment/2-generate-refine-test.yaml
+++ b/scidag/templates/experiment/2-generate-refine-test.yaml
@@ -1,0 +1,22 @@
+name: generate-refine-test
+stage: experiment
+complexity: 2
+paper_figure: false
+description: "Core operators only (generate + refine + test). A reasoned design fans out into a refined branch and a directly-tested branch, which merge at a final reliability check. The generate/refine/test loop the experiment stage favors."
+#
+#        root
+#         |
+#     GenerateCoT
+#        /  \
+#    Refine  Test
+#        \  /
+#        Test                 (single leaf = reliability-checked design)
+nodes:
+  - op: GenerateCoT
+    parents: [root]
+  - op: Refine
+    parents: [0]
+  - op: Test
+    parents: [0]
+  - op: Test
+    parents: [1, 2]

--- a/scidag/templates/experiment/3-multigen-test-refine.yaml
+++ b/scidag/templates/experiment/3-multigen-test-refine.yaml
@@ -1,0 +1,29 @@
+name: multigen-test-refine
+stage: experiment
+complexity: 3
+paper_figure: true
+description: "The paper's experimentation template (Fig. 9): emphasize reliability checks, core operators only (generate + test + refine). MultiGenerate seeds candidate designs; one branch is tested directly while another is refined then tested; both reliability results are consolidated by Refine into a final design."
+# This is the experimentation architecture shown in the paper figure, expressed
+# with the stage's preferred operators only: generate (MultiGenerate), test (×2,
+# the reliability emphasis), and refine. No variation/debate.
+#
+#              root
+#               |
+#        MultiGenerate (3 lanes)
+#         /          \
+#       Test        Refine
+#        |            |
+#        |           Test
+#         \          /
+#           Refine             (single leaf = consolidated reliable design)
+nodes:
+  - op: MultiGenerate
+    parents: [root]
+  - op: Test
+    parents: [0]
+  - op: Refine
+    parents: [0]
+  - op: Test
+    parents: [2]
+  - op: Refine
+    parents: [1, 3]

--- a/scidag/templates/experiment/4-iterative-test-refine.yaml
+++ b/scidag/templates/experiment/4-iterative-test-refine.yaml
@@ -1,0 +1,32 @@
+name: iterative-test-refine
+stage: experiment
+complexity: 4
+paper_figure: false
+description: "Core operators only (generate + test + refine). A test→refine→test chain (the iterative-ablation spirit) runs alongside an independently tested second draft, then both reliability results are consolidated by Refine. Test appears three times — maximal reliability emphasis without leaving the core operator set."
+#
+#        root ─────────────┐
+#         |                 |
+#     GenerateCoT        Generate
+#         |                 |
+#        Test              Test
+#         |                 |
+#       Refine              |
+#         |                 |
+#        Test               |
+#          \               /
+#            Refine                 (single leaf = consolidated reliable design)
+nodes:
+  - op: GenerateCoT
+    parents: [root]
+  - op: Test
+    parents: [0]
+  - op: Refine
+    parents: [1]
+  - op: Test
+    parents: [2]
+  - op: Generate
+    parents: [root]
+  - op: Test
+    parents: [4]
+  - op: Refine
+    parents: [3, 5]

--- a/scidag/templates/experiment/5-candidate-variation-suite.yaml
+++ b/scidag/templates/experiment/5-candidate-variation-suite.yaml
@@ -1,0 +1,28 @@
+name: candidate-variation-suite
+stage: experiment
+complexity: 4
+paper_figure: false
+description: "Mixed-operator experiment DAG (the minority that goes beyond the core set): MultiGenerate seeds candidates, an explore branch (Variation) and a refine branch each get reliability-tested, then Debate consolidates the two tested designs. Adds variation + debate on top of generate/test/refine for harder, more exploratory designs."
+#
+#              root
+#               |
+#        MultiGenerate (3 lanes)
+#         /          \
+#   Variation      Refine
+#        |            |
+#       Test         Test
+#         \          /
+#           Debate             (single leaf = consolidated design)
+nodes:
+  - op: MultiGenerate
+    parents: [root]
+  - op: Variation
+    parents: [0]
+  - op: Refine
+    parents: [0]
+  - op: Test
+    parents: [1]
+  - op: Test
+    parents: [2]
+  - op: Debate
+    parents: [3, 4]

--- a/scidag/templates/ideation/1-dual-draft-vote.yaml
+++ b/scidag/templates/ideation/1-dual-draft-vote.yaml
@@ -1,0 +1,17 @@
+name: dual-draft-vote
+stage: ideation
+complexity: 1
+paper_figure: false
+description: "Simplest ideation DAG: two parallel producers (direct + reasoned) draft ideas independently, then the executor votes one out. Non-linear via root fan-out + leaf fan-in vote."
+# Replaces the lightest form of /ideate Phase 2 brainstorm: generate a couple of
+# independent candidate directions and keep the strongest. Even this minimal
+# template is a DAG (root branches to two producers), not a single chain.
+#
+#        root
+#        /  \
+#  Generate  GenerateCoT      -> final Ensemble vote across the two leaves
+nodes:
+  - op: Generate
+    parents: [root]
+  - op: GenerateCoT
+    parents: [root]

--- a/scidag/templates/ideation/2-diamond-explore.yaml
+++ b/scidag/templates/ideation/2-diamond-explore.yaml
@@ -1,0 +1,20 @@
+name: diamond-explore
+stage: ideation
+complexity: 2
+paper_figure: false
+description: "One reasoned draft, then two divergent transforms (refine vs. explore) that vote at the end. The canonical diamond: fan-out into improve/explore, fan-in at the final vote."
+# Mirrors /ideate's tension between sharpening a promising direction (Refine)
+# and exploring a genuinely different bet (Variation), then choosing.
+#
+#        root
+#         |
+#     GenerateCoT
+#        /  \
+#   Refine  Variation        -> final vote across the two leaves
+nodes:
+  - op: GenerateCoT
+    parents: [root]
+  - op: Refine
+    parents: [0]
+  - op: Variation
+    parents: [0]

--- a/scidag/templates/ideation/3-debate-screen.yaml
+++ b/scidag/templates/ideation/3-debate-screen.yaml
@@ -1,0 +1,24 @@
+name: debate-screen
+stage: ideation
+complexity: 2
+paper_figure: false
+description: "Generate one idea, then in parallel debate it (two experts) and explore an alternative; merge both and screen feasibility. Fan-out to debate/explore, fan-in at the feasibility screen."
+# /ideate Phase 2 (debate-style refinement) + Phase 3 (feasibility screening) in
+# a compact graph.
+#
+#        root
+#         |
+#      Generate
+#        /  \
+#   Debate   Variation
+#        \  /
+#        Test                 (single leaf = screened idea)
+nodes:
+  - op: Generate
+    parents: [root]
+  - op: Debate
+    parents: [0]
+  - op: Variation
+    parents: [0]
+  - op: Test
+    parents: [1, 2]

--- a/scidag/templates/ideation/4-explore-debate-test.yaml
+++ b/scidag/templates/ideation/4-explore-debate-test.yaml
@@ -1,0 +1,24 @@
+name: explore-debate-test
+stage: ideation
+complexity: 3
+paper_figure: true
+description: "The paper's ideation template (Fig. 9): emphasize diverse generation and debate. MultiGenerate fans out parallel idea lanes, which are explored (Variation) and debated (Debate) in parallel, then merged and feasibility-screened (Test)."
+# This is the ideation architecture shown in the paper figure: exploration-heavy
+# (MultiGenerate + Variation) plus debate, converging through a feasibility test.
+#
+#          root
+#           |
+#     MultiGenerate (3 lanes)
+#         /     \
+#   Variation   Debate
+#         \     /
+#          Test                (single leaf = screened idea)
+nodes:
+  - op: MultiGenerate
+    parents: [root]
+  - op: Variation
+    parents: [0]
+  - op: Debate
+    parents: [0]
+  - op: Test
+    parents: [1, 2]

--- a/scidag/templates/ideation/5-broad-explore-converge.yaml
+++ b/scidag/templates/ideation/5-broad-explore-converge.yaml
@@ -1,0 +1,27 @@
+name: broad-explore-converge
+stage: ideation
+complexity: 4
+paper_figure: false
+description: "Widest ideation DAG: MultiGenerate seeds many ideas, three parallel transforms (explore / debate / refine) probe them along different axes, then all converge into one feasibility screen. Three-way fan-out, three-way fan-in."
+# The maximally-divergent ideation template (still bounded): covers /ideate's
+# Path A–E spirit by running exploration, debate, and refinement concurrently
+# before a single screening gate.
+#
+#              root
+#               |
+#        MultiGenerate (3 lanes)
+#         /     |     \
+#  Variation Debate  Refine
+#         \     |     /
+#             Test                (single leaf = screened idea)
+nodes:
+  - op: MultiGenerate
+    parents: [root]
+  - op: Variation
+    parents: [0]
+  - op: Debate
+    parents: [0]
+  - op: Refine
+    parents: [0]
+  - op: Test
+    parents: [1, 2, 3]

--- a/scidag/templates/writing/1-draft-dual-review-polish.yaml
+++ b/scidag/templates/writing/1-draft-dual-review-polish.yaml
@@ -1,0 +1,25 @@
+name: draft-dual-review-polish
+stage: writing
+complexity: 1
+paper_figure: false
+description: "Simplest writing DAG, core operators only (review + polish, on a single draft). One outline draft is reviewed twice in parallel (two independent reviewers), then polished against both. Non-linear via fan-out to two reviews + fan-in at Polish."
+# Writing stage emphasizes review→polish. Core operators only: a single producer
+# to draft, then {Review×2, Polish}. The two parallel reviews make it a DAG, not
+# a linear draft→review→polish chain.
+#
+#        root
+#         |
+#      Generate
+#        /  \
+#   Review  Review
+#        \  /
+#       Polish                (single leaf = polished outline)
+nodes:
+  - op: Generate
+    parents: [root]
+  - op: Review
+    parents: [0]
+  - op: Review
+    parents: [0]
+  - op: Polish
+    parents: [1, 2]

--- a/scidag/templates/writing/2-dual-draft-review-polish.yaml
+++ b/scidag/templates/writing/2-dual-draft-review-polish.yaml
@@ -1,0 +1,27 @@
+name: dual-draft-review-polish
+stage: writing
+complexity: 2
+paper_figure: true
+description: "The paper's writing template (Fig. 9): emphasize review→polish, core operators only. Two outline drafts are each independently reviewed, then merged and polished against both critiques. A genuine DAG built purely from the writing stage's preferred operators (review, polish)."
+# This is the writing architecture shown in the paper figure, expressed with the
+# stage's preferred operators only: two producers draft, each is Reviewed, and
+# Polish consolidates. No variation/debate/refine — review and polish are central.
+#
+#        root
+#        /  \
+#  Generate  GenerateCoT
+#     |          |
+#   Review     Review
+#        \    /
+#        Polish               (single leaf = polished outline)
+nodes:
+  - op: Generate
+    parents: [root]
+  - op: GenerateCoT
+    parents: [root]
+  - op: Review
+    parents: [0]
+  - op: Review
+    parents: [1]
+  - op: Polish
+    parents: [2, 3]

--- a/scidag/templates/writing/3-review-polish-review.yaml
+++ b/scidag/templates/writing/3-review-polish-review.yaml
@@ -1,0 +1,30 @@
+name: review-polish-review
+stage: writing
+complexity: 3
+paper_figure: false
+description: "Core operators only (review + polish), a two-pass review→polish→review cycle plus a parallel review of the raw draft. One draft is reviewed and polished, the polished result is reviewed again, and that re-review is merged with an independent review of the original draft by a final Polish. Review/polish-centric."
+#
+#        root
+#         |
+#     GenerateCoT
+#        /  \
+#   Review   Review        (left = re-review path, right = raw-draft review)
+#     |        |
+#   Polish     |
+#     |        |
+#   Review     |
+#        \    /
+#        Polish               (single leaf = polished outline)
+nodes:
+  - op: GenerateCoT
+    parents: [root]
+  - op: Review
+    parents: [0]
+  - op: Review
+    parents: [0]
+  - op: Polish
+    parents: [1]
+  - op: Review
+    parents: [3]
+  - op: Polish
+    parents: [4, 2]

--- a/scidag/templates/writing/4-refine-review-polish.yaml
+++ b/scidag/templates/writing/4-refine-review-polish.yaml
@@ -1,0 +1,22 @@
+name: refine-review-polish
+stage: writing
+complexity: 3
+paper_figure: false
+description: "Mixed-operator writing DAG (minority beyond the core set): adds refine for evidence fidelity. A reasoned draft is refined and (in parallel) reviewed; Polish consolidates the refined version with the review feedback. Keeps review→polish central while bringing in refine."
+#
+#        root
+#         |
+#     GenerateCoT
+#        /  \
+#    Refine  Review
+#        \  /
+#       Polish                (single leaf = polished outline)
+nodes:
+  - op: GenerateCoT
+    parents: [root]
+  - op: Refine
+    parents: [0]
+  - op: Review
+    parents: [0]
+  - op: Polish
+    parents: [1, 2]

--- a/scidag/templates/writing/5-debate-review-polish-suite.yaml
+++ b/scidag/templates/writing/5-debate-review-polish-suite.yaml
@@ -1,0 +1,24 @@
+name: debate-review-polish-suite
+stage: writing
+complexity: 4
+paper_figure: false
+description: "Mixed-operator writing DAG (minority beyond the core set): MultiGenerate seeds outline drafts, then debate and review probe them in parallel (narrative-structure debate + correctness/evidence review), and Polish consolidates both into the final write-up. Adds variation/debate on top of the review→polish core for harder outlines."
+#
+#              root
+#               |
+#        MultiGenerate (3 lanes)
+#         /     |     \
+#  Variation  Debate  Review
+#         \     |     /
+#            Polish               (single leaf = polished outline)
+nodes:
+  - op: MultiGenerate
+    parents: [root]
+  - op: Variation
+    parents: [0]
+  - op: Debate
+    parents: [0]
+  - op: Review
+    parents: [0]
+  - op: Polish
+    parents: [1, 2, 3]


### PR DESCRIPTION
## Summary

Implements the **SciDAG** module from the AutoSci paper (Agent4S @ BAAI 2026, §5): DAG-based multi-agent augmentation. SciDAG runs an operator DAG as a tool and returns one research-idea artifact, so calling skills keep their artifact contract. **No existing files are modified** — this is purely additive (`scidag/` + three new skills).

## What's included

- **`scidag/operators/`** — the paper's 9 operators (generate[+cot/multi], variation, refine, debate, test, review, polish, ensemble, early-stop), reframed from the MaAS code task to research ideas. No MetaGPT dependency; the LLM layer speaks the OpenAI-compatible endpoint (`LLM_API_KEY`/`LLM_BASE_URL`/`LLM_MODEL`, same as the llm-review MCP).
- **`scidag/dag.py` + `executor.py`** — `SampledDAG` data structure + topological executor (lane mechanism, multi-parent ensemble merge, final leaf vote).
- **`scidag/templates/`** — three stage DAG libraries (5 architectures each, simple→complex, all genuine DAGs, each including the paper-figure architecture). Stage operator emphasis per the paper:
  - ideation → generation + debate
  - experiment → generate/test/refine (4/5 core-only)
  - writing → review/polish (3/5 core-only)
- **`scidag/cli.py` + `builder.py`** — `list`/`select`/`run` CLI used by the skills.
- **`.claude/skills/{ideate,exp-design,paper-plan}-dag`** — additive SciDAG-augmented skills that wire the libraries into SciFlow, returning the same artifact contract as `/ideate`, `/exp-design`, `/paper-plan`.

## Not yet implemented (initial version)

Learned controller (architecture-layer selection), conditional-edge router / early-stop pruning (execution-layer), and the trace/experience repository — these are the paper's §3 dynamic-selection mechanisms, left for follow-up.

## Testing

- Offline mock-LLM smoke tests: all 15 DAGs build, are non-linear, and run; operator-emphasis constraints verified.
- Live end-to-end against a real OpenAI-compatible endpoint (gpt-4o-mini): ideation / experiment / writing each ran a DAG and produced well-formed idea artifacts with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
