### PR TITLE
Fix i18n ↔ .claude drift (restore /discover guidance, backfill zh)

### DIFF
--- a/.claude/skills/discover/SKILL.md
+++ b/.claude/skills/discover/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "(--anchor <id> [--anchor <id>] [--negative <id>] | --topic <str>
 Use these local references on demand:
 
 - `references/seed-modes.md` — when to pick anchor / topic / wiki / venue mode and how to translate the user's phrasing into one
-- `references/ranking-signals.md` — what `tools/discover.py` scores on.
+- `references/ranking-signals.md` — what `tools/discover.py` scores on and why discovery does **not** share `/init`'s survey preference
 - `references/wiki-dedup.md` — how candidates are filtered against `wiki/papers/` and what to do with matches
 
 ## Inputs
@@ -28,9 +28,9 @@ Exactly one of `--anchor`, `--topic`, `--from-wiki`, or `--venue` must be given.
 
 - `.checkpoints/discover-{seed-slug}-{YYYY-MM-DD}.json` — full shortlist payload, machine-readable; the seed slug is derived from the first anchor or the topic
 - a human-readable markdown summary printed to the user with rationale per candidate
-- `wiki/log.md` — one append line via `tools/research_wiki.py log`.
+- `wiki/log.md` — one append line via `tools/research_wiki.py log` for anchor/topic/wiki runs only
 
-`/discover` does not write anywhere else in `wiki/` and does not touch `raw/`.
+`/discover` does not write anywhere else in `wiki/` and does not touch `raw/`. `from-venue` is stricter: it does not write to `wiki/` at all, including `wiki/log.md`. Whether to actually pull a candidate into the wiki is the caller's decision (a follow-up `/ingest`).
 
 ## Wiki Interaction
 
@@ -42,7 +42,8 @@ Exactly one of `--anchor`, `--topic`, `--from-wiki`, or `--venue` must be given.
 
 ### Writes
 
-- `wiki/log.md` — APPEND via `tools/research_wiki.py log`
+- anchor/topic/wiki runs: `wiki/log.md` — APPEND via `tools/research_wiki.py log`
+- venue runs: none
 
 ### Graph edges created
 
@@ -131,6 +132,10 @@ Skip this step for `from-venue`; venue discovery must not write to `wiki/` or `r
 ### From `/ingest --discover`
 
 When `/ingest` is invoked with the optional `--discover` flag (default off), it calls `/discover` after the final report, with the just-ingested paper's arXiv ID as the single anchor. The shortlist is appended to `/ingest`'s report under a "Related papers you may want to ingest next" heading. `/ingest` never auto-ingests anything from this list.
+
+### From `/init`
+
+`/init` does not call `/discover`. `/init`'s planner (`tools/init_discovery.py plan`) has its own scoring that favors surveys, broad coverage, and seed anchors — appropriate for bootstrapping a wiki. `/discover`'s ranking is intentionally different (no survey preference; weights anchor similarity and influential citations) and would dilute `/init`'s shortlist if substituted in. Keep them separate.
 
 ## Constraints
 

--- a/.claude/skills/discover/references/ranking-signals.md
+++ b/.claude/skills/discover/references/ranking-signals.md
@@ -46,6 +46,16 @@ They answer different questions:
 
 A paper can score high on one and low on the other. Example: a well-known benchmark paper has a high aggregate count (everyone cites it) but rarely a True edge from a method paper (the benchmark is used, not built upon). Our ranking uses both, so benchmarks surface when there's no better signal, but papers the anchor literally built on outrank them.
 
+## What discovery does **not** score on
+
+This is where `/discover` deliberately differs from `/init`'s planner (`tools/init_discovery.py`):
+
+- **No survey preference**. `/init` favors survey/review papers because a fresh wiki benefits from them as anchor coverage. `/discover` is invoked when a user already knows the area (anchor mode) or is exploring (topic mode); they rarely need yet another survey, and surfacing surveys above novel work would be noise.
+- **No "older canonical anchor" bonus**. `/init`'s bootstrap mode promotes one older citation-heavy paper to broaden coverage. `/discover` users typically want forward-looking recommendations, not foundational re-anchoring.
+- **No notes/web priority terms**. `/init` reads `raw/notes/` and `raw/web/` to extract the user's stated intent. `/discover` does not — its inputs are explicit (anchor, topic, or wiki state).
+
+If a future ranking signal seems shared between `/init` and `/discover`, prefer keeping two implementations rather than extracting a shared scorer. The objectives genuinely differ; a shared scorer would force one skill to compromise.
+
 ## Field-set restrictions on S2 endpoints
 
 `tools/fetch_s2.py` uses two field sets:

--- a/.claude/skills/discover/references/seed-modes.md
+++ b/.claude/skills/discover/references/seed-modes.md
@@ -55,6 +55,8 @@ Triggers:
 
 Venue mode fetches the full paper list for that venue/year from Paper Copilot's public GitHub JSON source (`papercopilot/paperlists`), normalizes each record, and ranks them by relevance to the user's existing wiki content. It requires a non-sparse wiki — if the wiki is too empty, the tool fails clearly rather than returning an unpersonalized list.
 
+Venue mode does **not** use Semantic Scholar or DeepXiv. It does not write to `wiki/` or `raw/`.
+
 ## What if the user gave both an anchor and a topic?
 
 Prefer anchor mode. Anchors are a much stronger signal than a topic string. Mention the topic in the user-facing report so they know it was noted, but the discovery itself runs through `from-anchors`.

--- a/i18n/en/skills/discover/SKILL.md
+++ b/i18n/en/skills/discover/SKILL.md
@@ -115,7 +115,7 @@ Append a short "next step" hint:
 To ingest a candidate: /ingest https://arxiv.org/abs/<arxiv-id>
 ```
 
-Do not ingest anything yourself. The user picks.
+**Do not ingest anything yourself. The user picks.**
 
 ### Step 4: Log
 

--- a/i18n/en/skills/ideate/SKILL.md
+++ b/i18n/en/skills/ideate/SKILL.md
@@ -409,8 +409,8 @@ Before writing pilot code, generate a structured Pilot Spec block per idea selec
 # Pilot Spec for: {idea-slug}
 pilot_spec:
   # --- Core context (from idea Phase 2) ---
-  hypothesis: "<testable proposition>"
-  approach_sketch: "<proposed method description>"
+  hypothesis: "<1-2 sentence testable proposition>"
+  approach_sketch: "<3-5 sentence proposed method description>"
 
   # --- What to implement ---
   implementation:

--- a/i18n/zh/skills/daily-arxiv/SKILL.md
+++ b/i18n/zh/skills/daily-arxiv/SKILL.md
@@ -28,6 +28,30 @@ argument-hint: "[setup|status|disable] [--mode inform|auto-ingest] [--hours 24] 
 - `--max-auto-ingest N`：高置信 auto-ingest 上限；config/default 为 1。
 - `--send-email true|false`：workflow/setup 用的 SMTP 发送偏好。
 
+## Setup Workflow
+
+由 `/daily-arxiv setup` 触发。幂等 —— 在健康的 repo 上重跑是 no-op。
+
+1. **Config**：如果缺少 `config/daily-arxiv.yml`，从 `config/daily-arxiv.yml.example` 拷贝。如果已存在，则保持不动（用户的偏好是持久的）。
+
+2. **Workflow 文件**：确认 `.github/workflows/daily-arxiv.yml` 存在。如果缺失，引导用户查阅 `docs/daily-arxiv-deployment.md` 并停止 —— 从零重建该 workflow 超出 setup 的范围。
+
+3. **Workflow env 暴露（自动补丁）**：在 `.github/workflows/daily-arxiv.yml` 中，定位 `daily-arxiv:` job 的 `env:` 块。用 Edit 工具确保下面两行作为 `HAS_CLAUDE_CODE_AUTH` 的同级存在：
+
+   ```yaml
+   SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
+   DEEPXIV_TOKEN:            ${{ secrets.DEEPXIV_TOKEN }}
+   ```
+
+   - 如果两行都已存在，什么都不做。
+   - 如果只缺一行，追加缺失的那一行。
+   - 如果 `env:` 块根本不存在（较旧的 workflow），在该 job 下插入它，包含这两行以及已有的 `HAS_CLAUDE_CODE_AUTH` / `HAS_REVIEW_LLM` 标志。不要改动任何其他 step。
+   - 任何补丁之后，告诉用户改了什么，并提醒他们 commit。
+
+4. **Secrets 检查**：列出用户已配置了哪些 —— `ANTHROPIC_API_KEY` 或 `CLAUDE_CODE_OAUTH_TOKEN`、`SEMANTIC_SCHOLAR_API_KEY`、`DEEPXIV_TOKEN`，以及可选的 SMTP secrets。可用时用 `gh secret list`；否则指导用户自己运行。对任何缺失但必需的 secret，给出他们需要的确切 `gh secret set` 命令。
+
+5. **Summary**：汇报创建了什么、打了什么补丁，以及用户还需要做什么（安装 GitHub App、设置缺失的 secrets、用一次 `gh workflow run daily-arxiv.yml` 验证）。
+
 ## Run Workflow
 
 1. 解析 Python 解释器并准备 deterministic context：

--- a/i18n/zh/skills/ideate/SKILL.md
+++ b/i18n/zh/skills/ideate/SKILL.md
@@ -408,8 +408,8 @@ argument-hint: "[research-direction-or-topic] [--max-ideas N] [--skip-validation
 ```yaml
 # Pilot Spec for: {idea-slug}
 pilot_spec:
-  hypothesis: "<可测试命题>"
-  approach_sketch: "<方法描述>"
+  hypothesis: "<1-2 句可测试命题>"
+  approach_sketch: "<3-5 句方法描述>"
   implementation:
     repo: "<基础代码 repo URL 或 'from-scratch'>"
     entry_point: "<主脚本>"


### PR DESCRIPTION
## What & why

`i18n/en` is the documented source of truth — `setup.sh --lang en` activates it into the tracked `.claude/` tree (and root `CLAUDE.md`). But `.claude/` had a **second write path**: contributors also hand-edited the active copies directly. The two drifted apart, with a real consequence — the live `/discover` skill that Claude Code actually loads had silently lost guidance.

This PR reconciles the drift. No tool behavior changes; these are skill docs.

## Axis 1 — reconcile `.claude` ↔ `i18n/en`

Root cause: commit `89f8462` ("venue+year mode for /discover") edited the two copies inconsistently — on the `.claude` side it incidentally **deleted** content unrelated to the venue feature, while `i18n/en` kept it. Fixed `i18n/en` where needed, then regenerated `.claude` from it:

- **`/discover` (active skill) regains**: the `### From /init` section (why `/init` doesn't call `/discover`), the `## What discovery does not score on` rationale, and the "venue mode does not use S2/DeepXiv" seed-mode line.
- **ideate**: `i18n/en` placeholder hints made specific again (`<1-2 sentence …>` / `<3-5 sentence …>`), matching the neighbouring prose written in the same commit.
- **discover**: bolded the "do not ingest" safety note in the source so it survives regeneration.

After this, `.claude/skills` == `i18n/en/skills` byte-for-byte.

## Axis 2 — `i18n/zh` backfill

The zh translations had drifted from en. Verified **per file structurally** (not by line count — most apparent "gaps" were just Chinese being more compact):

- **daily-arxiv**: add the missing `## Setup Workflow` section (existed only in en).
- **ideate**: align placeholder length hints with en.

(`visualize`'s apparent 32-line gap was a false positive — line-wrapping + translated in-code comments, no missing content.)

## Follow-up (not in this PR)

To prevent recurrence: add CI that asserts `.claude` == `setup.sh --lang en` output, plus an en↔zh structural drift check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
