### PR TITLE
fix(remote): order rsync excludes before includes in sync_code (#65)

### DIFF
--- a/tools/remote.py
+++ b/tools/remote.py
@@ -466,13 +466,16 @@ def cmd_sync_code(cfg: dict, args: argparse.Namespace) -> None:
     transport = build_ssh_transport(cfg)
     cmd = ["rsync", "-avz", "--delete", "-e", transport]
 
-    # Include directories for recursion, then specific file patterns
+    # rsync evaluates filters top-to-bottom, first match wins. Excludes for
+    # directories like .venv/ must precede the include rules — otherwise
+    # --include=*/ (and --include=*.py) match first, rsync descends into them
+    # and --delete clobbers remote files that live there. See issue #65.
+    for pat in excludes:
+        cmd += [f"--exclude={pat}"]
+    # Recurse into remaining directories, then keep only wanted file patterns
     cmd += ["--include=*/"]
     for pat in includes:
         cmd += [f"--include={pat}"]
-    # Exclude everything else
-    for pat in excludes:
-        cmd += [f"--exclude={pat}"]
     cmd += ["--exclude=*"]
 
     if args.dry_run:


### PR DESCRIPTION
## Problem

`tools/remote.py` `cmd_sync_code` built the rsync filter rules in the wrong order:

```
--include=*/        # recurse into every dir, incl. .venv/, data/, __pycache__/
--include=*.py ...  # whitelist source files
--exclude=.venv/ …  # too late — never wins a first match
--exclude=*
```

rsync evaluates filters **top-to-bottom, first match wins**. So `--include=*/` matched `.venv/` before the `--exclude=.venv/` rule was ever reached: rsync descended into it, `--include=*.py` then pulled its `*.py` files into the transfer set, and with `--delete` this **overwrote or deleted remote files** inside `.venv/`, `data/`, `__pycache__/`, etc. In effect the entire `DEFAULT_SYNC_EXCLUDE` list (and any user-configured `sync.exclude`) was silently ignored.

## Fix

Emit the excludes **before** the include rules so directory excludes win the first match and rsync never descends into them (and `--delete` leaves excluded files protected):

```
--exclude=.venv/ …  # skip these dirs entirely, first
--include=*/        # recurse into the rest
--include=*.py ...  # whitelist source files
--exclude=*
```

## Verification

Local `rsync --dry-run` against a dest that already has a populated `.venv`:

- **Old order** → `deleting .venv/lib/extra.py` + overwrites `.venv/lib/site.py`
- **New order** → `.venv` untouched ✓

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)