### PR TITLE
docs: publish Codex Preview branch and clarify research bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/Python-3.9+-yellow.svg)](https://www.python.org/)
-[![Claude Code](https://img.shields.io/badge/Powered_by-Claude_Code-d97706.svg)](https://docs.anthropic.com/en/docs/claude-code)
+[![Claude Code](https://img.shields.io/badge/main-Claude_Code_stable-d97706.svg)](https://docs.anthropic.com/en/docs/claude-code)
+[![Codex Preview](https://img.shields.io/badge/Codex-preview-111111.svg)](https://developers.openai.com/codex)
 [![arXiv](https://img.shields.io/badge/arXiv-2605.31468-b31b1b.svg)](https://arxiv.org/abs/2605.31468)
 [![Status](https://img.shields.io/badge/status-internal_beta-orange.svg)](#️⃣-status--update)
 
@@ -21,7 +22,31 @@
 
 > **Thanks to everyone who's been trying AutoSci — the community response has been amazing!** AutoSci evolved from our earlier OmegaWiki prototype into what we're building toward: a next-generation research agent that can handle the full scientific lifecycle. We're actively testing and iterating on new features, and more capabilities are on the way. Jump in, break things, and tell us what you think — your feedback and ideas are what's shaping where this goes next. 🙏
 
-> **🌿 Which branch?** [`main`](https://github.com/skyllwt/AutoSci/tree/main) is the **stable, lean** version. The **full system described in our [paper](https://arxiv.org/abs/2605.31468)** — SciMem · SciFlow · SciDAG · SciEvolve — lives on the [`paper`](https://github.com/skyllwt/AutoSci/tree/paper) branch (frozen as tag [`arxiv-v1`](https://github.com/skyllwt/AutoSci/tree/arxiv-v1)). Note that `paper` is a **research snapshot, not a finished product**: it's under active testing and iteration, and some capabilities described in the paper are still being implemented and refined.
+> **🌿 Which branch?** [`main`](https://github.com/skyllwt/AutoSci/tree/main) remains the **stable Claude Code version**. This [`migrate-codex`](https://github.com/skyllwt/AutoSci/tree/migrate-codex) branch is the **official Codex Preview**: local Codex skills are available under `.agents/skills`, while Claude Code compatibility is preserved under `.claude/skills`. The **full system described in our [paper](https://arxiv.org/abs/2605.31468)** — SciMem · SciFlow · SciDAG · SciEvolve — lives on the [`paper`](https://github.com/skyllwt/AutoSci/tree/paper) branch (frozen as tag [`arxiv-v1`](https://github.com/skyllwt/AutoSci/tree/arxiv-v1)).
+
+### Codex Preview
+
+Try the Codex preview without changing your `main` checkout:
+
+```bash
+git clone -b migrate-codex https://github.com/skyllwt/AutoSci.git
+cd AutoSci
+./setup.sh --lang en
+codex
+# Then invoke: $init [your-research-topic]
+```
+
+Current boundary:
+
+| Area | Status |
+|---|---|
+| Local Codex skills | Preview supported via `.agents/skills` |
+| Claude Code skills | Still supported via `.claude/skills` |
+| Shared skill source | `i18n/<lang>/skills` regenerates both active skill trees |
+| Daily arXiv CI inform recommendations | Codex supported |
+| Daily arXiv CI auto-ingest/writeback | Still uses the legacy Claude Code Action path until unattended Codex writeback is verified |
+
+See [docs/codex-preview.md](docs/codex-preview.md) for the preview notes and known boundaries.
 
 ---
 
@@ -93,7 +118,7 @@ Add the code decision gate, code optimization and config check
 
 ### 🎨 2026-05-18 · /poster — drafted paper → print-ready conference poster
 
-Run `/poster` after `/paper-draft` + `/paper-compile` to turn your finished draft into a self-contained 1400×900 HTML poster and a print-quality PNG. Figures, booktabs tables, and math macros are extracted automatically from your LaTeX source; Claude walks you through picking which figures land in which sections and customizing the header (venue, affiliation logo). Export to PDF from your browser's print dialog. Pipeline adapted from [PaperX](https://github.com/yutao1024/PaperX) ([arXiv:2602.03866](https://arxiv.org/abs/2602.03866)).
+Run the poster skill after paper-draft and paper-compile (`/poster` in Claude Code, `$poster` in Codex) to turn your finished draft into a self-contained 1400×900 HTML poster and a print-quality PNG. Figures, booktabs tables, and math macros are extracted automatically from your LaTeX source; the agent walks you through picking which figures land in which sections and customizing the header (venue, affiliation logo). Export to PDF from your browser's print dialog. Pipeline adapted from [PaperX](https://github.com/yutao1024/PaperX) ([arXiv:2602.03866](https://arxiv.org/abs/2602.03866)).
 
 <p align="center">
   <img src="assets/poster_demo_tikz_tables.png" alt="Example /poster output" width="720" />
@@ -101,11 +126,11 @@ Run `/poster` after `/paper-draft` + `/paper-compile` to turn your finished draf
 
 ### 🎯 2026-05-12 · /discover from a venue — "what should I read first from ICLR 2024?"
 
-Run `/discover --venue iclr --year 2024` (or any conference/year) and get a personalized shortlist of papers from that venue, ranked by relevance to what's already in your wiki. Instead of scrolling a 7000-paper proceedings, you see the dozen that actually matter for your research direction, each with a rationale tied to topics and methods you already track. No new API keys, no ingest side-effects on your wiki — just a ranked reading list. Supports NeurIPS, ICLR, ICML, and other venues covered by [Paper Copilot](https://github.com/papercopilot/paperlists).
+Use `/discover --venue iclr --year 2024` in Claude Code or `$discover --venue iclr --year 2024` in Codex (or any conference/year) and get a personalized shortlist of papers from that venue, ranked by relevance to what's already in your wiki. Instead of scrolling a 7000-paper proceedings, you see the dozen that actually matter for your research direction, each with a rationale tied to topics and methods you already track. No new API keys, no ingest side-effects on your wiki — just a ranked reading list. Supports NeurIPS, ICLR, ICML, and other venues covered by [Paper Copilot](https://github.com/papercopilot/paperlists).
 
 ### 📰 2026-05-09 · Daily arXiv — fresh-paper recommendations, on demand or scheduled
 
-Run `/daily-arxiv` for a one-off pass, or `/daily-arxiv setup` to schedule the same pipeline in GitHub Actions. The skill builds an evidence packet from arXiv + Semantic Scholar + DeepXiv, lets the LLM rank candidates against your wiki interests, and delivers a digest by e-mail. Explicit `--mode auto-ingest` calls `/ingest` for high-confidence picks; `inform` mode just notifies.
+Use `/daily-arxiv` in Claude Code or `$daily-arxiv` in Codex for a one-off pass. The GitHub Actions scheduler supports Codex CLI for unattended `inform` recommendations, with legacy Claude Code Action and Review LLM fallbacks; CI `auto-ingest` remains on the legacy Claude Action path until Codex writeback is separately verified. The skill builds an evidence packet from arXiv + Semantic Scholar + DeepXiv, lets the LLM rank candidates against your wiki interests, and delivers a digest by e-mail. Explicit `--mode auto-ingest` calls the ingest skill for high-confidence picks; `inform` mode just notifies.
 
 ### 🌐 2026-05-06 · Knowledge Graph Visualization — browser + Obsidian
 
@@ -245,29 +270,38 @@ The following papers were generated end-to-end using AutoSci — from literature
 
 ---
 
-## Quick Start
+## Codex Preview Quick Start
 
 **Prerequisites:** Python 3.9+, Node.js 18+
 
 ```bash
-# 1. Clone
-git clone https://github.com/skyllwt/AutoSci.git
+# 1. Clone the Codex Preview branch
+git clone -b migrate-codex https://github.com/skyllwt/AutoSci.git
 cd AutoSci
 
-# 2. Install Claude Code
-npm install -g @anthropic-ai/claude-code
-claude login
+# 2. Install and sign in to Codex
+# Follow your Codex/OpenAI setup path, then verify:
+codex --version
 
 # 3. One-click setup
 chmod +x setup.sh && ./setup.sh        # Linux / macOS
 # Windows (PowerShell):
 #   powershell -ExecutionPolicy Bypass -File .\setup.ps1
-# setup creates a .venv for AutoSci; /init will use it automatically
+# setup creates .venv and syncs both .claude/skills and .agents/skills
 
 # 4. Put your own papers in raw/papers/ (.tex or .pdf)
 #    Optional: intent notes in raw/notes/, saved pages in raw/web/
 
 # 5. Build your research memory and start a project
+codex
+# Then invoke: $init [your-research-topic]
+```
+
+Claude Code users can still use the same checkout:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+claude login
 claude
 # Then type: /init [your-research-topic]
 ```
@@ -279,7 +313,13 @@ claude
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env                 # Edit to add API keys
-cp config/settings.local.json.example .claude/settings.local.json
+mkdir -p .agents/skills/shared-references
+cp -R i18n/en/skills/. .agents/skills/
+cp i18n/en/shared-references/*.md .agents/skills/shared-references/
+mkdir -p .claude/skills/shared-references
+cp -R i18n/en/skills/. .claude/skills/
+cp i18n/en/shared-references/*.md .claude/skills/shared-references/
+cp config/settings.local.json.example .claude/settings.local.json  # Claude Code compatibility
 ```
 
 </details>
@@ -292,7 +332,13 @@ python -m venv .venv
 .\.venv\Scripts\Activate.ps1
 pip install -r requirements.txt
 Copy-Item .env.example .env          # Edit to add API keys
-Copy-Item config\settings.local.json.example .claude\settings.local.json
+New-Item -ItemType Directory -Force .agents\skills\shared-references | Out-Null
+Copy-Item i18n\en\skills\* .agents\skills -Recurse -Force
+Copy-Item i18n\en\shared-references\*.md .agents\skills\shared-references -Force
+New-Item -ItemType Directory -Force .claude\skills\shared-references | Out-Null
+Copy-Item i18n\en\skills\* .claude\skills -Recurse -Force
+Copy-Item i18n\en\shared-references\*.md .claude\skills\shared-references -Force
+Copy-Item config\settings.local.json.example .claude\settings.local.json  # Claude Code compatibility
 ```
 
 Note: native Windows is supported for the local pipeline. Remote-GPU
@@ -305,23 +351,25 @@ and are best run from WSL2 or Linux/macOS.
 
 | Key | Required? | How to get | What it enables |
 |-----|-----------|-----------|-----------------|
-| `ANTHROPIC_API_KEY` | **Yes** (or use a third-party compatible API — see below) | `claude login` (automatic) | Powers all Claude Code skills |
-| `CLAUDE_CODE_OAUTH_TOKEN` | Optional | `claude setup-token` | GitHub Actions Claude Code auth for Pro/Max users |
+| Agent runtime auth | **Yes** | Claude Code: `claude login`; Codex: sign in through Codex | Powers the interactive coding-agent skills |
+| `OPENAI_API_KEY` or `CODEX_ACCESS_TOKEN` | Optional | OpenAI / Codex account | GitHub Actions Codex CLI recommender for daily-arxiv inform mode |
+| `ANTHROPIC_API_KEY` | Claude Code only (or use a third-party compatible API — see below) | `claude login` (automatic) | Powers Claude Code skills |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Optional | `claude setup-token` | GitHub Actions legacy Claude Code auth for Pro/Max users and daily-arxiv auto-ingest |
 | `SEMANTIC_SCHOLAR_API_KEY` | Optional | [semanticscholar.org/product/api](https://www.semanticscholar.org/product/api) (free) | Citation graph, paper search |
 | `DEEPXIV_TOKEN` | Optional | `setup.sh` auto-registers | Semantic search, TLDR, trending |
 | `LLM_API_KEY` + `LLM_BASE_URL` + `LLM_MODEL` | Optional | Any OpenAI-compatible API | Cross-model review; `/daily-arxiv` inform recommendations |
 
-> **Don't have an Anthropic API key?** AutoSci runs on Claude Code, which supports any Anthropic-protocol-compatible provider — DeepSeek, Kimi, MiMo, GLM, and more. See the [LLM API Configuration](#llm-api-configuration--大模型-api-配置) section below for setup snippets.
+> **Don't have an Anthropic API key?** You can use Codex, or use Claude Code with any Anthropic-protocol-compatible provider — DeepSeek, Kimi, MiMo, GLM, and more. See the [LLM API Configuration](#llm-api-configuration--大模型-api-配置) section below for Claude Code provider snippets.
 
-> **Cross-model review**: AutoSci uses a second LLM as an independent reviewer for ideas, experiments, and paper drafts. Works with **any OpenAI-compatible API** — DeepSeek, OpenAI, Qwen, OpenRouter, SiliconFlow, etc. If not configured, skills still work in Claude-only mode.
+> **Cross-model review**: AutoSci uses a second LLM as an independent reviewer for ideas, experiments, and paper drafts. Works with **any OpenAI-compatible API** — DeepSeek, OpenAI, Qwen, OpenRouter, SiliconFlow, etc. If not configured, skills still work in single-agent mode.
 
 ---
 
 ## LLM API Configuration / 大模型 API 配置
 
-AutoSci runs on **Claude Code**, which speaks the **Anthropic API** protocol. You can use Claude directly, or route Claude Code to any third-party provider that exposes an Anthropic-compatible endpoint by overriding a few environment variables.
+AutoSci runs on **Claude Code** or **Codex**. Claude Code speaks the **Anthropic API** protocol: you can use Claude directly, or route Claude Code to any third-party provider that exposes an Anthropic-compatible endpoint by overriding a few environment variables. Codex uses the Codex/OpenAI sign-in path and reads the repo skills from `.agents/skills`.
 
-AutoSci 基于 **Claude Code**,Claude Code 使用 **Anthropic API** 协议通信。你既可以直接使用 Claude,也可以通过覆盖几个环境变量,把 Claude Code 指向任意支持 Anthropic 协议的第三方供应商。
+AutoSci 支持 **Claude Code** 与 **Codex**。Claude Code 使用 **Anthropic API** 协议通信：你既可以直接使用 Claude, 也可以通过覆盖几个环境变量, 把 Claude Code 指向任意支持 Anthropic 协议的第三方供应商。Codex 使用 Codex/OpenAI 登录路径，并从 `.agents/skills` 读取 repo skills。
 
 ### Option A — Native Claude / 原生 Claude
 
@@ -410,58 +458,65 @@ Pick a provider below, paste the snippet into `~/.claude/settings.json` (or the 
 
 ## Skills
 
-AutoSci ships with 30+ slash commands spanning the full research lifecycle.
+AutoSci ships with 30+ agent skills spanning the full research lifecycle.
+
+- Claude Code: invoke skills as slash commands, for example `/init`.
+- Codex: invoke skills with `$skill-name` or from `/skills`, for example `$init`.
 
 <details>
 <summary><b>View all skills</b></summary>
 
+Each skill has the same name in both runtimes. Use the Claude Code slash form
+inside Claude Code, and the Codex dollar form inside Codex or select the skill
+from Codex `/skills`.
+
 ### Phase 0: Setup
-| Command | What it does |
-|---------|-------------|
-| `/setup` | Interactive API key configuration — checks `.env` state and walks through Semantic Scholar, DeepXiv, and Review LLM setup |
-| `/reset` | Destructive cleanup — reset wiki state to a clean scaffold by scope (`wiki / raw / log / checkpoints / all`) |
+| Skill | Claude Code | Codex | What it does |
+|-------|-------------|-------|-------------|
+| setup | `/setup` | `$setup` | Interactive API key configuration — checks `.env` state and walks through Semantic Scholar, DeepXiv, and Review LLM setup |
+| reset | `/reset` | `$reset` | Destructive cleanup — reset wiki state to a clean scaffold by scope (`wiki / raw / log / checkpoints / all`) |
 
 ### Phase 1: Knowledge Base
-| Command | What it does |
-|---------|-------------|
-| `/prefill` | Seed `wiki/foundations/` with domain background so subsequent `/ingest` doesn't create duplicate concept pages for textbook material |
-| `/init` | Bootstrap the wiki from your source files, with optional discovery, then ingest the final paper set in parallel |
-| `/ingest` | Ingest a paper (local path or arXiv URL) — creates pages and builds all cross-references and graph edges |
-| `/discover` | Build a ranked shortlist of candidate papers (anchor-driven, topic-driven, venue-filtered, or from wiki state) without ingesting |
-| `/edit` | Add or remove raw sources, or update wiki content, per user request |
-| `/ask` | Ask the wiki a question — retrieve and synthesize relevant pages, optionally crystallize the answer back into the wiki |
-| `/check` | Scan the full wiki to detect health issues and produce a tiered fix-recommendation report |
+| Skill | Claude Code | Codex | What it does |
+|-------|-------------|-------|-------------|
+| prefill | `/prefill` | `$prefill` | Seed `wiki/foundations/` with domain background so later ingest runs do not create duplicate concept pages for textbook material |
+| init | `/init` | `$init` | Bootstrap the wiki from your source files, with optional discovery, then ingest the final paper set serially by default, with optional parallel worktree mode |
+| ingest | `/ingest` | `$ingest` | Ingest a paper (local path or arXiv URL) — creates pages and builds all cross-references and graph edges |
+| discover | `/discover` | `$discover` | Build a ranked shortlist of candidate papers (anchor-driven, topic-driven, venue-filtered, or from wiki state) without ingesting |
+| edit | `/edit` | `$edit` | Add or remove raw sources, or update wiki content, per user request |
+| ask | `/ask` | `$ask` | Ask the wiki a question — retrieve and synthesize relevant pages, optionally crystallize the answer back into the wiki |
+| check | `/check` | `$check` | Scan the full wiki to detect health issues and produce a tiered fix-recommendation report |
 
 ### Phase 2: Ideation & Experiments
-| Command | What it does |
-|---------|-------------|
-| `/daily-arxiv` | Run or schedule the daily arXiv recommendation feed; delivers a ranked digest by email with optional auto-ingest for high-confidence picks |
-| `/ideate` | Multi-phase research idea generation: landscape scan → dual-model brainstorm → filter & validation → write to wiki → pilot |
-| `/exp-pilot-run` | Pilot experiment execution — write code, deploy, monitor, collect raw results (called by `/ideate` Phase 5) |
-| `/exp-pilot-eval` | Pilot result evaluation — read results, apply success criteria, update idea page (called by `/ideate` Phase 5) |
-| `/novelty` | Multi-source novelty verification via WebSearch + Semantic Scholar + wiki + Review LLM; outputs novelty score and recommendations |
-| `/review` | Cross-model review of any research artifact — outputs structured scores, wiki entity mapping, and improvement suggestions |
-| `/exp-design` | Idea-driven experiment design with iterative ablation — method candidates → benchmark selection → sensitivity analysis → main experiment |
-| `/exp-run` | Full experiment execution pipeline — prepare code → deploy → monitor → collect results |
-| `/exp-status` | View the status of all running experiments; optionally auto-collect completed runs and advance the pipeline |
-| `/exp-eval` | Experiment verdict gate — Review LLM independently judges results and auto-updates the linked idea's status and graph edges |
-| `/refine` | Multi-round iterative improvement — repeatedly calls `/review`, parses feedback, applies fixes, and updates wiki until target score |
+| Skill | Claude Code | Codex | What it does |
+|-------|-------------|-------|-------------|
+| daily-arxiv | `/daily-arxiv` | `$daily-arxiv` | Run or schedule the daily arXiv recommendation feed; delivers a ranked digest by email with optional auto-ingest for high-confidence picks |
+| ideate | `/ideate` | `$ideate` | Multi-phase research idea generation: landscape scan → dual-model brainstorm → filter & validation → write to wiki → pilot |
+| exp-pilot-run | `/exp-pilot-run` | `$exp-pilot-run` | Pilot experiment execution — write code, deploy, monitor, collect raw results as part of the ideation pipeline |
+| exp-pilot-eval | `/exp-pilot-eval` | `$exp-pilot-eval` | Pilot result evaluation — read results, apply success criteria, update idea page as part of the ideation pipeline |
+| novelty | `/novelty` | `$novelty` | Multi-source novelty verification via WebSearch + Semantic Scholar + wiki + Review LLM; outputs novelty score and recommendations |
+| review | `/review` | `$review` | Cross-model review of any research artifact — outputs structured scores, wiki entity mapping, and improvement suggestions |
+| exp-design | `/exp-design` | `$exp-design` | Idea-driven experiment design with iterative ablation — method candidates → benchmark selection → sensitivity analysis → main experiment |
+| exp-run | `/exp-run` | `$exp-run` | Full experiment execution pipeline — prepare code → deploy → monitor → collect results |
+| exp-status | `/exp-status` | `$exp-status` | View the status of all running experiments; optionally auto-collect completed runs and advance the pipeline |
+| exp-eval | `/exp-eval` | `$exp-eval` | Experiment verdict gate — Review LLM independently judges results and auto-updates the linked idea's status and graph edges |
+| refine | `/refine` | `$refine` | Multi-round iterative improvement — repeatedly reviews an artifact, parses feedback, applies fixes, and updates wiki until target score |
 
 ### Phase 3: Writing & Dissemination
-| Command | What it does |
-|---------|-------------|
-| `/survey` | Generate a Related Work section from wiki knowledge — thematic grouping → narrative structure → LaTeX output |
-| `/paper-plan` | Compile a paper outline from the idea graph — evidence map → narrative structure → section + figure + citation plan |
-| `/paper-draft` | Draft a LaTeX paper from `PAPER_PLAN` — write each section from wiki sources, generate figures/tables, verify BibTeX |
-| `/paper-compile` | LaTeX compile → PDF — latexmk compile + auto-fix + page count / anonymity / font checks + submission checklist |
-| `/research` | End-to-end research orchestrator — idea discovery → experiment design → execution → verdict → paper writing with human gates |
-| `/rebuttal` | Parse review comments → atomize concerns → map to wiki → stress-test with Review LLM → generate rebuttal |
-| `/poster` | Generate an academic poster from a drafted paper — distill sections into a single-page HTML poster with figures |
+| Skill | Claude Code | Codex | What it does |
+|-------|-------------|-------|-------------|
+| survey | `/survey` | `$survey` | Generate a Related Work section from wiki knowledge — thematic grouping → narrative structure → LaTeX output |
+| paper-plan | `/paper-plan` | `$paper-plan` | Compile a paper outline from the idea graph — evidence map → narrative structure → section + figure + citation plan |
+| paper-draft | `/paper-draft` | `$paper-draft` | Draft a LaTeX paper from `PAPER_PLAN` — write each section from wiki sources, generate figures/tables, verify BibTeX |
+| paper-compile | `/paper-compile` | `$paper-compile` | LaTeX compile → PDF — latexmk compile + auto-fix + page count / anonymity / font checks + submission checklist |
+| research | `/research` | `$research` | End-to-end research orchestrator — idea discovery → experiment design → execution → verdict → paper writing with human gates |
+| rebuttal | `/rebuttal` | `$rebuttal` | Parse review comments → atomize concerns → map to wiki → stress-test with Review LLM → generate rebuttal |
+| poster | `/poster` | `$poster` | Generate an academic poster from a drafted paper — distill sections into a single-page HTML poster with figures |
 
 ### Utilities
-| Command | What it does |
-|---------|-------------|
-| `/visualize` | Generate Obsidian graph configs and Canvas knowledge maps; the interactive web graph is served by `tools/serve.py` |
+| Skill | Claude Code | Codex | What it does |
+|-------|-------------|-------|-------------|
+| visualize | `/visualize` | `$visualize` | Generate Obsidian graph configs and Canvas knowledge maps; the interactive web graph is served by `tools/serve.py` |
 
 </details>
 
@@ -495,7 +550,7 @@ If you find AutoSci useful in your research, please cite our paper:
 
 ## Acknowledgments
 
-- **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** — the AI agent runtime that powers AutoSci
+- **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** and **[Codex](https://developers.openai.com/codex)** — supported coding-agent runtimes for AutoSci
 - The `/poster` pipeline is adapted from [PaperX](https://github.com/yutao1024/PaperX)
 
 ## License
@@ -517,7 +572,7 @@ If you find AutoSci useful in your research, please cite our paper:
 
 <div align="center">
 
-**Built with [Claude Code](https://docs.anthropic.com/en/docs/claude-code)**
+**Built for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [Codex](https://developers.openai.com/codex)**
 
 If this project helps your research, give it a ⭐
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ If you find AutoSci useful in your research, please [cite our paper](#citation).
 
 ## 🆕 What's New
 
+### 🛠️ 2026-07-10 · migrate-codex branch codex adaptation
+
+Ported the project from a Claude Code-first baseline to a Codex-adapted branch on top of `main`: standardized runtime-facing docs, aligned setup/sync behavior, and updated workflow expectations for Codex compatibility.  
+Key functional change in this cycle: `/research` no longer auto-implements bootstrap ingest logic on cold wiki; it now delegates bootstrap explicitly to `/init` / `$init` and proceeds only after bootstrap completion.
+
 ### 🛠️ 2026-05-19 · Experiment Overhaul
 
 A possible usage process：`/ideate [research-direction-or-topic]`(You can use `--skip-pilot` to decide whether to conduct preliminary experiments) -> `/exp-design <idea-slug>`-> For each experimental block,recommended flow: `/exp-run <slug> [--env local|remote]` to deploy → `/exp-status` to monitor → `/exp-run <slug> --collect` to collect.->`/exp-eval <experiment-slug>`

--- a/i18n/en/skills/research/SKILL.md
+++ b/i18n/en/skills/research/SKILL.md
@@ -7,7 +7,7 @@ argument-hint: <research-direction-or-brief> [--auto] [--start-from stage1|stage
 
 > End-to-end research orchestrator that composes all skills into a complete research workflow.
 > Stage 0 (Bootstrap) + 5 Stages + 2 Human Gates, covering the full pipeline from empty wiki to paper submission.
-> **Zero-friction entry**: if the wiki is empty, Bootstrap is triggered automatically (search + auto-ingest 5 papers); no need to run /init manually.
+> **Zero-friction entry**: if the wiki is cold, research pauses at Stage 0 and requires explicit bootstrap via `/init` / `$init` before continuing.
 > Every Gate and Stage saves progress to `wiki/outputs/pipeline-progress.md`, supporting cross-session recovery.
 >
 > **Stage 3 is non-blocking**: experiments are deployed and control returns immediately (`--auto` mode automatically sets up a CronCreate to monitor every 30 minutes).
@@ -138,32 +138,23 @@ argument-hint: <research-direction-or-brief> [--auto] [--start-from stage1|stage
    ```
    Save returned JSON to memory variable `maturity_before`.
 
-### Stage 0: Bootstrap (triggered automatically when wiki is empty)
+### Stage 0: Bootstrap (cold wiki handoff path)
 
-**Trigger condition**: run `python3 tools/research_wiki.py maturity wiki/ --json`. If `level == "cold"` and `papers < 3`: enter Bootstrap automatically. Otherwise skip and proceed to Stage 1.
+**Trigger condition**: run `python3 tools/research_wiki.py maturity wiki/ --json`. If `level == "cold"` and `papers < 3`: stop Stage 0 and hand off to `/init` / `$init`. Otherwise skip and proceed to Stage 1.
 
 1. **Initialize wiki structure** (if not yet initialized):
    ```bash
    python3 tools/research_wiki.py init wiki/
    ```
 
-2. **Search for relevant papers** (use Agent tool with 3 parallel searches):
-   - DeepXiv: `python3 tools/fetch_deepxiv.py search "{direction}" --mode hybrid --limit 20`
-   - Semantic Scholar: `python3 tools/fetch_s2.py search "{direction}" --limit 20`
-   - arXiv: `python3 tools/fetch_arxiv.py` (using direction keywords)
-   - If DeepXiv is unavailable: skip; use only S2 + arXiv
-
-3. **Merge, rank, and select top 5**:
-   - Deduplicate by arxiv_id
-   - Ranking priority: DeepXiv relevance score > S2 citation count > recency
-   - Select top 5 (5 = minimum threshold for cold→warm)
-
-4. **Auto-ingest each paper**:
+2. **Defer to `/init` / `$init`**:
+   ```bash
+   Skill: init
+   Args: "{direction}"
    ```
-   Skill: ingest
-   Args: "{arxiv_url_or_path}"
-   ```
-   Output progress after each ingest: `[{i}/5] Ingested: {paper_title}`
+   In `/research`, Stage 0 should not duplicate the init logic and should not claim to auto-ingest papers on its own.
+
+3. **Wait for `/init` completion** (or user confirmation in interactive flow) before continuing.
 
 5. **Rebuild derived data**:
    ```bash
@@ -177,16 +168,16 @@ argument-hint: <research-direction-or-brief> [--auto] [--start-from stage1|stage
    ```
    Output to terminal:
    ```
-   Bootstrap complete:
+   Bootstrap handoff complete:
    Papers: {N} | Concepts: {K} | Methods: {Mt} | Edges: {E}
    Maturity: cold → {new_level}
-   Proceeding to Stage 1: Idea Discovery...
+   Proceeding to Stage 1: Idea Discovery after init completion...
    ```
 
 7. **Log + update progress**:
    ```bash
    python3 tools/research_wiki.py log wiki/ \
-     "research | stage0-bootstrap | auto-ingested {N} papers | maturity: {level}"
+     "research | stage0-bootstrap | init-handoff-complete | maturity: {level}"
    python3 tools/research_wiki.py set-meta \
      wiki/outputs/pipeline-progress.md current_stage stage1
    ```
@@ -513,14 +504,14 @@ Update pipeline-progress: status: completed
 - **All experiment collects fail (non-baseline)**: proceed to Stage 4 evaluation (treat failures as evidence)
 - **Gate user selects stop**: save progress to pipeline-progress; generate partial report
 - **RESEARCH_BRIEF.md malformed**: fall back to plain-text direction; ignore structured fields
-- **Wiki empty (no papers/concepts)**: auto-trigger Stage 0 Bootstrap (search + auto-ingest 5 papers)
+- **Wiki empty (no papers/concepts)**: trigger Stage 0 handoff path; require explicit `/init`/`$init` bootstrap before Stage 1
 - **Idea evidence still insufficient after iteration**: annotate report with "idea evidence insufficient after max iterations"; let user decide whether to continue
 - **User selects view status (auto-recovery detection [3])**: call `/exp-status --pipeline {slug}` then exit without starting a new pipeline
 
 ## Dependencies
 
 ### Skills（via Skill tool）
-- `/ingest` — Stage 0 Bootstrap auto-ingest
+- `/init` — Stage 0 bootstrap handoff
 - `/ideate` — Stage 1 idea discovery
 - `/exp-design` — Stage 2 experiment design
 - `/exp-run` — Stage 3a (deploy mode) and Stage 3c (--collect mode)
@@ -537,9 +528,6 @@ Update pipeline-progress: status: completed
 - `python3 tools/research_wiki.py log wiki/ "<message>"` — append log entry
 - `python3 tools/research_wiki.py maturity wiki/ --json` — check wiki maturity (Stage 0 trigger + Growth Report)
 - `python3 tools/research_wiki.py init wiki/` — initialize wiki structure (Stage 0)
-- `python3 tools/fetch_deepxiv.py search "{query}" --mode hybrid --limit 20` — DeepXiv semantic search (Stage 0)
-- `python3 tools/fetch_s2.py search "{query}" --limit 20` — Semantic Scholar search (Stage 0)
-- `python3 tools/fetch_arxiv.py` — arXiv RSS search (Stage 0)
 
 ### MCP Servers
 - None directly — all Review LLM interactions are used indirectly via sub-skills

--- a/i18n/zh/skills/research/SKILL.md
+++ b/i18n/zh/skills/research/SKILL.md
@@ -7,7 +7,7 @@ argument-hint: <research-direction-or-brief> [--auto] [--start-from stage1|stage
 
 > 端到端研究编排器，将所有 skill 组合为完整的研究流程。
 > Stage 0 (Bootstrap) + 5 个 Stage + 2 个 Human Gate，覆盖从空 wiki 到论文提交的全流程。
-> **零摩擦入口**：wiki 为空时自动触发 Bootstrap（搜索 + auto-ingest 5 篇论文），无需手动 /init。
+> **零摩擦入口**：wiki 处于冷启动时，`/research` 在 Stage 0 暂停，需显式运行 `/init` / `$init` 进行 Bootstrap 后再继续。
 > 每个 Gate 和 Stage 保存进度到 `wiki/outputs/pipeline-progress.md`，支持跨 session 恢复。
 >
 > **Stage 3 为非阻塞设计**：实验部署后立即返回（`--auto` 模式自动设置 CronCreate 每 30 分钟监控），
@@ -138,32 +138,23 @@ argument-hint: <research-direction-or-brief> [--auto] [--start-from stage1|stage
    ```
    保存返回的 JSON 到内存变量 `maturity_before`。
 
-### Stage 0: Bootstrap（wiki 为空时自动触发）
+### Stage 0: Bootstrap（冷启动 handoff 路径）
 
-**触发条件**：运行 `python3 tools/research_wiki.py maturity wiki/ --json`，若 `level == "cold"` 且 `papers < 3`：自动进入 Bootstrap。否则跳过，直接进入 Stage 1。
+**触发条件**：运行 `python3 tools/research_wiki.py maturity wiki/ --json`，若 `level == "cold"` 且 `papers < 3`：触发 `/init` / `$init` handoff 流程；否则跳过，直接进入 Stage 1。
 
 1. **初始化 wiki 结构**（若未初始化）：
    ```bash
    python3 tools/research_wiki.py init wiki/
    ```
 
-2. **搜索相关论文**（使用 Agent tool 并行 3 路搜索）：
-   - DeepXiv：`python3 tools/fetch_deepxiv.py search "{direction}" --mode hybrid --limit 20`
-   - Semantic Scholar：`python3 tools/fetch_s2.py search "{direction}" --limit 20`
-   - arXiv：`python3 tools/fetch_arxiv.py`（使用 direction 关键词）
-   - 若 DeepXiv 不可用：跳过，仅使用 S2 + arXiv
-
-3. **合并排名 & 选取 top 5**：
-   - 按 arxiv_id 去重
-   - 排序优先级：DeepXiv relevance score > S2 citation count > recency
-   - 取 top 5 篇（5 = cold→warm 最低门槛）
-
-4. **逐一 auto-ingest**：
+2. **交给 `/init` / `$init`**：
    ```
-   Skill: ingest
-   Args: "{arxiv_url_or_path}"
+   Skill: init
+   Args: "{direction}"
    ```
-   每篇 ingest 后输出进度：`[{i}/5] Ingested: {paper_title}`
+   `/research` 不应重复实现 bootstrap 的搜索 / 排名 / auto-ingest 逻辑。
+
+3. **等待 `/init` 完成**（或在交互流程中征得用户确认）后进入 Stage 1。
 
 5. **重建派生数据**：
    ```bash
@@ -171,7 +162,7 @@ argument-hint: <research-direction-or-brief> [--auto] [--start-from stage1|stage
    python3 tools/research_wiki.py rebuild-open-questions wiki/
    ```
 
-6. **Bootstrap 报告**：
+6. **Bootstrap 报告**（`/init` 完成后）：
    ```bash
    python3 tools/research_wiki.py maturity wiki/ --json
    ```
@@ -186,7 +177,7 @@ argument-hint: <research-direction-or-brief> [--auto] [--start-from stage1|stage
 7. **日志 + 进度更新**：
    ```bash
    python3 tools/research_wiki.py log wiki/ \
-     "research | stage0-bootstrap | auto-ingested {N} papers | maturity: {level}"
+     "research | stage0-bootstrap | init-handoff-complete | maturity: {level}"
    python3 tools/research_wiki.py set-meta \
      wiki/outputs/pipeline-progress.md current_stage stage1
    ```
@@ -513,14 +504,14 @@ python3 tools/research_wiki.py log wiki/ \
 - **所有实验 collect 失败（其他非 baseline）**：进入 Stage 4 评估（以失败为证据）
 - **Gate 用户选择 stop**：保存进度到 pipeline-progress，生成部分报告
 - **RESEARCH_BRIEF.md 格式错误**：降级为纯文本 direction，忽略结构化字段
-- **wiki 为空（无 papers/concepts）**：自动触发 Stage 0 Bootstrap（搜索 + auto-ingest 5 篇论文）
+- **wiki 为空（无 papers/concepts）**：先触发 Stage 0 handoff，要求执行 `/init` / `$init` 再进入 Stage 1
 - **迭代后 idea 证据仍不足**：在报告中标注 "idea evidence insufficient after max iterations"，由用户决定是否继续
 - **用户选择查看状态（自动恢复检测 [3]）**：调用 `/exp-status --pipeline {slug}` 后退出，不继续执行新流水线
 
 ## Dependencies
 
 ### Skills（via Skill tool）
-- `/ingest` — Stage 0 Bootstrap auto-ingest
+- `/init` — Stage 0 Bootstrap handoff
 - `/ideate` — Stage 1 idea 发现
 - `/exp-design` — Stage 2 实验设计
 - `/exp-run` — Stage 3a（deploy 模式）和 Stage 3c（--collect 模式）
@@ -537,9 +528,6 @@ python3 tools/research_wiki.py log wiki/ \
 - `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
 - `python3 tools/research_wiki.py maturity wiki/ --json` — 检查 wiki 成熟度（Stage 0 触发条件 + Growth Report）
 - `python3 tools/research_wiki.py init wiki/` — 初始化 wiki 结构（Stage 0）
-- `python3 tools/fetch_deepxiv.py search "{query}" --mode hybrid --limit 20` — DeepXiv 语义搜索（Stage 0）
-- `python3 tools/fetch_s2.py search "{query}" --limit 20` — Semantic Scholar 搜索（Stage 0）
-- `python3 tools/fetch_arxiv.py` — arXiv RSS 搜索（Stage 0）
 
 ### MCP Servers
 - 无直接 MCP 调用 — 所有 Review LLM 交互通过子 skill 间接使用


### PR DESCRIPTION
## Summary

- Document `migrate-codex` as the official Codex Preview branch while keeping `main` as the stable Claude Code branch.
- Add Codex Preview setup and invocation guidance, including current daily-arXiv CI boundaries.
- Update the `/research` cold-wiki path: it now hands off explicitly to `/init` (or `$init` in Codex) instead of duplicating paper search and auto-ingest logic.

## Scope

- `README.md`
- `i18n/en/skills/research/SKILL.md`
- `i18n/zh/skills/research/SKILL.md`

## Validation

- Reviewed the branch diff against current `main`: 2 commits, 3 text files, with no code or dependency changes.
- GitHub currently reports no automated check runs for the branch tip.