### PR TITLE
feat: add Qoder preview adaptation (autosci-qoder)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,14 @@ build/
 # Language state (set by setup.sh --lang)
 .claude/.current-lang
 
+# Language state (set by setup-qoder / tools/convert_to_qoder.py)
+.qoder/.current-lang
+
 # Claude Code local settings (contains MCP server permissions, may contain API keys)
 .claude/settings.local.json
+
+# Qoder local MCP registration (generated from config/mcp.qoder.json.example)
+.qoder/mcp.json
 
 # IDE
 .vscode/

--- a/.qoder/skills/ask/SKILL.md
+++ b/.qoder/skills/ask/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: ask
+description: 对 wiki 提问，综合检索相关页面后回答，好的回答可 crystallize 回 wiki
+---
+
+# /ask
+
+> **用法**：`<question>`
+
+
+> 对 wiki 知识库提问。LLM 读取 context_brief.md 获取全局上下文，检索相关页面，
+> 综合回答并附带引用。好的回答可以 crystallize 回 wiki——写入 outputs/、创建新的
+> concept 页面，或追加到已有的 idea/method/output 笔记上，让探索成果像 ingest 一样持续积累。
+
+## Inputs
+
+- `question`：自然语言问题（如 "LoRA 和 Adapter 的核心区别是什么？"）
+- `--crystallize`（可选）：若指定，将回答 crystallize 回 wiki（默认仅回答不写入）
+- `--format`（可选）：输出格式，默认 `markdown`，可选 `table` / `timeline` / `bullets`
+
+## Outputs
+
+- **始终**：终端输出综合回答（含 `[[slug]]` 引用）
+- **若 crystallize**：
+  - `wiki/outputs/{query-slug}.md` — 查询结果页面（默认 crystallize 目标）
+  - 或 `wiki/concepts/{slug}.md` — 若回答揭示了新的跨论文概念
+  - 或追加到已有的 `wiki/ideas/{slug}.md` / `wiki/methods/{slug}.md` / `wiki/outputs/{slug}.md` — 若回答为已有实体补充了新发现
+  - 更新的 `wiki/graph/edges.jsonl`（crystallize 产生的关系）
+  - 更新的 `wiki/index.md` 和 `wiki/log.md`
+
+## Wiki Interaction
+
+### Reads
+- `wiki/graph/context_brief.md` — 全局压缩上下文（ideas, gaps, failed ideas, papers, edges）
+- `wiki/index.md` — 页面目录，用于定位相关页面
+- `wiki/graph/open_questions.md` — 开放问题，辅助判断问题是否涉及已知知识缺口
+- `wiki/papers/*.md` — 与问题相关的论文页面
+- `wiki/concepts/*.md` — 与问题相关的概念页面
+- `wiki/methods/*.md` — 与问题相关的 method 页面
+- `wiki/topics/*.md` — 与问题相关的 topic 页面
+- `wiki/people/*.md` — 若问题涉及特定研究者
+- `wiki/ideas/*.md` — 若问题涉及研究想法或 failed ideas
+- `wiki/experiments/*.md` — 若问题涉及实验结果
+- `wiki/Summary/*.md` — 若问题涉及领域全景
+
+### Writes（仅 crystallize 模式）
+- `wiki/outputs/{query-slug}.md` — CREATE（查询结果页面）
+- `wiki/concepts/{slug}.md` — CREATE（新发现概念）或 EDIT（补充已有概念）
+- `wiki/ideas/{slug}.md` / `wiki/methods/{slug}.md` / `wiki/outputs/{slug}.md` — EDIT（向已有页面追加新发现）
+- `wiki/graph/edges.jsonl` — APPEND（crystallize 产生的关系）
+- `wiki/graph/context_brief.md` — REBUILD（若 crystallize 创建了新页面）
+- `wiki/graph/open_questions.md` — REBUILD（若 crystallize 创建了新页面）
+- `wiki/index.md` — EDIT（若 crystallize 创建了新页面）
+- `wiki/log.md` — APPEND
+
+### Graph edges created（仅 crystallize）
+- `output → paper`: `derived_from`（回答引用的论文）
+- `output → concept`: `derived_from`（回答引用的概念）
+- `output → idea` / `output → method`: `derived_from`（回答引用的 idea 或 method）
+- `concept → paper`: `supports`（若新概念从论文中归纳）
+
+## Workflow
+
+**前置**：确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）。
+设 `WIKI_ROOT=wiki/`。
+
+### Step 1: 加载全局上下文
+
+1. 读取 `wiki/graph/context_brief.md`——获取 wiki 当前知识的压缩快照（ideas, gaps, papers, edges）
+2. 读取 `wiki/graph/open_questions.md`——了解已知的开放问题和知识缺口
+3. 若两者都不存在，先重建：
+   ```bash
+   python3 tools/research_wiki.py rebuild-context-brief wiki/
+   python3 tools/research_wiki.py rebuild-open-questions wiki/
+   ```
+
+### Step 2: 检索相关页面
+
+1. 读取 `wiki/index.md`，基于 question 关键词匹配相关 slugs
+2. 从 context_brief.md 中提取与 question 语义相关的 ideas、methods 和 papers
+3. 按相关性排序，选取 top-K 页面（K ≤ 15，避免上下文过长）
+4. 读取选中页面的完整内容
+5. 若 question 涉及关系（如 "X 和 Y 的区别"），额外读取 `wiki/graph/edges.jsonl` 中连接 X 和 Y 的边
+
+### Step 3: 综合回答
+
+1. 基于收集的页面内容，综合回答用户问题
+2. 回答要求：
+   - **有引用**：每个关键论断必须附带 `[[slug]]` wikilink 指向来源页面
+   - **有结构**：根据 `--format` 参数组织输出（markdown / table / timeline / bullets）
+   - **识别不确定性**：对 wiki 中证据不足的部分明确标注 "wiki 中尚无充分证据"
+   - **标注知识缺口**：若问题触及 open_questions.md 中的已知缺口，明确指出
+   - **引用 idea 状态**：涉及 idea 时注明其 `status` 和 `novelty_score`
+3. 若问题超出 wiki 当前知识范围，坦诚告知并建议：
+   - 需要 ingest 哪些论文来填补
+   - 可能的搜索方向（arXiv 关键词、Semantic Scholar 查询）
+
+### Step 4: 评估 crystallize 价值
+
+1. 判断回答是否值得写回 wiki（即使用户未指定 `--crystallize`，也给出建议）
+2. Crystallize 值得的信号：
+   - 回答综合了多篇论文的信息，形成了新的跨论文洞察
+   - 回答揭示了一个 wiki 中尚未显式记录的概念
+   - 回答为已有的 idea、method 或 output 笔记补充了新发现
+   - 回答回应了 open_questions.md 中的一个已知缺口
+3. Crystallize 不值得的信号：
+   - 回答只是复述了单一页面的内容
+   - 问题是简单事实查询（如 "LoRA 是哪年发表的？"）
+   - 回答主要依赖推测而非 wiki 中的证据
+4. 在回答末尾附带 crystallize 建议：
+   ```
+   💡 Crystallize 建议：[值得/不必要] — [原因]
+   ```
+
+### Step 5: Crystallize 回 wiki（若用户确认或指定了 --crystallize）
+
+根据回答内容选择 crystallize 目标：
+
+**Case A — 写入 outputs/（默认）：**
+1. 生成 slug：`python3 tools/research_wiki.py slug "<query-summary>"`
+2. 创建 `wiki/outputs/{query-slug}.md`：
+   ```yaml
+   ---
+   title: ""
+   slug: ""
+   query: ""           # 原始问题
+   source_pages: []    # 回答引用的所有页面 slugs
+   date_created: YYYY-MM-DD
+   ---
+   ```
+   正文为回答内容（保留 wikilinks）
+3. 为每个引用的源页面添加 graph edge：
+   ```bash
+   python3 tools/research_wiki.py add-edge wiki/ --from outputs/<slug> --to papers/<source-slug> --type derived_from --evidence "query answer"
+   ```
+
+**Case B — 创建新 concept：**
+1. 若回答揭示了新概念：按 CLAUDE.md concept 模板创建 `wiki/concepts/{slug}.md`
+2. maturity: emerging
+3. key_papers: 从回答引用中提取
+4. 添加 graph edges（concept → papers）
+5. 在相关 paper 页面的 `## Related` 追加反向链接
+
+**Case C — 向已有 idea、method 或 output 笔记追加发现：**
+1. 若回答扩展了与已有实体相关的发现，向对应章节追加一段（带 `[[slug]]` 引用）：
+   - `wiki/ideas/{slug}.md` → `## Lessons learned` 或 `## Pilot results`
+   - `wiki/methods/{slug}.md` → `## Limitations` 或 `## Tradeoff profile`
+   - `wiki/outputs/{slug}.md` → 正文末尾
+2. 从被修改的页面向引用的 papers/concepts/methods 添加 graph edges（`derived_from`）
+3. 不创建新实体；本 case 仅丰富已有实体
+
+### Step 6: 更新导航与图谱（仅 crystallize）
+
+1. **index.md**：在对应分类下追加新建页面条目
+2. **log.md**：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ "ask | <question-summary> | crystallized: <target-path>"
+   ```
+   若未 crystallize：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ "ask | <question-summary> | answer-only"
+   ```
+3. **重建 graph 派生文件**（仅 crystallize 创建了新页面时）：
+   ```bash
+   python3 tools/research_wiki.py rebuild-context-brief wiki/
+   python3 tools/research_wiki.py rebuild-open-questions wiki/
+   ```
+
+### Step 7: 报告给用户
+
+输出摘要，包含：
+- 检索的页面数量和列表
+- 回答（带引用和格式）
+- 知识缺口标注（若有）
+- Crystallize 建议或执行结果
+- 后续建议（推荐 ingest 的论文、相关的 open questions）
+
+## Constraints
+
+- **不得虚构**：回答必须基于 wiki 中的实际内容，不得凭 LLM 预训练知识编造
+- **引用必须存在**：每个 `[[slug]]` 必须指向 wiki 中实际存在的页面
+- **raw/ 只读**：不得修改 `raw/` 下的文件
+- **graph/ 仅通过 tools 维护**：不得手动编辑 `graph/` 下的文件
+- **Crystallize 需确认**：除非用户显式指定 `--crystallize`，否则仅建议但不执行写入
+- **上下文限制**：检索页面数量 ≤ 15，避免超出上下文窗口
+- **idea 状态引用**：涉及 idea 时必须注明其 `status` 和 `novelty_score`
+- **gap 标注**：若问题涉及 open_questions.md 中的已知缺口，必须明确指出
+- **outputs/ frontmatter 必须包含 query 和 source_pages**：确保可追溯
+
+## Error Handling
+
+- **context_brief.md 不存在**：运行 `python3 tools/research_wiki.py rebuild-context-brief wiki/` 重建后重试
+- **wiki 为空**：告知用户先运行 `/init` 或 `/ingest` 建立知识基础
+- **无相关页面匹配**：坦诚告知 wiki 中无相关内容，建议搜索和 ingest 方向
+- **crystallize slug 冲突**：追加数字后缀（如 `query-result-2`）
+- **index.md 不存在**：运行 `python3 tools/research_wiki.py init wiki/` 初始化后重试
+
+## Dependencies
+
+### Tools（via Bash）
+- `python3 tools/research_wiki.py slug "<title>"` — slug 生成
+- `python3 tools/research_wiki.py add-edge wiki/ --from <id> --to <id> --type <type> --evidence "<text>"` — 添加 graph edge
+- `python3 tools/research_wiki.py rebuild-context-brief wiki/` — 重建压缩上下文
+- `python3 tools/research_wiki.py rebuild-open-questions wiki/` — 重建知识缺口地图
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+- `python3 tools/research_wiki.py init wiki/` — 初始化 wiki（fallback）
+
+### Skills（via Skill tool）
+- `/ingest` — 若建议用户补充知识时引用
+
+### Shared References
+- `.qoder/skills/shared-references/citation-verification.md`（Phase 3 创建）

--- a/.qoder/skills/check/SKILL.md
+++ b/.qoder/skills/check/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: check
+description: 扫描全 wiki 发现健康问题，生成分级修复建议报告（覆盖 runtime/schema/entities.yaml 中全部 entity 类型 + graph 一致性）
+---
+
+# /check
+
+> 扫描全 wiki，发现结构、链接、字段、graph 的健康问题，生成分级修复建议。
+> 覆盖 `runtime/schema/entities.yaml` 中声明的所有 entity 类型（papers, concepts, topics, people, ideas, experiments, methods, Summary, foundations），以及 graph edge / citation 一致性。重点检查包括：idea novelty-score 合理性、idea 失败原因完整性、experiment `linked_idea` 有效性。
+
+## Inputs
+
+- 全 wiki 目录（默认 `wiki/`）
+- 可选：`--json` 标志（通过 tools/lint.py 输出 JSON 格式）
+- 可选：`--fix` 标志（自动修复确定性问题）
+- 可选：`--fix --dry-run`（预览修复但不执行）
+- 可选：`--suggest` 标志（显示非自动修复问题的建议）
+
+## Outputs
+
+- Lint report（直接报告给用户）
+- 可选写入文件：`wiki/outputs/lint-report-{date}.md`
+
+## Wiki Interaction
+
+### Reads
+- `wiki/papers/*.md` — 论文页面字段和链接
+- `wiki/concepts/*.md` — 概念页面字段和链接
+- `wiki/topics/*.md` — 方向页面字段和链接
+- `wiki/people/*.md` — 人物页面字段和链接
+- `wiki/ideas/*.md` — idea status、novelty_score、failure_reason、origin_gaps、target_venue
+- `wiki/experiments/*.md` — experiment status、linked_idea、outcome
+- `wiki/methods/*.md` — method type、source_papers、parent/child 链
+- `wiki/Summary/*.md` — 综述页面字段
+- `wiki/foundations/*.md` — foundations(终端 — 仅检查入链)
+- `wiki/graph/edges.jsonl` — semantic graph edge 一致性检查
+- `wiki/graph/citations.jsonl` — bibliographic citation 一致性检查
+- `wiki/index.md` — 对照页面完整性
+
+### Writes
+- 不直接修改 wiki 内容（仅报告，除非指定 `--fix`）
+- `wiki/log.md` — 通过 `tools/research_wiki.py log` 记录 lint 结果摘要
+
+## Workflow
+
+**前置**：确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）。
+设 `WIKI_ROOT=wiki/`。
+
+### Step 1: 运行自动化 lint 工具
+
+**默认模式（只报告）**：
+```bash
+python3 tools/lint.py --wiki-dir wiki/ --json
+```
+
+**自动修复模式**（用户指定 `--fix` 时）：
+```bash
+python3 tools/lint.py --wiki-dir wiki/ --fix --json
+```
+自动修复确定性问题（xref 反向链接补全、缺失字段填默认值），输出修复报告。
+
+**预览模式**（用户指定 `--fix --dry-run` 时）：
+```bash
+python3 tools/lint.py --wiki-dir wiki/ --fix --dry-run --json
+```
+预览会修复什么，不实际执行。
+
+解析 JSON 输出，获取所有自动检测到的 issues（及修复结果）。
+
+### Step 2: 结构完整性（自动化覆盖）
+
+自动化工具检查以下项目：
+
+1. **Broken wikilinks**：`[[slug]]` 目标文件不存在
+2. **Orphan pages**：无任何入链的页面
+3. **必填字段缺失**（按 `runtime/schema/entities.yaml` 中声明的每种 entity）。权威源：`runtime.loader.REQUIRED_FIELDS`。当前集合：
+   - papers: title, slug, tags, importance
+   - concepts: title, tags, maturity, key_papers
+   - topics: title, tags
+   - people: name
+   - methods: name, slug, type, tags
+   - Summary: title, scope, key_topics
+   - ideas: title, slug, status, origin, tags, priority
+   - experiments: title, slug, status, linked_idea, hypothesis, tags
+   - foundations: title, slug, domain, status
+
+### Step 3: 字段值验证（自动化覆盖）
+
+1. **Enum 值检查**（来源：`runtime.loader.VALID_VALUES`）：
+   - papers.importance ∈ {1,2,3,4,5}
+   - concepts.maturity ∈ {stable, active, emerging, deprecated}
+   - ideas.status ∈ {proposed, in_progress, tested, validated, failed}
+   - ideas.priority ∈ {1,2,3,4,5}
+   - experiments.status ∈ {planned, running, completed, abandoned}
+   - experiments.outcome ∈ {succeeded, failed, inconclusive}
+   - methods.type ∈ {architecture, training, inference, evaluation, data, benchmark, system, optimization, prompting, protocol, other}
+   - foundations.status ∈ {mainstream, historical}
+2. **Idea novelty_score**（若存在）∈ [1, 5]（整数）
+3. **Idea failure_reason**：status=failed 时必须非空（anti-repetition memory）
+4. **Experiment linked_idea**：引用的 idea 页面必须存在
+
+### Step 4: Cross Reference 对称性（自动化覆盖）
+
+检查 `runtime/schema/xref.yaml` 中定义的所有双向链接规则：
+
+| 正向链接 | 检查的反向链接 |
+|----------|---------------|
+| `papers ## Related → concepts` | `concepts.key_papers` 含 paper slug |
+| `papers wikilink → people` | `people ## Recent work` 含 paper slug |
+| `topics.key_people → people` | `people ## Research areas` 含 topic slug |
+| `concepts.key_papers → papers` | `papers ## Related` 含 concept slug |
+| `ideas.origin_gaps → concepts` | `concepts.linked_ideas` 含 idea slug |
+| `ideas.origin_gaps → topics` | `topics.linked_ideas` 含 idea slug |
+| `experiments.linked_idea → ideas` | `ideas.linked_experiments` 含 experiment slug |
+| `methods.source_papers → papers` | `papers ## Related` 含 method slug |
+| `methods.parent_methods ↔ methods.child_methods` | 互逆 |
+
+### Step 5: Graph Edge 一致性（自动化覆盖）
+
+1. **JSON 格式有效性**：每行都是合法 JSON
+2. **必填字段**：每条 edge 有 from, to, type
+3. **Edge type 合法性**：semantic edges 使用当前 endpoint-aware type set；旧 paper-paper / paper-concept 类型给出迁移 warning
+4. **Edge confidence**：`/ingest` 写出的 paper-paper 与 paper-concept semantic edges 使用 `confidence: high|medium|low`
+5. **Citation layer**：`graph/citations.jsonl` 使用 `type: cites`、合法 source/date、paper endpoints，且不写 confidence 字段
+6. **Dangling nodes**：from/to 引用的 wiki 页面必须存在
+
+### Step 6: 内容质量（LLM 辅助）
+
+自动化工具可检测的：
+1. importance=5 的论文无 concept 页引用
+2. maturity=stable 的 concept 只有 1 篇 key_paper
+3. topics 的 `## Open problems` 章节为空（同样标记空的 `### Known gaps` / `### Methodological gaps` 子章节）
+
+LLM 额外判断（需要阅读内容）：
+1. **Concept 近似重复检测**：扫描所有 concept 页面的 title + aliases，判断是否有语义相同/高度相似的概念对（如 "attention mechanism" 和 "self-attention"）。对疑似重复对输出合并建议。
+2. **Method 近似重复检测**：在 `wiki/methods/*.md` 上做相同检测，对比 `name` + `tags` + `## Mechanism` 摘要。
+3. 矛盾表述检测（不同页面对同一事实的描述不一致）
+4. SOTA 记录超过 6 个月未更新
+5. people 的 `## Recent work` 超过 6 个月未更新
+6. Idea novelty_score 与 `## Novelty argument` 强度不匹配（低分 + 论证扎实，或高分 + 论证薄弱）
+7. 高 priority idea 长期停留在 proposed 状态且无 `linked_experiments`
+
+### Step 7: 生成报告
+
+按优先级排序输出：
+
+```
+## Lint Report — YYYY-MM-DD
+
+**Summary**: N 🔴, M 🟡, K 🔵
+
+### 🔴 需立即修复
+1. [file] — {issue description}
+
+### 🟡 建议修复
+1. [file] — {issue description}
+
+### 🔵 可选优化
+1. [file] — {issue description}
+```
+
+分类标准：
+- **🔴 需立即修复**：broken links、missing required fields、invalid enum values、failed idea without failure_reason、invalid JSON in edges、novelty_score 越界
+- **🟡 建议修复**：xref asymmetry、dangling graph edges、broken `linked_idea` 引用、unknown edge types
+- **🔵 可选优化**：orphan pages、quality suggestions、empty sections
+
+记录日志：
+```bash
+python3 tools/research_wiki.py log wiki/ "check | report: N 🔴, M 🟡, K 🔵"
+```
+
+## Constraints
+
+- **默认只报告**：不带 `--fix` 时只报告不修复
+- **`--fix` 仅修复确定性问题**：xref 反向链接补全、缺失字段填安全默认值。不确定的问题输出建议（`--suggest`），由用户手动批准
+- **raw/ 只读**：不修改 `raw/` 下的文件
+- **graph/ 只读**：lint 不修改 graph 文件，仅检查一致性
+- **LLM 判断标注来源**：自动化检查和 LLM 判断在报告中明确区分
+- **幂等**：多次运行产生相同结果（除非 wiki 内容变化）
+
+## Error Handling
+
+- **wiki/ 不存在**：报错并建议运行 `/init`
+- **graph 文件不存在**：跳过缺失 graph 文件的检查，在报告中注明
+- **部分目录缺失**：跳过缺失目录的检查，在报告中列出缺失目录
+
+## Dependencies
+
+### Tools（via Bash）
+- `python3 tools/lint.py --wiki-dir wiki/ [--json] [--fix] [--dry-run] [--suggest]` — 自动化结构检查 + 修复（核心依赖）
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+- `python3 tools/research_wiki.py stats wiki/` — 获取统计信息（可选，用于报告）

--- a/.qoder/skills/daily-arxiv/SKILL.md
+++ b/.qoder/skills/daily-arxiv/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: daily-arxiv
+description: 运行或管理每日 arXiv 推荐 feed。用于手动获取新论文推荐、配置/检查/停用 GitHub Actions 定时任务、邮件 digest，以及显式高置信 auto-ingest。
+---
+
+# /daily-arxiv
+
+> **用法**：`[setup|status|disable] [--mode inform|auto-ingest] [--hours 24] [--categories <cat...>] [--max-recommendations 10] [--max-auto-ingest 1] [--send-email true|false]`
+
+
+> 运行或管理每日论文推荐 feed。裸 `/daily-arxiv` 表示“现在跑一次今天的推荐”；GitHub Actions 只是同一条 pipeline 的无人值守调度器。
+
+按需读取 reference：
+
+- `references/recommendation-and-ingest-policy.md` — evidence、LLM 决策 schema、置信度门控和 auto-ingest 约束
+- `references/automation-scaffold.md` — GitHub Actions setup/status、secrets、artifacts 与失败行为
+
+## Commands
+
+- `/daily-arxiv`：现在跑一次推荐。如果缺少 `config/daily-arxiv.yml`，从 wiki 推断默认值后继续。
+- `/daily-arxiv setup`：从 `config/daily-arxiv.yml.example` 创建或修复配置，检查 `.github/workflows/daily-arxiv.yml`，并说明需要的 secrets。
+- `/daily-arxiv status`：检查 config、workflow、schedule、mode、API/e-mail secrets 可用性，以及最近 artifacts。
+- `/daily-arxiv disable`：把 config 中的 `schedule.enabled` 设为 `false`，或告诉用户需要怎样修改；手动 `/daily-arxiv` 仍可使用。
+
+## Inputs
+
+- `--mode inform|auto-ingest`：默认 `inform`。不要从 repo 状态推断 `auto-ingest`。
+- `--hours N`：拉取最近 N 小时论文；config/default 为 24。
+- `--categories <cat...>`：覆盖配置中的 arXiv 分类。
+- `--max-recommendations N`：digest 中最多展示的论文数；config/default 为 10。
+- `--max-auto-ingest N`：高置信 auto-ingest 上限；config/default 为 1。
+- `--send-email true|false`：workflow/setup 用的 SMTP 发送偏好。
+
+## Setup Workflow
+
+由 `/daily-arxiv setup` 触发。幂等 —— 在健康的 repo 上重跑是 no-op。
+
+1. **Config**：如果缺少 `config/daily-arxiv.yml`，从 `config/daily-arxiv.yml.example` 拷贝。如果已存在，则保持不动（用户的偏好是持久的）。
+
+2. **Workflow 文件**：确认 `.github/workflows/daily-arxiv.yml` 存在。如果缺失，引导用户查阅 `docs/daily-arxiv-deployment.md` 并停止 —— 从零重建该 workflow 超出 setup 的范围。
+
+3. **Workflow env 暴露（自动补丁）**：在 `.github/workflows/daily-arxiv.yml` 中，定位 `daily-arxiv:` job 的 `env:` 块。用 Edit 工具确保下面两行作为 `HAS_CLAUDE_CODE_AUTH` 的同级存在：
+
+   ```yaml
+   SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
+   DEEPXIV_TOKEN:            ${{ secrets.DEEPXIV_TOKEN }}
+   ```
+
+   - 如果两行都已存在，什么都不做。
+   - 如果只缺一行，追加缺失的那一行。
+   - 如果 `env:` 块根本不存在（较旧的 workflow），在该 job 下插入它，包含这两行以及已有的 `HAS_CLAUDE_CODE_AUTH` / `HAS_REVIEW_LLM` 标志。不要改动任何其他 step。
+   - 任何补丁之后，告诉用户改了什么，并提醒他们 commit。
+
+4. **Secrets 检查**：列出用户已配置了哪些 —— `ANTHROPIC_API_KEY` 或 `CLAUDE_CODE_OAUTH_TOKEN`、`SEMANTIC_SCHOLAR_API_KEY`、`DEEPXIV_TOKEN`，以及可选的 SMTP secrets。可用时用 `gh secret list`；否则指导用户自己运行。对任何缺失但必需的 secret，给出他们需要的确切 `gh secret set` 命令。
+
+5. **Summary**：汇报创建了什么、打了什么补丁，以及用户还需要做什么（安装 GitHub App、设置缺失的 secrets、用一次 `gh workflow run daily-arxiv.yml` 验证）。
+
+## Run Workflow
+
+1. 解析 Python 解释器并准备 deterministic context：
+
+   ```bash
+   python3 tools/daily_arxiv.py prepare --wiki-root wiki --out .daily-arxiv/run/recommendation-context.json --out-feed .daily-arxiv/run/feed.json
+   ```
+
+2. 读取 `.daily-arxiv/run/recommendation-context.json`。基于 arXiv、wiki、Semantic Scholar、DeepXiv evidence，用 LLM 判断推荐质量。写出 `.daily-arxiv/run/llm-decisions.json`，字段包括 `decision`、`confidence`、`score`、`rationale`、`wiki_connections`、`signals_used`。在 CI 的 inform mode 中，可用 OpenAI-compatible review LLM 执行：
+
+   ```bash
+   python3 tools/daily_arxiv.py recommend-llm --context .daily-arxiv/run/recommendation-context.json --out .daily-arxiv/run/llm-decisions.json
+   ```
+
+3. 如果 mode 是 `auto-ingest`，只能使用 Qoder runtime：选择 `decision: ingest` 且 `confidence: high` 的论文，遵守 `max_auto_ingest`，并按顺序调用 `/ingest <arxiv-url>`。不要手写 wiki 或 graph 文件。第三方 LLM 只用于推荐，不能 auto-ingest。
+
+4. 生成 digest：
+
+   ```bash
+   python3 tools/daily_arxiv.py finalize --context .daily-arxiv/run/recommendation-context.json --decisions .daily-arxiv/run/llm-decisions.json --out-md .daily-arxiv/run/digest.md --out-json .daily-arxiv/run/digest.json
+   ```
+
+5. 汇报 strong recommendations、maybe interesting、重复跳过项、degraded signals、auto-ingest 结果，以及 setup/status 提示。
+
+## Wiki Interaction
+
+读取 `wiki/index.md`、`wiki/papers/`、`wiki/topics/`、`wiki/concepts/`、`wiki/methods/`、`wiki/ideas/`、`wiki/log.md` 来构建兴趣 profile 和去重。
+
+inform 运行只写 `.daily-arxiv/` 下的 scratch 文件。`auto-ingest` 中所有持久 wiki/raw 变更都必须来自 `/ingest`。
+
+## Relationships
+
+- `/discover` 回答用户主动提出的 next-read 请求，可来自 anchors、topic 或 wiki 状态；它永不 ingest。
+- `/daily-arxiv` 监听 fresh arXiv stream，可手动或每日通知。
+- `/ingest` 是唯一论文纳入路径。`/daily-arxiv` 只能在显式 `auto-ingest` mode 下调用它。

--- a/.qoder/skills/daily-arxiv/references/automation-scaffold.md
+++ b/.qoder/skills/daily-arxiv/references/automation-scaffold.md
@@ -1,0 +1,81 @@
+# Daily arXiv Automation
+
+GitHub Actions 是 `/daily-arxiv` 的无人值守调度器。它应运行与手动 slash
+skill 相同的 pipeline；它不定义这个功能的用户入口。
+
+## Source of Truth
+
+- `config/daily-arxiv.yml`：持久、非 secret 的用户偏好。
+- `tools/daily_arxiv.py`：确定性的 config、feed、evidence、digest helper。
+- `/daily-arxiv`：LLM 判断、setup/status UX，以及可选 `/ingest` 编排。
+- `.github/workflows/daily-arxiv.yml`：定时执行器。
+
+如果缺少 `config/daily-arxiv.yml`，手动运行继续使用推断默认值。
+`/daily-arxiv setup` 可复制 `config/daily-arxiv.yml.example`。
+
+## Workflow Behavior
+
+- 默认定时：`17 0 * * *` UTC。
+- 手动 dispatch 可覆盖 mode、hours、categories、caps 和 e-mail。
+- Inform mode 准备 context，然后使用第一个可用 recommender：
+  带 `ANTHROPIC_API_KEY` 或 `CLAUDE_CODE_OAUTH_TOKEN` 的 Qoder agent runtime；
+  否则使用 `LLM_API_KEY` / `LLM_BASE_URL` / `LLM_MODEL` 对应的
+  OpenAI-compatible LLM；否则输出 tool-ranked fallback digest。
+- Auto-ingest mode 缺少 Qoder agent runtime auth 时 fail closed。
+- Auto-ingest 只提交 `/ingest` 产生并 staged 的 `wiki/` 和
+  `raw/discovered/` 变更。
+
+## Secrets
+
+推荐/ingest：
+
+- `ANTHROPIC_API_KEY` — Qoder agent runtime 的直接 Anthropic API auth。
+- `CLAUDE_CODE_OAUTH_TOKEN` — Pro/Max 用户的 Qoder OAuth auth；在本地
+  通过 `claude setup-token` 生成。它是 `ANTHROPIC_API_KEY` 的替代方案。
+- `LLM_API_KEY`、`LLM_BASE_URL`、`LLM_MODEL` — 可选的 OpenAI-compatible
+  LLM，用于没有 Qoder 时的 `inform` 推荐。
+- `LLM_FALLBACK_MODEL` — 可选的 OpenAI-compatible LLM fallback。
+- `SEMANTIC_SCHOLAR_API_KEY` — 可选，提高 S2 rate limit。
+- `DEEPXIV_TOKEN` — 可选，启用 DeepXiv enrichment。
+
+SMTP 发送：
+
+- `SMTP_HOST`
+- `SMTP_PORT`
+- `SMTP_USER`
+- `SMTP_PASSWORD`
+- `SMTP_FROM`
+- `DAILY_ARXIV_EMAIL_TO`
+
+不要把 secrets 写进 `config/daily-arxiv.yml`。
+
+## Artifacts
+
+每次 workflow run 上传：
+
+- `resolved-config.json`
+- `feed.json`
+- `recommendation-context.json`
+- Claude 运行时的 `llm-decisions.json`
+- `digest.md`
+- `digest.json`
+
+Markdown digest 也会写入 GitHub Actions job summary。
+
+## Status Checks
+
+`/daily-arxiv status` 应检查：
+
+- config 是否存在，以及解析后的 mode/caps/categories
+- workflow 文件是否存在和 schedule
+- `schedule.enabled` 是否为 false
+- 本地 env vars 或可见 CI secrets 是否可用
+- 本地 `.daily-arxiv/` 中最近 digest（若存在）
+
+## Failure Behavior
+
+- arXiv fetch 失败：在 recommendation/finalization 前失败。
+- SMTP secrets 缺失：仅在 e-mail 启用时失败。
+- 空 feed 或全部重复：生成合法空 artifacts。
+- 外部 API 失败：继续运行，并保留 degraded notes。
+- Auto-ingest 失败：保留逐论文 error，并继续生成最终 digest。

--- a/.qoder/skills/daily-arxiv/references/recommendation-and-ingest-policy.md
+++ b/.qoder/skills/daily-arxiv/references/recommendation-and-ingest-policy.md
@@ -1,0 +1,75 @@
+# Daily arXiv Recommendation and Ingest Policy
+
+`/daily-arxiv` 是 LLM-first：确定性工具先构建 evidence packet，
+再由 skill 判断相关性和动作。工具分数只用于排序，不是最终决策。
+
+## Pipeline
+
+1. 解析 `config/daily-arxiv.yml`；缺失时使用推断默认值。
+2. 拉取最近 arXiv 论文，并按 wiki 已知 arXiv ID 去重。
+3. 从 papers、topics、concepts、methods、ideas、open questions、recent log
+   和可选 profile 偏好构建 wiki profile。
+4. 用可用的 Semantic Scholar 和 DeepXiv evidence 增强候选。
+5. 由 LLM 给出最终 decisions 和 rationales。
+6. 通过 digest 通知；只有显式允许时才调用 `/ingest`。
+
+## Evidence
+
+新增逻辑前先使用已有集成：
+
+- arXiv：title、authors、category、date、URL、abstract。
+- Wiki：anchors、topics、concepts、methods、ideas、open questions、recent ingests。
+- Semantic Scholar：paper metadata、citation counts、influential counts、
+  fields of study、TLDR，以及来自 wiki anchors 的 recommendations。
+- DeepXiv：trending rank、social impact、brief/TLDR、keywords，以及可用时的论文结构。
+
+如果 S2 或 DeepXiv 失败，保持运行，并把 degraded signal 写入 digest。
+缺失 enrichment 永远不能作为 ingest 依据。
+
+## Decision Schema
+
+LLM 为每个候选写一条 decision：
+
+```json
+{
+  "arxiv_id": "2501.01234",
+  "decision": "strong_recommend",
+  "confidence": "high",
+  "score": 0.82,
+  "rationale": "Connects to the wiki's open question about ...",
+  "wiki_connections": ["efficient adaptation", "retrieval"],
+  "signals_used": ["arxiv", "wiki_profile", "semantic_scholar", "deepxiv"]
+}
+```
+
+允许的 decisions 是 `strong_recommend`、`maybe`、`skip`、`ingest`。
+允许的 confidence 是 `high`、`medium`、`low`。
+
+OpenAI-compatible 第三方 LLM 只支持 `inform` mode，通过
+`tools/daily_arxiv.py recommend-llm` 使用。在这条路径中，`ingest` 不是
+允许输出；如果模型尝试输出 `ingest`，会降级为 `strong_recommend`。
+
+## Modes
+
+- `inform`：默认。生成 digest，按配置发送邮件，然后停止。
+- `auto-ingest`：显式 opt-in。只有 `decision: ingest` 且
+  `confidence: high` 的论文可继续，并且受 `max_auto_ingest` 限制。
+
+不要从 repository 状态、branch、已有 workflow 或 credentials 推断
+`auto-ingest`。必须由用户/config/workflow input 显式选择。
+
+## Auto-Ingest Guardrails
+
+- `/ingest` 负责所有论文纳入。`/daily-arxiv` 不得手写 paper pages、
+  concepts、methods、people、graph files 或 index entries。
+- 顺序调用 `/ingest`；parallel ingest 不在 scope 内。
+- 通过 `ingest_status` 或 `ingest_error` 在 `llm-decisions.json` 和最终
+  digest 中保留失败信息。
+- 只提交 `/ingest` 产生的变更，通常位于 `wiki/` 和 `raw/discovered/`。
+- 边界候选保留为 `maybe`；不要 ingest medium/low confidence 项。
+
+## Relationship to `/discover`
+
+`/discover` 回答用户主动提出的 “what should I read next?”，来源可以是
+anchors、topic 或 wiki 状态，并且永不 ingest。`/daily-arxiv` 从一个新的
+arXiv 时间窗口出发，可通知，也可在显式配置下 ingest。

--- a/.qoder/skills/discover/SKILL.md
+++ b/.qoder/skills/discover/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: discover
+description: 基于 anchor 论文、topic 关键词或当前 wiki 状态，产出一份排好序的候选论文 shortlist，供用户或上游 skill 决定是否进一步 `/ingest`。当用户问 "接下来该读什么"、"找和这篇相似的论文"、"推荐相关工作"、"这个方向周围有什么" 时触发；`/ingest --discover` 也会内部调用本 skill。本身不 ingest，只提出候选。
+---
+
+# /discover
+
+> **用法**：`(--anchor <id> [--anchor <id>] [--negative <id>] | --topic <str> | --from-wiki | --venue <slug> --year <int>) [--limit N]`
+
+
+> 从四种 seed 模式之一产出一份排好序的候选论文 shortlist，附带每条候选的 rationale，呈现给用户或调用方 skill。`/discover` 绝不自动 ingest —— 它只负责提出候选，实际动作由 `/ingest` 负责。
+
+按需打开下列本地参考文件：
+
+- `references/seed-modes.md` —— 如何把用户的措辞映射到 anchor / topic / wiki / venue 模式，以及四者的选择规则
+- `references/ranking-signals.md` —— `tools/discover.py` 的打分依据，以及为什么 discovery 不共享 `/init` 的 survey 偏好
+- `references/wiki-dedup.md` —— 候选如何被过滤掉已 ingest 的论文，以及 dedup 边界
+
+## Inputs
+
+- `--anchor <id>`（可重复）：一或多个 anchor 论文 ID（优先 arXiv ID，也接受 S2 paperId）。驱动 **anchor 模式** —— 主要使用场景，包括 `/ingest` 后的 "接下来该读什么"。
+- `--negative <id>`（可重复，可选）：希望推开的论文 ID。只在配合 `--anchor` 时有意义。
+- `--topic "<str>"`：topic / query 字符串。驱动 **topic 模式** —— 相对 `/init` planner 更轻量的替代。
+- `--from-wiki`：自动从 wiki 最近修改过的论文页派生 seed。驱动 **wiki 模式**。
+- `--venue <slug>` + `--year <int>`：会议/venue 缩写与年份（如 `neurips` `2024`）。驱动 **venue 模式** —— 从该 venue/year 的论文列表中按与现有 wiki 的相关性排序。
+- `--limit N`（可选，默认 10）：shortlist 最大长度。
+
+`--anchor`、`--topic`、`--from-wiki`、`--venue` 四者必须恰好选一。
+
+## Outputs
+
+- `.checkpoints/discover-{seed-slug}-{YYYY-MM-DD}.json` —— 完整 shortlist payload，机器可读；seed slug 基于首个 anchor 或 topic 派生
+- 给用户的 markdown 摘要，包含每条候选的 rationale
+- `wiki/log.md` —— 仅 anchor/topic/wiki 运行通过 `tools/research_wiki.py log` 追加一行
+
+`/discover` 除了 `log.md` 外不向 `wiki/` 写入任何内容，也不触碰 `raw/`。`from-venue` 更严格：它完全不写 `wiki/`，包括 `wiki/log.md`。是否把候选拉进 wiki 是调用方的决定（之后的 `/ingest`）。
+
+## Wiki Interaction
+
+### Reads
+
+- `wiki/papers/*.md` —— frontmatter 中的 `arxiv`（或旧版 `arxiv_id`），用于与已 ingest 的论文做 dedup
+- `wiki/papers/*.md` 修改时间 —— 用于 `--from-wiki` 模式下 anchor 选取
+- `wiki/papers/*.md`、`wiki/concepts/*.md`、`wiki/topics/*.md` —— 标题与正文，用于 venue 模式的相关性打分
+
+### Writes
+
+- anchor/topic/wiki 运行：`wiki/log.md` —— 通过 `tools/research_wiki.py log` APPEND
+- venue 运行：无
+
+### Graph edges created
+
+- 无。图变更属于 `/ingest`，不属于 `/discover`。
+
+## Workflow
+
+**前置条件**：工作目录包含 `wiki/`、`raw/`、`tools/`。一次解析 Python 解释器路径并复用：
+
+```bash
+if [ -x .venv/bin/python ]; then
+  PYTHON_BIN=.venv/bin/python
+elif [ -x .venv/Scripts/python.exe ]; then
+  PYTHON_BIN=.venv/Scripts/python.exe
+else
+  PYTHON_BIN=python3
+fi
+export PYTHON_BIN
+```
+
+### Step 1: 选定 seed 模式
+
+把用户请求映射到 `from-anchors`、`from-topic`、`from-wiki` 或 `from-venue` 之一。决策规则见 `references/seed-modes.md`，简版：
+
+- 用户指明了一或多篇具体论文，或者这是 `/ingest --discover` 的后续 → **anchors**
+- 用户给的是 topic / 方向 / 关键词 → **topic**
+- 用户问开放式 "接下来读什么"，没有 anchor 也没有 topic → **wiki**
+- 用户要求某个具体会议和年份的论文 → **venue**
+
+如果用户同时提到 "不要这些"，在 anchor 模式下通过 `--negative` 传入。
+
+### Step 2: 运行 discovery 工具
+
+```bash
+"$PYTHON_BIN" tools/discover.py from-anchors \
+  --id <arxiv-id> [--id <arxiv-id>...] [--negative <id>...] \
+  --wiki-root wiki \
+  --limit 10 \
+  --output-checkpoint .checkpoints/ \
+  --markdown
+```
+
+venue 模式下必须传 `--wiki-root`，以便工具根据现有内容计算相关性。若 wiki 过于稀疏，工具会明确报错而不是返回未个性化的列表。
+
+或 topic / wiki 模式：
+
+```bash
+"$PYTHON_BIN" tools/discover.py from-topic "<query>" --wiki-root wiki --limit 10 --output-checkpoint .checkpoints/ --markdown
+"$PYTHON_BIN" tools/discover.py from-wiki --wiki-root wiki --limit 10 --output-checkpoint .checkpoints/ --markdown
+```
+
+anchor（与 wiki）模式每个 anchor 默认跑三个 S2 通道 —— `recommend` + `references` + `citations`。这正是 `/discover` 明显区别于 `/daily-arxiv` 的关键：references 带进 anchor 站在其肩膀上的 canonical 老论文，citations 带进高影响后续工作。只有在 API 成本成为硬约束时才考虑 `--no-citation-expand` 退回到只跑 recommend —— 质量退化会很明显。
+
+工具内部处理候选抓取、wiki dedup、ranking，并写 checkpoint。始终传 `--wiki-root wiki`，否则已 ingest 论文会继续出现在 shortlist 中，浪费用户 review 时间。
+
+topic 模式下若 S2 不可用，工具会继续用可用的通道产出；检查输出并向用户说明 degraded discovery。若全部通道失败，需明确报错而不是把空 shortlist 当作真实推荐返回。
+
+### Step 3: 展示 shortlist
+
+把 markdown 输出呈现给用户。每条候选要能让用户判断是否值得 ingest：
+
+- 标题和 arXiv ID（或 S2 paperId fallback）
+- 一行 rationale（工具已产出：anchor 命中数、influential citations、年份）
+- 工具带出 TLDR 时一并展示（topic 模式常有；anchor 模式通常没有 —— recommendations endpoint 不返回 TLDR）
+
+最后附一行 "next step" 提示：
+
+```
+如需 ingest：/ingest https://arxiv.org/abs/<arxiv-id>
+```
+
+不要自行 ingest。选择权归用户。
+
+### Step 4: 日志
+
+```bash
+"$PYTHON_BIN" tools/research_wiki.py log wiki "discover | mode=<anchors|topic|wiki> | seed=<short-desc> | shortlist=<N>"
+```
+
+`from-venue` 跳过这一步；venue discovery 不能写 `wiki/` 或 `raw/`。
+
+## Internal Callers
+
+`/discover` 既供用户手动调用，也供其他 skill 作为子例程调用。
+
+### 来自 `/ingest --discover`
+
+`/ingest` 支持可选的 `--discover` flag（默认关闭）。开启时，`/ingest` 在最终 report 之后以刚 ingest 论文的 arXiv ID 作为单 anchor 调用 `/discover`，并把 shortlist 以 "接下来可能想 ingest 的相关论文" 段落附在 report 里。`/ingest` 不会从这份列表自动 ingest 任何东西。
+
+### 来自 `/init`
+
+`/init` **不调用** `/discover`。`/init` 的 planner（`tools/init_discovery.py plan`）有自己的打分策略，偏爱 survey、广覆盖、seed anchor —— 适合 bootstrap 场景。`/discover` 的 ranking 有意不同（不偏 survey；以 anchor 相似度 + influential citations 为主），替换进 `/init` 会稀释 shortlist 质量。两者保持独立。
+
+## Constraints
+
+- **不自动 ingest**：`/discover` 产出 shortlist 就结束。即便被 `/ingest --discover` 调用，调用方也只是呈现结果，最终 ingest 由用户决定。
+- **不向 `wiki/` 写内容**：paper 页、concept、method、graph edge 全都属于 `/ingest`。anchor/topic/wiki 运行可以追加 `wiki/log.md`；`from-venue` 完全不能写 `wiki/`。
+- **不写 `raw/`**：`/discover` 不下载论文。用户选定某个候选后，再手动 `/ingest <arxiv-url>`。
+- **始终对 wiki 做 dedup**：必须传 `--wiki-root wiki`，否则已 ingest 论文会污染 shortlist，这是最常见的低质量失败模式。
+- **ranking 是 discovery 专属**：不要复用或复制 `tools/init_discovery.py` 的打分函数。两者目标不同 —— `/init` 要宽覆盖与基础面；`/discover` 要相关的 *next reads*。见 `references/ranking-signals.md`。
+- **三通道 anchor 抓取**：anchor 模式默认对每个 anchor 同时跑 S2 `recommend` + `references` + `citations`。砍掉 citation 通道（`--no-citation-expand`）会让结果退化为偏最新的语义聚类，和 `/daily-arxiv` 严重重合。除非 API 成本成为硬约束，否则保留三个通道。见 `references/ranking-signals.md`。
+- **部分 S2 endpoint 字段较扁平**：`/citations`、`/references`、`/recommendations/*` 拒绝嵌套 selector —— 没有 `authors.hIndex`，没有 `tldr`。`/paper/{id}` 和 `/paper/search` 接受，所以 topic 模式的候选带完整 enrichment；anchor 模式下只从 citations/references/recommend 进来的候选没有。这是 S2 的真实约束，不是 bug。
+- **rate limit**：anchor 模式每个 anchor 最多三次 S2 调用（recommend + references + citations）。默认 recs 每 anchor 拉 50 条、references/citations 各 30 条。多 anchor 时调用量成倍增长；有 API key（1 req/sec）时三 anchor 约 10 秒。
+
+## Error Handling
+
+- **所有 seed 通道都失败**：明确报错、不写 shortlist，也不记录成功日志。
+- **S2 不可用但 DeepXiv 可用（topic 模式）**：仅用 DeepXiv 继续；在 report 中注明 degraded。
+- **S2 对某个 anchor 返回零推荐**：保留其他 anchor 的结果继续；若所有 anchor 都返回零，视为整体失败。
+- **`--from-wiki` 找不到可用 anchor**（`wiki/papers/` 为空或全部缺少 `arxiv_id`）：告诉用户 wiki 过于稀疏，建议改用 topic 模式（或跑 `/init`）。
+- **`from-venue` wiki 过于稀疏**（从 wiki 提取到的有效词太少）：明确报错，建议先 ingest 一些论文或改用 topic 模式。venue 模式依赖现有 wiki 内容计算相关性，没有内容时排名将失去意义。
+- **anchor ID 非法或未知**：S2 会返回 404；在 report 中暴露该坏 ID，并用剩余 anchor 继续。
+
+## Dependencies
+
+### Tools（via Bash）
+
+- `"$PYTHON_BIN" tools/discover.py from-anchors --id <id> [--id <id>...] [--negative <id>...] --wiki-root wiki --limit <N> --output-checkpoint .checkpoints/ --markdown`
+- `"$PYTHON_BIN" tools/discover.py from-topic "<query>" --wiki-root wiki --limit <N> --output-checkpoint .checkpoints/ --markdown`
+- `"$PYTHON_BIN" tools/discover.py from-wiki --wiki-root wiki --limit <N> --output-checkpoint .checkpoints/ --markdown`
+- `"$PYTHON_BIN" tools/discover.py from-venue --venue <slug> --year <int> --wiki-root wiki --limit <N> --output-checkpoint .checkpoints/ --markdown`
+- `"$PYTHON_BIN" tools/research_wiki.py log wiki "<message>"`
+
+### Skills
+
+- `/ingest` —— 通过 `--discover` flag 调用；也是用户对选中候选执行的动作
+- `/init` —— 独立 planner，不调用 `/discover`
+
+### External APIs
+
+- Semantic Scholar —— recommendations (`/recommendations/v1/papers/forpaper/{id}`, `POST /recommendations/v1/papers/`)、search、paper detail（通过 `tools/fetch_s2.py`）
+- DeepXiv —— topic 模式下的 search 辅助通道（通过 `tools/fetch_deepxiv.py`，可选，失败时优雅降级）
+- Paper Copilot —— 公开 GitHub raw JSON（`papercopilot/paperlists`），用于 venue/year 论文列表。不使用 live-site 抓取，也不把数据集 vendor 进仓库。Venue normalization 应保留来源中已有的 title、abstract、TLDR、keywords / primary area / topic、track、status、citations、ratings、reviews 与论文 URL 等相关性字段。

--- a/.qoder/skills/discover/references/ranking-signals.md
+++ b/.qoder/skills/discover/references/ranking-signals.md
@@ -1,0 +1,68 @@
+# /discover ranking 信号
+
+确定性 ranking 住在 `tools/discover.py`，本文件记录它权衡什么、以及**为什么与 `/init` 不同**，防止后续修改不小心把二者收敛到一起。
+
+## Anchor 模式的三个候选通道
+
+anchor 模式每个 anchor 默认从 **三个** S2 通道抓取，因为任何单通道都有其特征偏差：
+
+- **`recommend`**（S2 语义推荐端点）—— 返回语义相似论文，但端点明显偏向最新工作。单用它会退化成 "这个 topic 附近的最新论文"，与 `/daily-arxiv` 严重重合。
+- **`references`**（anchor 引用的论文）—— 暴露 anchor 站在其肩膀上的**老 canonical 工作**，是文献综述通道。
+- **`citations`**（引用 anchor 的论文）—— 暴露在 anchor 之上的**高影响后续工作**。
+
+三者合起来才是一次真正的文献图游走：语义邻居 + 祖先 + 后代。去掉任何一个通道都是明显的质量倒退。只有在 API 成本确实是约束时（例如 anchor 太多而 recommend 已经够用），才通过 `--no-citation-expand` 砍掉 references+citations 通道。
+
+## discovery 的打分依据
+
+Anchor 模式（按大致权重排序）：
+
+1. **聚合 influential citation count** —— 对数缩放，反映候选在整个领域的声望。权重高于原始 `citationCount`。
+2. **Anchor-influence edge** —— S2 的 per-edge `isInfluential` 标记，从 `references`/`citations` envelope 抽到候选上作为 `is_influential_edge`。为 True 时，意味着 S2 的引用分析模型判断：anchor 实质性地构建在这个候选之上（references 通道）或这个候选实质性地构建在 anchor 之上（citations 通道）。比聚合计数尖锐得多：它告诉你 "这一篇对 anchor 具体有意义"，而不是 "这一篇对领域有意义"。S2 的这个标记比较严格，大多数情况为 False；但一旦为 True，就应该起主导作用。
+3. **Anchor overlap** —— 候选被几个 anchor 同时命中。两个 anchor 都指向同一篇论文，说明它正在它们的交集上。
+4. **Channel diversity** —— 同一候选出现在多个通道（如同时出现在 `recommend` 与 `references`）时给 bonus。三通道全中的候选罕见，通常是 anchor 邻域里的核心论文。
+5. **Freshness** —— 对较新的年份给轻微 bonus。新 ≠ 更好，曲线较平（1.0 / 0.85 / 0.6 / 0.4 / 0.25，按年龄分桶）。
+6. **Author h-index**（作者最大值）—— 有上限的 tiebreaker。list endpoint 不返回 `authors.hIndex`，因此这个信号主要在 topic 模式下通过 `/paper/{id}` 单点 API 才会点亮。
+
+Topic / wiki 模式：相同信号，去掉 anchor overlap 与 anchor-influence edge（topic 模式没有 anchor；wiki 模式的派生 anchor 仍有 edge 信号）。influence 与 freshness 权重相应抬高以补偿。
+
+Venue 模式：
+
+1. **Wiki relevance** —— 主信号。`tools/discover.py` 会从 `wiki/papers/`、`wiki/concepts/`、`wiki/topics/` 建一个小型 BM25 风格的本地 corpus，其中页面标题和 frontmatter 权重大于正文。候选的标题、摘要、keywords、TLDR 和 track name 会与这个 corpus 打分。若 wiki 过于稀疏，或 venue 候选完全无法命中 corpus，工具会失败，而不是假装给出个性化 ranking。
+2. **Citation count** —— Paper Copilot 可用的引用字段，做对数缩放，作为次级信号。
+3. **Freshness** —— 轻量 tie-breaker；venue 运行通常固定一个年份，所以它一般影响不大。
+4. **Paper Copilot rating / review metadata** —— 存在时仅作次级 tie-breaker。
+5. **Paper Copilot status / decision** —— 小权重 tie-breaker；wiki 相关性接近时，accepted / oral / spotlight 记录会排在 rejected 或 withdrawn 记录前面。
+
+Venue 模式使用 Paper Copilot 的公开 GitHub JSON 数据（`papercopilot/paperlists`）作为 venue/year 论文列表来源，不抓取 live website，也不把完整数据集 vendor 进仓库。
+
+Paper Copilot normalization 不能丢掉来源中明确存在、会影响相关性判断的字段。应尽量把 title、abstract、TLDR、keywords / primary area / topic、track、status、citations、ratings、review metadata，以及论文 URL（`url`、`site`、`openreview`、`pdf`，有 project/GitHub 链接时也保留）写入 shortlist payload。这些字段要么直接参与打分，要么作为次级证据展示给用户。
+
+### 为什么同时使用聚合 influence 和 per-edge influence？
+
+它们回答不同问题：
+
+- `influentialCitationCount` = "领域里的论文有没有实质性地引用这篇？" —— 一般重要性的代理
+- anchor edge 上的 `isInfluential` = "**这个 anchor** 是不是实质性地构建在这篇之上 / 被这篇实质性地构建？" —— anchor-specific 相关性的代理
+
+一篇论文可能一个高一个低。例如：一个著名 benchmark 论文聚合计数很高（谁都在引用它）但很少在 method paper 的 anchor 边上标为 True（benchmark 是被使用，不是被构建之上）。我们的 ranking 同时用两者 —— 这样 benchmark 在没有更好信号时仍会浮上来，但 anchor 真正构建之上的论文会压过它们。
+
+## discovery **不**打分的东西
+
+这里是 `/discover` 有意与 `/init` planner（`tools/init_discovery.py`）分道扬镳之处：
+
+- **不偏 survey**。`/init` 偏爱 survey/review 论文，因为空白 wiki 需要它们做 anchor 覆盖。`/discover` 被调用时用户通常已熟悉领域（anchor 模式）或在探索中（topic 模式），很少还需要再一篇 survey；把 survey 抬到新工作之前只会制造噪音。
+- **不给 "older canonical anchor" 加 bonus**。`/init` bootstrap 模式会抬升一篇老的高被引论文以拓宽覆盖面。`/discover` 的用户通常想要前瞻性的推荐，而不是再做一次基础面 anchor。
+- **不读 notes/web priority terms**。`/init` 会读 `raw/notes/` 与 `raw/web/` 抽取用户意图。`/discover` 不读 —— 它的输入是显式的（anchor、topic 或 wiki 状态）。
+
+如果将来出现一个看起来 `/init` 和 `/discover` 可以共享的 ranking 信号，**优先保持两份实现**，而不是抽出共享 scorer。目标确实不同，共享 scorer 会迫使其中一方妥协。
+
+## S2 endpoint 的字段限制
+
+`tools/fetch_s2.py` 使用两套字段集：
+
+- `FIELDS` —— 完整 rich 字段集。`/paper/{id}` **和** `/paper/search` 都接受。包含 `authors.hIndex`、`tldr`，以及我们用到的所有嵌套 selector。
+- `FLAT_FIELDS` —— 扁平 authors，无 `tldr`，无嵌套 selector。仅以下三个 endpoint 必须用：`/paper/{id}/citations`、`/paper/{id}/references`、`/recommendations/*`。这三个端点在收到嵌套 selector 或 `tldr` 时会返回 400 Bad Request。
+
+不要把两套字段集合回一套 —— 上述三个端点确实会拒绝嵌套形式，已用线上探测确认。
+
+实际影响（anchor 模式）：只从 `references` / `citations` / `recommend` 通道进来的候选，rationale 里不带 `hIndex` 与 `tldr`。topic 模式的候选（通过 `/paper/search`）两者都带。理论上对每个候选再 `fetch_s2.paper(arxiv_id)` 一次可以补齐缺的，但 discovery 工具有意不做 —— 这会把每次运行的成本乘以 (shortlist_size × latency)，只为了让 rationale 看起来更丰富一点。用户选中某个候选去 `/ingest` 时再 enrich 就够了。

--- a/.qoder/skills/discover/references/seed-modes.md
+++ b/.qoder/skills/discover/references/seed-modes.md
@@ -1,0 +1,66 @@
+# /discover seed 模式
+
+每次调用只选一个模式。决策依据是用户（或调用方 skill）实际说了什么，而不是 wiki 里已有什么。
+
+## Anchor 模式（`from-anchors`）
+
+使用场景：用户指明了一或多篇具体论文，或者这是 `/ingest --discover` 的后续。
+
+触发信号：
+
+- "找和 LoRA 相似的论文"
+- "这篇刚 ingest 的，周围还有什么"
+- 请求里出现了 arXiv URL / ID / wiki paper slug
+- `/ingest --discover` 的内部调用（anchor = 刚 ingest 论文的 arXiv ID）
+
+anchor 模式是最强信号通道 —— Semantic Scholar 的 recommendations endpoint 基于训练模型返回语义相似论文，比在用户手握具体参考点时做关键词搜索更有效。
+
+如果用户给了负例（"不要这些"、"和 X 不一样的"），通过 `--negative` 传入。S2 recommendations endpoint 会把结果分布推离负 anchor，当用户想跳出自己已熟悉的子领域时非常有用。
+
+## Topic 模式（`from-topic`）
+
+使用场景：用户给的是 topic / 方向 / 关键词，没有指明具体论文。
+
+触发信号：
+
+- "找 diffusion model fine-tuning 方向的论文"
+- "retrieval augmented generation 这块都写了些什么"
+- 只有领域短语，没有 anchor
+
+topic 模式跑 S2 search 加（如可用的）DeepXiv search，再排序。它是 `/init` planner 的轻量替代：适合探索，但**不**替代 `/init` 的完整 bootstrap workflow。用户想用一个 topic 从头建 wiki，应该引导到 `/init`，而不是让 `/discover` 承担那个职责。
+
+## Wiki 模式（`from-wiki`）
+
+使用场景：用户开放式地问 "接下来读什么"，没有 anchor 也没有 topic。
+
+触发信号：
+
+- "给我下一批要读的论文"
+- "当前 wiki 的一个好后续是什么"
+- 显式 `--from-wiki` flag
+
+wiki 模式取 wiki 最近修改过的几篇论文页，提取 arXiv ID 作为 anchor。这会隐式把 discovery 偏向用户最近在做的东西 —— 通常正是期望行为。
+
+如果 `wiki/papers/` 为空，或没有论文带 `arxiv` 或 `arxiv_id` frontmatter，wiki 模式无法运行。告诉用户 wiki 过于稀疏，建议改用 topic 模式（或 `/init`）。
+
+## Venue 模式（`from-venue`）
+
+使用场景：用户要求查看某个具体会议/venue 和年份的论文。
+
+触发信号：
+
+- "给我看看 NeurIPS 2024 里和我 wiki 相关的论文"
+- "ICML 2023 里有哪些关于 diffusion model 的论文"
+- "ICLR 2024 有什么值得读的"
+
+Venue 模式从 Paper Copilot 的公开 GitHub JSON 源（`papercopilot/paperlists`）拉取该 venue/year 的完整论文列表，规范化每条记录，并按与用户现有 wiki 内容的相关性排序。该模式要求 wiki 不能过于稀疏 —— 若 wiki 太空，工具会明确报错而不是返回一份未个性化的列表。
+
+Venue 模式**不**使用 Semantic Scholar 或 DeepXiv，也**不**向 `wiki/` 或 `raw/` 写入。
+
+## 用户同时给了 anchor 和 topic 怎么办？
+
+优先 anchor 模式。anchor 是比 topic 字符串强得多的信号。可以在给用户的 report 里提一下 topic 已被注意，但 discovery 本身走 `from-anchors`。
+
+## 用户同时给了 venue 和 topic 怎么办？
+
+若用户明确指名了 venue 和年份，优先 venue 模式。可以在报告中提及 topic，但 venue 模式的排名由 wiki 相关性驱动，而非 topic 字符串。若 wiki 过于稀疏导致 venue 模式无法运行，应明确报错并建议先 ingest 更多论文，或另行运行 topic discovery；不要静默回退到未个性化的 venue ranking。

--- a/.qoder/skills/discover/references/wiki-dedup.md
+++ b/.qoder/skills/discover/references/wiki-dedup.md
@@ -1,0 +1,30 @@
+# /discover wiki dedup
+
+传入 `--wiki-root wiki` 时，`tools/discover.py` 会对已存在于 wiki 的论文做 dedup。本文说明这一层能抓到什么、抓不到什么，方便 user-facing report 准确反映情况。
+
+## 能抓到的情况
+
+对每条候选，`tools/discover.py` 从候选记录里抽出 `arxiv_id`（S2 的 `externalIds.ArXiv`、DeepXiv 的 `arxiv_id`、Paper Copilot 的 arXiv 字段/URL 等），然后检查是否存在某个 `wiki/papers/*.md` 页面 frontmatter 中 `arxiv`（或旧版 `arxiv_id`）与之匹配。命中的候选在打分前被剔除，实际剔除的候选数量以 `wiki_dedup_count` 字段汇报。
+
+这覆盖典型场景：某篇已 ingest 的论文又被当推荐冒上来。把它继续展示给用户是浪费 review 时间，剔掉是对的。
+
+venue 模式还会把候选标题规范化后，与 `wiki/papers/*.md` 的标题做精确 key 匹配。Paper Copilot 记录常常缺少 arXiv ID，因此标题 fallback 是这个来源上实用的 dedup 层。这类按标题 fallback 剔除的候选也计入 `wiki_dedup_count`。
+
+## 抓不到的情况
+
+- **venue 之外的仅标题匹配**：wiki 里一篇没有 `arxiv` 或 `arxiv_id` 的论文（如通过 `/edit` ingest 的期刊文章）不会与 anchor/topic/wiki 候选按标题匹配。这是有意为之 —— 宽松模糊标题匹配会引入假阳，反而遮蔽合法候选。
+- **宽松模糊标题**：venue 标题 fallback 使用规范化后的精确 title key，不做语义/模糊标题匹配。
+- **候选集内部的跨源重复**：wiki 过滤前的 dedup pass 使用 `_candidate_key`（arxiv → S2 paperId → title-slug 顺序），能抓住 S2 与 DeepXiv 之间的大多数跨源重复。完全缺失 ID 与 title 的记录会被静默丢弃。
+
+## 遇到 "高 dedup" 如何处理
+
+若 `wiki_dedup_count` 相对 `candidates_total` 偏高（例如 50 里有 30），说明这个 anchor / topic 附近 wiki 已经覆盖得差不多了。两种解读：
+
+1. 用户是在找广度，应该换个 seed（另一个 anchor、更宽的 topic，或用 `--from-wiki` 去探索邻近论文）。
+2. 推荐通道本身已经饱和 —— 这个邻域确实没什么可新增的。
+
+skill 应该在给用户的 report 里提及高 dedup，不要隐藏。
+
+## dedup 不做的事
+
+`/discover` 从不为了 "修" 某个 duplicate 而修改 wiki。如果候选的 metadata 看起来比 wiki 现有版本更丰富，那属于 `/edit` 或 `/check` 的职责，不属于 `/discover`。

--- a/.qoder/skills/edit/SKILL.md
+++ b/.qoder/skills/edit/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: edit
+description: 根据用户要求增删 raw sources 或更新 wiki 内容
+---
+
+# /edit
+
+> **用法**：`[request]`
+
+
+> 根据用户要求增删 raw sources 或更新 wiki 内容。
+
+## 触发
+
+用户手动：`/edit <用户要求>`
+
+## 输入
+
+用户请求，例如：
+- "把这篇论文下载到 raw/papers/"
+- "删除 raw/papers/xxx.pdf"
+- "更新 topics/efficient-llm-adaptation 的 SOTA tracker"
+- "给 concepts/lora 加一个新变体"
+
+## 输出
+
+更新后的 wiki 文件、`index.md`、`log.md`
+
+## 步骤
+
+### STEP 1: 解析用户意图
+
+1. **增加 raw sources**：
+   - 若用户提供了本地路径：复制到 `raw/` 对应目录
+   - 若用户提供了 arXiv URL：下载到 `raw/papers/`
+   - 若用户提供了网页 URL：用 markdownify 抓取内容存到 `raw/web/`
+2. **删除 raw sources**：
+   - 确认后执行删除
+3. **更新 wiki**：
+   - 读取相关页面，按用户要求修改内容
+
+### STEP 2: 执行更新
+
+1. 增加的 raw sources 后续可通过 `/ingest` 纳入 wiki
+2. 直接 wiki 修改：按用户指令更新特定页面的特定字段/内容
+3. 写正向链接时同步写反向链接
+
+### STEP 3: 更新导航
+
+1. `EDIT wiki/index.md`：更新相关条目
+2. `APPEND wiki/log.md`：`## [{date}] update | {description}`
+
+### STEP 4: 报告
+
+- 列出变更内容
+- 提示后续操作（如需要 ingest 新增的 raw sources）
+
+## 约束
+
+- `raw/` 只读（本 skill 可以往 `raw/` 添加文件，但不修改已有文件）
+- wiki 修改遵循模板结构
+- 双向链接同步维护

--- a/.qoder/skills/exp-design/SKILL.md
+++ b/.qoder/skills/exp-design/SKILL.md
@@ -1,0 +1,512 @@
+---
+name: exp-design
+description: 基于idea的实验设计（含迭代消融） — 方法候选生成（直接实现/混合融合/跨idea结合） → 基准选择 → 迭代消融（非线性：消融可触发方法简化与重新规划）→ 敏感度分析 → 主实验 → 可选泛化实验 → 中间量深度分析。在预实验评估后为idea设计完整实验套件时使用。
+---
+
+# /exp-design
+
+> **用法**：`<idea-slug>`
+
+
+> 为idea设计完整、非线性的实验套件。
+> 本skill支持方法候选生成、带方法简化的迭代消融、敏感度分析和中间量深度分析。
+> 消融循环是非线性的核心：消融结果将各因子分类为必要/贡献/边际/有害，边际/有害因子触发方法简化和重新规划（上限2次迭代）。
+
+## Inputs
+
+- `idea-slug`：要为其设计实验的idea（从 `wiki/ideas/{slug}.md` 读取）
+
+## Outputs
+
+- 实验wiki页面：`wiki/experiments/{exp-slug}.md` — 每个实验块一个页面（ablation、sensitivity、main、generalization、analysis），每个页面 `status: planned`，`linked_idea` 已设置
+- 主设计文档：`experiments/designs/{slug}-master.md` — 各实验块的详细spec
+- `wiki/graph/edges.jsonl` — 新的 `tested_by` 边：idea → 每个experiment
+- `wiki/ideas/{slug}.md` — 更新的 `linked_experiments` 字段
+- `wiki/graph/context_brief.md` — 重建
+- `wiki/graph/open_questions.md` — 重建
+- `wiki/log.md` — 追加日志条目
+- **DESIGN_REPORT**（输出到终端） — 实验套件摘要、运行顺序、计算预算
+
+## Wiki Interaction
+
+### Reads
+- `wiki/ideas/{slug}.md` — idea的假设、方法、风险、新颖性论点
+- `wiki/ideas/*.md` — 其他idea（用于候选C跨idea结合，筛选已验证/通过预实验的idea）
+- `experiments/pilot/{slug}/report.md` — 预实验评估结果（若存在）
+- `wiki/papers/*.md` — 相关论文的baseline设置和方法细节
+- `wiki/concepts/*.md` 和 `wiki/topics/*.md` — 通过idea的 `origin_gaps` 引用
+- `wiki/methods/*.md` — idea所基于的可复用方法
+- `wiki/experiments/*.md` — 已有实验（避免重复设计）
+- `wiki/graph/context_brief.md` — 全局上下文
+- `wiki/graph/open_questions.md` — 知识空白
+
+### Writes
+- `wiki/experiments/{exp-slug}.md` — 实验wiki页面（每个实验块一个，遵循entity schema）
+- `experiments/designs/{slug}-master.md` — 主设计文档，含各块详细spec
+- `wiki/ideas/{slug}.md` — 在 `linked_experiments` 中追加experiment slug
+- `wiki/graph/edges.jsonl` — 添加 `tested_by` 边（idea → 每个experiment）
+- `wiki/graph/context_brief.md` — 重建
+- `wiki/graph/open_questions.md` — 重建
+- `wiki/log.md` — 追加操作日志
+
+### Graph edges created
+- `tested_by`：idea → experiment（该idea正被此实验验证）。反向关系由experiment的 `linked_idea` frontmatter字段捕获，`xref.yaml` 将其反转为idea的 `linked_experiments` 列表。
+
+## Workflow
+
+**前置条件**：确认工作目录为wiki项目根目录（包含 `wiki/`、`raw/`、`tools/` 的目录）。
+
+---
+
+### Phase 1：加载上下文与验证前置条件
+
+1. **读取idea页面**：加载 `wiki/ideas/{slug}.md`，提取 `## Motivation`、`## Hypothesis`、`## Approach sketch`、`## Novelty argument`、`## Risks` 以及frontmatter字段 `origin_gaps`、`tags`、`target_venue`、`priority`、`novelty_score`。
+
+2. **读取预实验结果**（若存在）：加载 `experiments/pilot/{slug}/report.md` 了解预实验结果。若预实验通过，可有信心地推进。若无预实验，谨慎推进并在设计文档中注明。
+
+3. **加载相关wiki上下文**：
+   - 读取 `wiki/graph/context_brief.md` 和 `wiki/graph/open_questions.md`
+   - 从idea的 `origin_gaps` 读取引用的 `wiki/concepts/*.md` 和 `wiki/topics/*.md`
+   - 从 `## Approach sketch` 的wikilinks读取引用的 `wiki/methods/*.md`
+   - 读取 `linked_idea` 匹配的已有 `wiki/experiments/*.md`
+
+4. **读取相关论文**：从 `wiki/papers/*.md` 中提取与idea相关的baseline设置和方法细节。
+
+---
+
+### Phase 2：方法候选生成
+
+从idea生成2–3个方法候选。每个候选代表不同的实现策略：
+
+- **候选A — 直接实现**：直接实现 `## Approach sketch` 中提出的方法
+- **候选B — 混合/融合**：将idea的方法与已有方法（来自 `wiki/methods/`）结合，平衡性能和成本
+- **候选C — 跨idea结合**：将此idea与另一个已验证或通过预实验的已有idea结合（检查 `wiki/ideas/` 中 `pilot_result: passed` 或 `status: validated` 的idea）。测试两个互补idea是否能产生叠加增益。
+
+每个候选需记录：
+- 核心机制/算法概述（2–4句话）
+- 预期优势和风险
+- 实现复杂度：低 / 中 / 高
+- 计算成本估算（相对于baseline）
+
+**向用户展示候选以供审查和选择。** 用户选择1–2个候选继续。若用户未选择，用更清晰的对比重新展示。
+
+---
+
+### Phase 3：基准与指标选择
+
+> 选择benchmark，包括数据集、评测指标和基线方法。其中数据集和评测指标要选择领域内该方向公认的标准级别。
+
+1. **确定基准**，基于：
+   - idea的领域（NLP、CV、RL等）
+   - 相关论文中使用的标准基准（来自 `wiki/papers/`）
+   - 数据集可用性和计算约束
+
+2. **选择数据集**：
+   - 明确使用的数据集(需考虑任务适配性、规模、数据集规范程度)
+   - 明确该数据集的组成结构及使用方法和规范
+
+3. **选择指标**：
+   - 主指标：衡量成功的单一最重要指标（如accuracy、F1、reward）
+   - 辅助指标：补充指标（如延迟、内存、吞吐量）
+
+4. **定义baselines**：列出所选候选需要比较的所有方法，包括：
+   - 最相关论文中复现的baseline
+   - 相关工作中的SOTA方法
+
+5. **记录理由**：为什么这些基准和指标适合idea的假设。
+
+---
+
+### Phase 4：实验套件设计（非线性，含迭代）
+
+本阶段设计所有实验块。消融循环（Step 4.6）是非线性的核心。
+
+#### Step 4.1 — 设计消融实验
+
+- 确定**消融因子**：方法中每个可独立开关的组件或假设
+- 设计**消融矩阵**：测试哪些组合（通常：完整方法逐一去掉一个因子）
+- 定义**收集的指标**：不仅是最终性能 — 还包括中间量（loss分量、梯度范数等），用于诊断每个因子为何重要
+- 每个因子后续将被分类为：必要 / 贡献 / 边际 / 有害
+
+#### Step 4.2 — 设计敏感度分析
+
+- 确定**要扫描的超参数**：学习率、方法特有参数（如稀疏度、融合权重）、模型特有参数
+- 定义**扫描范围和分辨率**：先粗后细
+- 计划**增量执行**：先在子集上运行（更少步数、更小数据集），然后用缩小的范围做完整扫描
+
+#### Step 4.3 — 设计主实验
+
+- 所选方法候选 vs 所有baselines，在完整基准上
+- 多seed（>= 3个seed用于方差估计）
+- 完整训练预算
+- 同时收集最终指标和中间量（用于Step 4.5的深度分析）
+
+#### Step 4.4 — 设计泛化实验（可选）
+
+- 在不同基准、数据集或设置上测试
+- 验证方法的假设在主设置之外是否仍然成立
+- 仅在idea的假设包含泛化声明时才包含
+- 若包含，记录：与主实验有何不同，提供什么新洞察
+
+#### Step 4.5 — 设计深度分析
+
+- 确定**主实验中要记录的中间量**：
+  - 梯度范数（逐层、逐组件）
+  - 注意力模式或特征分布
+  - loss分解（各loss项）
+  - 任何能验证或否定方法核心假设的量
+- 定义**分析脚本/可视化**，在实验完成后产出
+- 这不是关于最终指标 — 而是理解方法*为什么*有效（或无效）
+- 指定哪些量必须在实验*开始前*收集（instrumentation要求）
+
+每个实验块应包含：
+- `title`：描述性标题
+- `linked_idea`：源idea slug（必需，schema要求）
+- `hypothesis`：实验测试的具体假设
+- `type`：ablation / sensitivity / main / generalization / analysis — 以tag形式记录
+- `setup`：模型、数据集、硬件、框架
+- `metrics`：评估指标列表
+- `baseline`：比较基线
+- `success_criterion`：明确的pass/fail标准（写在实验页面的 `## Procedure` 中）
+- `estimated_gpu_hours`：预估计算时间
+- `seeds`：随机种子数（建议 >= 3）
+
+各块具体要求：
+
+**消融**：
+- 目的：隔离方法中每个独立因子的贡献
+- 每次消融去掉一个因子，验证性能变化
+- N个因子 → N次消融运行（加完整方法作为对照）
+- 每次运行收集中间量（不只是最终指标）
+- 成功标准：因子分类表（必要 / 贡献 / 边际 / 有害）
+- 计算量：约等于主实验 × N个因子
+
+**敏感度分析**：
+- 目的：找到方法的最优超参数值
+- 确定所有方法特有超参数（学习率、稀疏度、融合权重等）
+- 定义扫描范围（先粗）和分辨率（网格或随机搜索）
+- 增量执行：先在子集上运行，缩小范围，再完整扫描
+- 成功标准：找到最优超参，有清晰的敏感度模式
+- 计算量：中等（子集扫描便宜，完整扫描取决于参数数量）
+
+**主实验**：
+- 目的：在完整基准上验证idea的核心命题，与所有baselines比较
+- 使用敏感度分析得到的最佳超参
+- 多seed（>= 3个）保证统计可靠性
+- 同时收集最终指标和中间量供深度分析使用
+- 成功标准：相比baselines有统计显著的提升
+- 计算量：最高（完整训练预算、多个seed、多个baseline）
+
+**泛化实验**（可选）：
+- 目的：验证方法在不同条件下是否成立
+- 至少测试2个变化维度（不同数据集、模型大小、领域等）
+- 使用主实验确定的最终方法和最佳超参
+- 成功标准：在新设置上性能保持（无灾难性下降）
+- 计算量：取决于变化维度数量
+
+**深度分析**：
+- 目的：通过检查中间量理解方法*为什么*有效（或无效）
+- 输入：主实验中收集的日志和中间数据
+- 产出可视化：梯度范数、注意力模式、loss分解等
+- 成功标准：中间量证实（或否定）方法的核心假设
+- 计算量：最小（事后分析，无需新的训练运行）
+
+#### Step 4.6 — 迭代消融循环（非线性核心）
+
+这是与线性实验设计的关键区别。初始消融结果后：
+
+```
+iteration = 0
+while iteration < 2:
+    运行消融实验（通过 /exp-run）
+    根据结果分类每个消融因子：
+      - 必要：   去掉后性能大幅下降（>10%）→ 保留
+      - 贡献：   去掉后性能中等下降（3-10%）→ 保留
+      - 边际：   去掉后效果可忽略（<3%）→ 候选移除
+      - 有害：   去掉后性能提升 → 移除
+    若发现任何边际或有害因子：
+      简化方法：
+        - 移除所有有害因子
+        - 与用户讨论是否移除边际因子
+      用减少后的因子集重新规划消融
+      iteration += 1
+    else:
+      break  # 方法已清洁，进入主实验
+```
+
+- 循环退出后（最多2次迭代）：确定最终方法设计
+- 在设计文档中记录完整的迭代历史（每次移除了什么、为什么、各迭代的结果）
+- 此循环确定的方法将用于主实验（Step 4.3）
+
+---
+
+### Phase 5：构建运行顺序
+
+按依赖关系排列实验，设置决策门：
+
+```
+Stage 0：消融（迭代1）
+  └── 运行消融矩阵
+  └── 分类因子 → 如需简化 → 重新运行（迭代2，最多2次）
+  
+Stage 1：敏感度分析（子集）
+  └── 在小子集上运行以缩小超参数范围
+  └── 门：若未找到合理超参 → 停止，重新考虑方法
+
+Stage 2：主实验
+  └── 最终方法 vs baselines，完整基准，多seed
+  └── 门：相比baseline无提升 → 停止，通过深度分析诊断
+
+Stage 3：泛化（可选）
+  └── 仅在Step 4.4设计了泛化实验时执行
+  └── 使用最终方法和最佳超参
+
+Stage 4：深度分析
+  └── 分析Stage 2中收集的中间量
+  └── 产出诊断报告
+```
+
+估算总计算预算。生成含依赖关系的执行清单。
+
+---
+
+### Gate: 用户审查设计的实验模块和运行顺序
+
+**在设计好实验模块，准备创建设计文档以及wiki页面之前，需向用户确认，申请用户手动检查设计的实验模块，确认后进入Phase6，否则需执行修改直到用户确认**
+
+### Phase 6：写入设计文档
+
+1. **创建主设计文档** `experiments/designs/{slug}-master.md`：
+   ```markdown
+   ---
+   title: "实验设计: {idea-title}"
+   slug: "{idea-slug}-design"
+   status: planned
+   linked_idea: "{idea-slug}"
+   tags: ["exp-design"]
+   date_planned: YYYY-MM-DD
+   ---
+
+   ## Idea摘要
+   {idea假设和方法概述}
+
+   ## 方法候选
+   {候选表格及选择理由}
+
+   ## 基准与指标
+   {数据集、指标、baselines}
+
+   ## 实验块
+
+   ### 消融
+   {消融因子、矩阵、指标}
+
+   ### 敏感度分析
+   {超参数、扫描范围}
+
+   ### 主实验
+   {方法 vs baselines，完整配置}
+
+   ### 泛化（可选）
+   {不同设置/基准}
+
+   ### 深度分析
+   {中间量、分析计划}
+
+   ## 消融迭代历史
+   {每次迭代记录：因子分类、简化操作}
+
+   ## 运行顺序与预算
+   {阶段依赖关系、预估GPU小时}
+
+   ## 结果
+   （/exp-run 后填写）
+   ```
+
+2. **创建experiment wiki页面** — 每个实验块一个页面（遵循 `runtime/schema/entities.yaml` 和 `runtime/templates/experiments.md.tmpl`）：
+   ```bash
+   python3 tools/research_wiki.py slug "<experiment-title>"
+   ```
+   创建 `wiki/experiments/{slug}.md`，严格遵循 `runtime/schema/entities.yaml::experiments` 和 `runtime/templates/experiments.md.tmpl` — 以下每个frontmatter字段必须存在（即使为空），因为 `/exp-run` 后续使用 `tools/research_wiki.py set-meta` 更新，而 `set-meta` 拒绝创建不存在的字段：
+   ```yaml
+   ---
+   title: ""
+   slug: ""
+   status: planned
+   linked_idea: "{idea-slug}"   # 必需（schema要求）。通过xref.yaml反向链接到 wiki/ideas/{idea-slug}.md::linked_experiments。
+   hypothesis: ""
+   tags: []                     # 标明类型：["ablation"]、["sensitivity"]、["main"]、["generalization"] 或 ["analysis"]
+   setup:
+     model: ""
+     dataset: ""
+     hardware: ""
+     framework: ""
+   metrics: []
+   baseline: ""
+   outcome: ""                  # /exp-run Phase 4 前留空 — succeeded | failed | inconclusive
+   key_result: ""               # /exp-run Phase 4 前留空
+   date_planned: YYYY-MM-DD
+   date_completed: ""           # /exp-run Phase 4 前留空
+   run_log: ""                  # /exp-run Phase 2 前留空
+   started: ""                  # /exp-run Phase 2 前留空（ISO时间戳，通过set-meta设置）
+   estimated_hours: 0           # /exp-run Phase 2 前为0（通过set-meta设置）
+   remote:                      # 整块必须存在，以便 /exp-run --env remote 通过Edit填充子字段
+     server: ""
+     gpu: ""
+     session: ""
+     started: ""
+     completed: ""
+   ---
+   ```
+
+   各块类型的正文section：
+
+   **消融**（`tags: ["ablation"]`）：
+   - `## Objective` — 测试哪些因子，消融揭示方法的什么特性
+   - `## Setup` — 消融矩阵（因子组合）、模型、数据集、硬件、超参数
+   - `## Procedure` — 逐步执行：运行每个因子组合，收集指标和中间量
+   - `## Results`（/exp-run 后填写）— 因子分类表：必要 / 贡献 / 边际 / 有害
+   - `## Analysis`（/exp-run 后填写）— 哪些因子应移除，迭代历史
+   - `## Follow-up` — 若发现边际/有害因子：简化方法并重新消融（迭代2）；若全部必要/贡献：进入主实验
+
+   **敏感度分析**（`tags: ["sensitivity"]`）：
+   - `## Objective` — 扫描哪些超参数，最优范围是什么
+   - `## Setup` — 扫描范围和分辨率、模型、数据集、硬件
+   - `## Procedure` — 逐步执行：先在子集上运行，缩小范围，再完整扫描
+   - `## Results`（/exp-run 后填写）— 最佳超参数值、性能曲线
+   - `## Analysis`（/exp-run 后填写）— 敏感度模式，推荐用于主实验的值
+   - `## Follow-up` — 将最佳超参传递给主实验
+
+   **主实验**（`tags: ["main"]`）：
+   - `## Objective` — 此实验证明idea相对于baselines的什么结论
+   - `## Setup` — 方法 vs 所有baselines，完整基准，多seed（>=3），敏感度分析的最佳超参
+   - `## Procedure` — 逐步执行计划，含明确成功标准；收集中间量供深度分析使用
+   - `## Results`（/exp-run 后填写）— 指标对比表（方法 vs baselines），统计显著性
+   - `## Analysis`（/exp-run 后填写）— 方法为何有效/失败，中间量分析
+   - `## Follow-up` — 应急计划：成功/失败后分别怎么做
+
+   **泛化实验**（`tags: ["generalization"]`，可选）：
+   - `## Objective` — 测试什么泛化声明
+   - `## Setup` — 与主实验不同的基准/数据集/设置
+   - `## Procedure` — 用最终方法和最佳超参在新设置上运行
+   - `## Results`（/exp-run 后填写）— 新设置 vs 主设置的性能
+   - `## Analysis`（/exp-run 后填写）— 方法是否泛化？
+   - `## Follow-up` — 若失败：识别哪个假设不成立
+
+   **深度分析**（`tags: ["analysis"]`）：
+   - `## Objective` — 分析哪些中间量，验证什么假设
+   - `## Setup` — 数据来源（主实验日志）、可视化规格
+   - `## Procedure` — 运行分析脚本，产出图表和诊断表
+   - `## Results`（/exp-run 后填写）— 图表、表格、关键观察
+   - `## Analysis`（/exp-run 后填写）— 中间量是否证实了方法的假设？
+   - `## Follow-up` — 若假设未证实：识别问题所在
+
+3. **添加graph edges**：
+   ```bash
+   # 每个experiment页面，idea → experiment
+   python3 tools/research_wiki.py add-edge wiki/ \
+     --from "ideas/{idea-slug}" --to "experiments/{exp-slug}" \
+     --type tested_by --evidence "Designed by /exp-design"
+   ```
+
+4. **更新idea页面**：在 `wiki/ideas/{slug}.md` 的 `linked_experiments` 中追加所有experiment slug。
+
+6. **重建派生数据**：
+   ```bash
+   python3 tools/research_wiki.py rebuild-context-brief wiki/
+   python3 tools/research_wiki.py rebuild-open-questions wiki/
+   ```
+
+7. **追加日志**：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ \
+     "exp-design | 为idea {slug}设计了{N}个实验 | linked_idea: {slug}"
+   ```
+
+8. **输出DESIGN_REPORT到终端**：
+   ```markdown
+   # 设计报告: {idea-slug}
+
+   ## 目标Idea
+   - Idea: [[idea-slug]]
+   - 假设: {hypothesis}
+
+   ## 方法候选
+   | # | 候选 | 类型 | 复杂度 | 是否选中 |
+   |---|------|------|--------|----------|
+   | A | {name} | 直接实现 | {低/中/高} | {是/否} |
+   | B | {name} | 混合/融合 | {低/中/高} | {是/否} |
+   | C | {name} | 跨idea结合 | {低/中/高} | {是/否} |
+
+   ## 基准
+   - 主要: {benchmark} | 指标: {metric}
+   - Baselines: {列表}
+
+   ## 实验块
+   | # | 实验 | 类型 | GPU小时 | 阶段 |
+   |---|------|------|---------|------|
+   | 1 | [[slug]] | 敏感度 | {N} | 0 |
+   | 2 | [[slug]] | 消融 | {N} | 1 |
+   | 3 | [[slug]] | 主实验 | {N} | 2 |
+   | 4 | [[slug]] | 泛化 | {N} | 3 |
+
+   ## 消融迭代
+   - 计划迭代次数: {N}（最多2次）
+   - 因子: {列表及分类}
+
+   ## 运行顺序
+   Stage 0: 敏感度 → Stage 1: 消融 → Stage 2: 主实验 → Stage 3: 泛化 → Stage 4: 深度分析
+
+   ## 预算
+   - 总预估: {N} GPU小时
+
+   ## 下一步
+   - 运行 `/exp-run [[sensitivity-slug]]` 开始Stage 0
+   ```
+
+## Constraints
+
+- **每个experiment必须引用一个idea**：`linked_idea` 是schema必需的。若无idea页面，拒绝设计 — 指示用户先运行 `/ideate`。
+- **不重复创建experiment**：创建前扫描 `wiki/experiments/*.md` 中已有相同 `linked_idea` + `hypothesis` 的实验。
+- **不覆盖已有设计文件**：若 `experiments/designs/{slug}-master.md` 已存在，覆盖前询问用户。
+- **方法候选必须有依据**：不凭空编造方法 — 所有候选必须源自idea页面内容。
+- **消融循环上限2次**：防止无限循环。2次迭代后用当前设计定稿。
+- **敏感度扫描必须增量**：先子集，后完整扫描。
+- **深度分析必须预先规划**：在实验*开始前*指定要收集的中间量 — 这是instrumentation，不是事后分析。
+- **Graph edges通过tools/research_wiki.py**：不要手动编辑 `edges.jsonl`。
+- **至少3个seed**：需要统计可靠性的实验（主实验）必须指定 >= 3个随机seed。
+- **成功标准必须量化**：每个实验块需要具体的pass/fail数值。
+
+## Error Handling
+
+- **Idea页面未找到**：报告错误，建议先运行 `/ideate`。
+- **无预实验结果**：警告用户，继续但在设计文档中注明信心降低。
+- **用户未选择任何方法候选**：用更清晰的对比重新展示，要求明确选择。
+- **基准不可用**：建议替代方案，由用户决定。
+- **消融循环达到2次迭代**：用当前设计定稿，在报告中注明剩余的边际因子。
+- **类似experiment已存在**：列出已有实验，询问用户是添加还是跳过。
+- **计算预算不足**：缩减泛化实验范围，在报告中注明实际分配。
+
+## Dependencies
+
+### Skills (via Skill tool)
+- `/exp-run` — 执行设计好的实验
+- `/exp-pilot-eval` — 前置条件：预实验评估应在正式设计前完成
+
+### Tools (via Bash)
+- `python3 tools/research_wiki.py slug "<title>"` — 生成slug
+- `python3 tools/research_wiki.py add-edge wiki/ ...` — 添加graph edge
+- `python3 tools/research_wiki.py set-meta ...` — 更新frontmatter字段
+- `python3 tools/research_wiki.py rebuild-context-brief wiki/` — 重建上下文
+- `python3 tools/research_wiki.py rebuild-open-questions wiki/` — 重建知识空白
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+
+### Qoder Native
+- `Read` — 读取wiki页面
+- `Write` — 创建设计文档和实验页面
+- `Glob` — 查找已有实验
+- `AskUserQuestion` — 方法候选选择
+
+### Called by
+- `/ideate`（预实验评估后）
+- 用户直接调用

--- a/.qoder/skills/exp-eval/SKILL.md
+++ b/.qoder/skills/exp-eval/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: exp-eval
+description: 实验判决门：Review LLM 独立评判实验结果 → 4 种判决路径 → 自动更新 linked idea 的 status / failure_reason 与 graph edges
+---
+
+# /exp-eval
+
+> **用法**：`<experiment-slug> [--auto]`
+
+
+> 将已完成实验的结果转化为 wiki 知识更新。
+> Review LLM 作为 impartial judge（遵循 cross-model-review），独立评估实验结果对 linked idea 的 hypothesis 的影响。
+> 4 种判决路径：supported → idea validated / partially_supported → 补充实验 /
+> not_supported → idea failed / inconclusive → debug。
+> 自动更新 linked idea 的 `status`、`failure_reason` 与 graph edges。
+
+## Inputs
+
+- `experiment`：wiki/experiments/ 中的 slug（status 必须为 `completed`）
+- `--auto`（可选）：自动模式，不暂停等待用户确认 wiki 更新（用于 /research 调用）
+
+## Outputs
+
+- `wiki/ideas/{linked-idea}.md` — 更新 `status`、`failure_reason`、`date_resolved`
+- `wiki/experiments/{slug}.md` — 填充 `## Idea updates` section（记录 linked idea 的 status 变化；旧名为 `## Claim updates`）
+- `wiki/graph/edges.jsonl` — 新增 `supports` / `invalidates` 边（experiment → idea）
+- `wiki/graph/context_brief.md` — 重建
+- `wiki/graph/open_questions.md` — 重建
+- `wiki/log.md` — 追加日志
+- **VERDICT_REPORT**（输出到终端）— 判决结果、wiki 变更摘要、下一步建议
+
+## Wiki Interaction
+
+### Reads
+- `wiki/experiments/{slug}.md` — 实验结果：`outcome`、`key_result`、`metrics`、完整 Results section、`linked_idea`
+- `wiki/ideas/{linked-idea}.md` — linked idea 当前状态：`status`、`## Hypothesis`、`## Risks`
+- `wiki/experiments/*.md` — 同一 `linked_idea` 的 sibling 实验（综合评估）
+- `wiki/graph/context_brief.md` — 全局上下文
+- `.qoder/skills/shared-references/cross-model-review.md` — 审稿独立性原则
+
+### Writes
+- `wiki/ideas/{linked-idea}.md` — 更新 `status`、`failure_reason`、`date_resolved`
+- `wiki/experiments/{slug}.md` — 填充 `## Idea updates` section
+- `wiki/graph/edges.jsonl` — 新增 `supports` / `invalidates` 边（experiment → idea）
+- `wiki/graph/context_brief.md` — 重建
+- `wiki/graph/open_questions.md` — 重建
+- `wiki/log.md` — 追加操作日志
+
+### Graph edges created
+- `supports`：experiment → idea（实验支持 idea 的 hypothesis）— verdict = supported 或 partially_supported
+- `invalidates`：experiment → idea（实验否定 idea 的 hypothesis）— verdict = not_supported
+
+## Workflow
+
+**前置**：
+1. 确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）
+2. 确认实验 status == `completed`（未完成的实验不能评判）
+
+### Step 1: 加载上下文
+
+1. **读取实验页面** `wiki/experiments/{slug}.md`：
+   - `outcome`（succeeded/failed/inconclusive）
+   - `key_result`
+   - `linked_idea` slug（必填；缺失则拒绝继续）
+   - `metrics` 与完整 `## Results` section
+   - `hypothesis`
+
+2. **读取 linked idea** `wiki/ideas/{linked-idea}.md`：
+   - 当前 `status`
+   - `## Hypothesis`、`## Approach sketch`、`## Risks`、`## Novelty argument`
+
+3. **加载 sibling 实验**（同一 `linked_idea`）：
+   - Glob `wiki/experiments/*.md`，过滤 `linked_idea == 当前 idea`
+   - 汇总它们的 outcome（判决要看完整证据组合，不是单个实验）
+
+4. **读取全局上下文**：`wiki/graph/context_brief.md`
+
+5. **读取 cross-model-review.md**：确认 Review LLM 独立性原则
+
+### Step 2: Review LLM 判决（Cross-Model Verdict）
+
+**遵循 cross-model-review.md**：不向 Review LLM 发送 Claude 的预判。
+
+```
+llm-review.chat:
+  system: "You are an impartial scientific judge evaluating whether experimental
+           results support or refute a research hypothesis. Be rigorous and objective.
+           Consider: statistical significance, effect size, experimental validity,
+           potential confounds, and whether the results generalize beyond the
+           specific setup tested."
+  message: |
+    ## Idea Hypothesis Under Test
+    Title: {idea title}
+    Hypothesis: {idea ## Hypothesis section}
+    Novelty argument: {idea ## Novelty argument section}
+    Current status: {idea status}
+
+    ## Experiment
+    Title: {experiment title}
+    Hypothesis: {experiment hypothesis}
+    Setup: {model, dataset, hardware, framework}
+    Metrics: {metrics list}
+
+    ## Results
+    {full Results section from experiment page}
+
+    ## Key Finding
+    {key_result}
+
+    ## Sibling Experiments on This Idea
+    {summary of other experiments' outcomes that share the same linked_idea, if any}
+
+    ## Your Task
+    Provide your verdict:
+    1. **Verdict**: One of: supported / partially_supported / not_supported / inconclusive
+    2. **Evidence strength**: weak / moderate / strong
+    3. **Idea status recommendation**: keep current / advance to validated / mark failed
+    4. **Key reasoning**: 2-3 sentences explaining your verdict
+    5. **Concerns**: Any methodological concerns or limitations
+    6. **Suggested next steps**: What would strengthen or clarify this result?
+```
+
+记录 Review LLM 的判决。
+
+### Step 3: Claude 综合评估
+
+1. **独立形成 Claude 的判决**（在读取 Review LLM 判决后，Claude 也独立分析）：
+   - 基于实验结果、idea 的 hypothesis，以及 sibling 实验的综合证据
+   - 形成 Claude 自己的 verdict 和 idea status 建议
+
+2. **综合两个判决**（遵循 cross-model-review.md composing rules）：
+   - **两者一致**（verdict 相同）：采用该 verdict，高置信度
+   - **两者不一致**：
+     - 明确标注分歧
+     - 取更保守的 verdict（supported > partially_supported > not_supported）
+     - 在报告中详述分歧原因
+   - **致命发现优先**：若任一方发现方法论问题（数据泄露、不公平比较），该发现优先
+
+3. **确定最终判决**：verdict + evidence_strength + idea_status_change
+
+### Step 4: 根据判决更新 Wiki
+
+**若 `--auto` 未设置**：先展示判决结果和计划变更，等待用户确认。
+
+#### 路径 A: SUPPORTED（实验支持 idea 的 hypothesis）
+
+1. **更新 idea**：
+   - 若 idea 只覆盖单一 hypothesis 且本实验是 主实验 块，把 idea 推进到 `validated`：
+     ```bash
+     python3 tools/research_wiki.py transition wiki/ideas/{linked-idea}.md --to validated
+     ```
+   - 否则保持 idea 当前生命周期状态（之前是 `tested` 就维持 `tested`；否则维持 `in_progress`）。
+
+2. **添加 graph edge**：
+   ```bash
+   python3 tools/research_wiki.py add-edge wiki/ \
+     --from "experiments/{slug}" --to "ideas/{linked-idea}" \
+     --type supports --evidence "{key_result}"
+   ```
+
+3. **建议下一步**：`/paper-plan {linked-idea}` 或继续 ablation/robustness 实验
+
+#### 路径 B: PARTIALLY_SUPPORTED（部分支持）
+
+1. **更新 idea**：
+   - 生命周期保持当前状态（`in_progress` 或 `tested`）
+
+2. **添加 graph edge**：
+   ```bash
+   python3 tools/research_wiki.py add-edge wiki/ \
+     --from "experiments/{slug}" --to "ideas/{linked-idea}" \
+     --type supports --evidence "Partially supported: {limitation}"
+   ```
+
+3. **建议补充实验**：
+   - 明确缺少什么证据
+   - 建议用 `/exp-design --linked-idea {linked-idea}` 设计补充实验
+   - 若 Review LLM 指出的 concern 可通过实验解决，具体建议实验方向
+
+#### 路径 C: NOT_SUPPORTED（实验否定 idea 的 hypothesis）
+
+1. **更新 idea**：
+   - 推进到 `failed`：
+     ```bash
+     python3 tools/research_wiki.py transition wiki/ideas/{linked-idea}.md --to failed --reason "<具体原因>"
+     ```
+     `transition` 要求非空 `--reason`；把综合得到的失败原因传进来。`transition` 命令会自动写入 `failure_reason` 与 `date_resolved`。
+   - 注意：`failure_reason` 是 anti-repetition memory —— 必须写出具体原因，不得是模糊的 "did not work"。
+
+2. **添加 graph edge**：
+   ```bash
+   python3 tools/research_wiki.py add-edge wiki/ \
+     --from "experiments/{slug}" --to "ideas/{linked-idea}" \
+     --type invalidates --evidence "{failure_reason}"
+   ```
+
+3. **建议下一步**：
+   - 分析失败原因
+   - 考虑 pivot（新 idea 解决同一 gap，避开已知失败原因）
+   - 建议 `/ideate` 生成替代方案
+
+#### 路径 D: INCONCLUSIVE（结果不确定）
+
+1. **不修改 idea status**：证据不足以做判断
+
+2. **更新实验页面**：outcome 已为 inconclusive（/exp-run 设置）
+
+3. **建议 debug**：
+   - 数据问题？实现 bug？错误的 metric？
+   - 方差过大？需要更多 seeds？
+   - 实验设置与 idea 的 hypothesis 不对齐？
+
+4. **idea status 不变**：保持当前状态
+
+#### 所有路径通用
+
+1. **更新实验页面的 `## Idea updates` section**（记录 linked idea 的更新；不再有独立的 claim 实体）：
+   ```markdown
+   ## Idea updates
+   - **Verdict**: {supported/partially_supported/not_supported/inconclusive}
+   - **Linked idea**: [[{linked-idea}]] status {old} → {new}
+   - **Judge agreement**: {Claude and Review LLM agreed / disagreed on ...}
+   - **Date**: YYYY-MM-DD
+   ```
+
+2. **更新 index.md**（若 idea status 变化）
+
+3. **重建派生数据**：
+   ```bash
+   python3 tools/research_wiki.py rebuild-context-brief wiki/
+   python3 tools/research_wiki.py rebuild-open-questions wiki/
+   ```
+
+4. **追加日志**：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ \
+     "exp-eval | {slug} → ideas/{linked-idea} | verdict: {verdict} | idea status: {old}→{new}"
+   ```
+
+5. **输出 VERDICT_REPORT 到终端**：
+   ```markdown
+   # Verdict Report: {experiment title}
+
+   ## Verdict: {SUPPORTED / PARTIALLY_SUPPORTED / NOT_SUPPORTED / INCONCLUSIVE}
+
+   ## Judge Assessment
+   | | Claude | Review LLM | Final |
+   |---|-------|------|-------|
+   | Verdict | {verdict} | {verdict} | {verdict} |
+   | Idea status rec | {rec} | {rec} | {rec} |
+   | Evidence strength | {strength} | {strength} | {strength} |
+
+   ## Key Reasoning
+   {2-3 sentences from Review LLM + Claude synthesis}
+
+   ## Wiki Changes
+   | Entity | Field | Before | After |
+   |--------|-------|--------|-------|
+   | ideas/{slug} | status | {old} | {new} |
+
+   ## Graph Edges Added
+   - experiments/{slug} → ideas/{linked-idea} (supports/invalidates)
+
+   ## Concerns
+   {methodological concerns from Review LLM}
+
+   ## Next Steps
+   - {path-specific suggestions}
+
+   ## Wiki Growth
+   | Metric | Before | After | Delta |
+   |--------|--------|-------|-------|
+   | Ideas validated | {before} | {after} | +{delta} |
+   | Ideas failed | {before} | {after} | +{delta} |
+   | Edges | {before} | {after} | +{delta} |
+   | Maturity | {level} | {level} | {unchanged/upgraded} |
+   （数据来自 Step 1 开始时和 Step 4 结束后分别调用 `python3 tools/research_wiki.py maturity wiki/ --json` 的对比。）
+   ```
+
+## Constraints
+
+- **只处理 completed 实验**：status != completed 的实验拒绝处理，提示用 /exp-run 先完成。
+- **`linked_idea` 必填**：拒绝评判任何 `linked_idea` 为空的实验（新 schema 强制要求；如果遇到这类页面，那是 refactor 之前的遗留物，必须先手动修复）。
+- **审稿独立性**：严格遵循 cross-model-review.md，不向 Review LLM 发送 Claude 的预判。
+- **`failure_reason` 必须具体**：not_supported 路径的 `failure_reason` 不能是空话（如 "实验失败"），必须写明具体原因。`transition --reason` 会拒绝空字符串。
+- **idea 生命周期只前进**：`proposed → in_progress → tested → validated/failed`。使用 `tools/research_wiki.py transition`（而非直接改 frontmatter），让生命周期校验器跑起来。
+- **graph edges 使用 tools/research_wiki.py**：不手动编辑 `edges.jsonl`。
+- **保守原则**：当 Claude 和 Review LLM 判决不一致时，取更保守的判决。
+- **综合所有 sibling 实验评估**：不仅看当前实验，还要参考同一 `linked_idea` 的其他实验。
+
+## Error Handling
+
+- **experiment 找不到**：提示用户检查 slug，列出 `wiki/experiments/` 中 status=completed 的候选。
+- **experiment 未完成**：提示 status，建议先运行 `/exp-run {slug}` 或 `/exp-run {slug} --check`。
+- **`linked_idea` 缺失**：拒绝继续；提示用户运行 `/edit` 设置实验的 `linked_idea`。
+- **linked idea 页面不存在**：报告 dangling reference；拒绝更新 —— 建议先用 `/edit` 或 `/ideate` 创建该 idea 页面。
+- **Review LLM 不可用**：降级为 Claude 单模型判决，在报告中标注「single-model verdict, cross-model verification unavailable」，建议用户稍后确认。
+- **idea 已被其他实验修改**：在应用 transition 前重新读取最新状态；不要把更高生命周期状态退回到更低。
+- **结果数据缺失**：若实验页面的 Results section 为空，提示用户先运行 `/exp-run {slug} --check`。
+
+## Dependencies
+
+### Tools（via Bash）
+- `python3 tools/research_wiki.py transition wiki/ideas/{slug}.md --to validated|failed [--reason "..."]` — 推进 idea 生命周期
+- `python3 tools/research_wiki.py add-edge wiki/ ...` — 添加 graph edge
+- `python3 tools/research_wiki.py rebuild-context-brief wiki/` — 重建 query_pack
+- `python3 tools/research_wiki.py rebuild-open-questions wiki/` — 重建 gap_map
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+
+### MCP Servers
+- `llm-review.chat` — Step 2 Review LLM 独立判决
+
+### Qoder Native
+- `Read` — 读取 wiki 页面
+- `Glob` — 查找同一 `linked_idea` 的 sibling 实验
+- `Edit` — 更新 wiki 页面
+
+### Shared References
+- `.qoder/skills/shared-references/cross-model-review.md` — Review LLM 独立性原则（必读）
+
+### Called by
+- `/research` Stage 4（判决与迭代阶段）
+- 用户手动调用

--- a/.qoder/skills/exp-pilot-eval/SKILL.md
+++ b/.qoder/skills/exp-pilot-eval/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: exp-pilot-eval
+description: 预实验结果评估 — 读取预实验结果，应用成功标准，更新 idea 页面（pilot_result，失败时更新 failure_reason），生成 PILOT_VERDICT_REPORT。由 /ideate Phase 5 在 /exp-pilot-run 之后调用。
+---
+
+# /exp-pilot-eval
+
+> **用法**：`<idea-slug> [--auto]`
+
+
+> 评估预实验结果并更新关联的 idea 页面。
+> 从 `experiments/pilot/code/{slug}/results/` 读取预实验结果，应用判定逻辑（pass/fail/inconclusive），更新 idea 的 `pilot_result`、`failure_reason` 和 `status` 字段。
+> 由 `/ideate` Phase 5 在 `/exp-pilot-run` 完成后调用。
+
+## Inputs
+
+- `idea-slug`：刚完成预实验的 idea 的 slug
+- `--auto`（可选）：自动模式，不暂停等待用户确认（由 `/research` 调用时使用）
+
+## Outputs
+
+- `wiki/ideas/{slug}.md` — 更新 `pilot_result`（始终）、`failure_reason`（失败时）、`status`（失败时 → `failed`）
+- `wiki/log.md` — 追加日志
+- **PILOT_VERDICT_REPORT**（输出到终端）— 判定结果、wiki 变更摘要、下一步建议
+- `experiments/pilot/{slug}/report.md` — PILOT_VERDICT_REPORT 文件副本（持久记录）
+
+## Wiki Interaction
+
+### Reads
+- `wiki/ideas/{slug}.md` — 关联 idea 当前状态：`status`、`pilot_result`、`failure_reason`
+- `experiments/pilot/code/{slug}/results/seed_*.json` — 预实验结果
+- `experiments/pilot/code/{slug}/pilot.log` — 预实验运行日志（用于失败诊断：错误、警告、运行时行为）
+- `experiments/pilot/{slug}.yaml` — Pilot Spec（用于 success_criterion 和 baseline 参考）
+
+### Writes
+- `wiki/ideas/{slug}.md` — 更新 `pilot_result`、`failure_reason`（失败时）、`status`（失败时）
+- `wiki/log.md` — 追加操作日志
+- `experiments/pilot/{slug}/report.md` — PILOT_VERDICT_REPORT 文件副本
+
+### Graph edges created
+- 无。预实验评估不创建 graph edges（正式实验的 edges 由 `/exp-eval` 创建）。
+
+## Workflow
+
+**Step 1: 加载上下文**
+
+1. 读取 idea 页面 `wiki/ideas/{slug}.md`：
+   - 当前 `status` 和 `pilot_result`
+   - 当前 `failure_reason`（对 proposed idea 应为空）
+
+2. 读取预实验结果 `experiments/pilot/code/{slug}/results/seed_*.json`：
+   - 解析结果文件（JSON）
+   - 计算每个 metric 的 mean ± std（跨 seeds）
+
+3. 读取预实验日志 `experiments/pilot/code/{slug}/pilot.log`：
+   - 扫描错误、警告、OOM、发散信号
+   - 提取运行时行为上下文，用于失败诊断和判定报告
+
+4. 读取 Pilot Spec `experiments/pilot/{slug}.yaml`：
+   - 提取 `success_criterion`（pass、fail、inconclusive 条件）
+   - 提取 `baseline.expected_value` 用于对比
+
+**Step 2: 应用判定逻辑**
+
+根据 Pilot Spec 的 success_criterion 评估预实验结果。判定阈值故意宽松 — 预实验的目的是检测明显失败，而非衡量最终性能。
+
+- **Pass**：预实验未显示明确失败。由于预实验使用缩减的 batch size（论文的 1/4–1/8）和缩短的训练（完整步数的 10–30%），结果天然带有噪声且偏向下限。因此：比 baseline 有改进、与 baseline 基本持平、甚至略差于 baseline 都算 pass。路径 C 下，若现有方法在新设定下确实失败（gap 被确认），也算 pass。
+- **Fail**：预实验显示明确、无歧义的失败（发散、相比 baseline 严重退化、根本性不兼容）。阈值较高 — 只有明显不可行的 idea 才应在此阶段被淘汰。
+- **Inconclusive**：预实验有噪声或不确定 — 结果无法明确判定为 pass 或 fail。
+
+**Step 3: 更新 Idea 页面**
+
+若 verdict == `pass`：
+- 设置 `pilot_result`：`"pass — <关键指标 vs baseline 的一句话总结>"`
+- Status 不变（保持 `proposed` 或当前状态）
+- 示例：`"pass — accuracy 0.82 vs baseline 0.80, loss converges"`
+
+若 verdict == `fail`：
+- 设置 `pilot_result`：`"fail — <具体失败>"`
+- 设置 `failure_reason`：`"[pilot] <具体失败描述>"`
+  - `[pilot]` 前缀区分于 Phase 3 的 `[filter]` 淘汰和 `/exp-eval` 的实验后失败
+- 将 status 转为 `failed`：
+  ```bash
+  python3 tools/research_wiki.py set-meta wiki/ideas/{slug}.md pilot_result "fail — <具体失败>"
+  python3 tools/research_wiki.py transition wiki/ideas/{slug}.md --to failed --reason "[pilot] <具体失败描述>"
+  ```
+  - `transition` 会校验生命周期规则（如拒绝从 `validated` 降级到 `failed`）并自动设置 `failure_reason` 和 `date_resolved`。
+- failure_reason 示例：`"[pilot] loss diverged after 50 steps (reached 1e5 vs baseline 0.3)"`
+
+若 verdict == `inconclusive`：
+- 设置 `pilot_result`：`"inconclusive — needs full experiment"`
+- Status 不变
+
+**Step 4: 报告**
+
+1. 若 `--auto` 未设置：在终端展示判定结果和 wiki 变更，对边界情况等待用户确认
+
+2. 追加日志：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ \
+     "exp-pilot-eval | {slug} | verdict: {verdict} | pilot_result: {result}"
+   ```
+
+3. 输出 **PILOT_VERDICT_REPORT** 到终端并写入 `experiments/pilot/{slug}/report.md`：
+   ```markdown
+   # Pilot Verdict Report: {slug}
+
+   ## Verdict: {pass / fail / inconclusive}
+
+   ## Results Summary
+   | Metric | Baseline | Pilot (mean±std) | Δ |
+   |--------|----------|------------------|---|
+   | {metric} | {baseline-value} | {mean}±{std} | {delta} |
+
+   ## Pilot Log
+   - 日志：experiments/pilot/code/{slug}/pilot.log
+   - 关键信号：{日志中观察到的错误/警告/OOM/发散，或"运行正常"}
+
+   ## Wiki Changes
+   | Page | Field | Old | New |
+   |------|-------|-----|-----|
+   | ideas/{slug} | pilot_result | {old} | {new} |
+   | ideas/{slug} | status | {old} | {new} | (only if changed) |
+   | ideas/{slug} | failure_reason | — | {new} | (only if failed) |
+
+   ## Next Steps
+   - {if pass: proceed to /exp-design for full experiments}
+   - {if fail: idea eliminated; review pilot log for details}
+   - {if inconclusive: proceed to full experiment with caution}
+   ```
+
+## Constraints
+
+- **只处理已预实验的 ideas**：结果必须存在于 `experiments/pilot/code/{slug}/results/`
+- **failure_reason 必须具体**：不能是模糊的 "pilot failed" — 需包含什么失败了以及为什么
+- **Idea 生命周期只向前**：`proposed → failed`（不能从 validated 退回 failed）
+- **不创建 graph edges**：正式实验的 edges 由 `/exp-eval` 创建
+- **Pass 阈值故意宽松**：检测明显失败，而非衡量最终性能
+- **`[pilot]` 前缀在 failure_reason 中必须存在**：区分于 `[filter]` 和实验后失败
+
+## Error Handling
+
+- **Idea 页面找不到**：报告错误，建议先运行 `/ideate`
+- **预实验结果找不到**：报告错误，建议先运行 `/exp-pilot-run`
+- **Idea 已经 failed**：报告当前状态，不覆盖
+- **Idea 已经 validated**：拒绝降级 status，报告警告
+- **Pilot Spec 找不到**：报告错误，建议先运行 `/ideate` 生成 spec
+
+## Dependencies
+
+### Skills (via Skill tool)
+- 无
+
+### Tools (via Bash)
+- `python3 tools/research_wiki.py set-meta wiki/ideas/{slug}.md <field> "<value>"` — 更新 idea 字段（如 pilot_result）
+- `python3 tools/research_wiki.py transition wiki/ideas/{slug}.md --to <status> [--reason "..."]` — 转换 idea 生命周期状态
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+
+### Qoder Native
+- `Read` — 读取 idea 页面、预实验结果、预实验日志、Pilot Spec
+- `Edit` — 更新 idea 页面字段
+- `Bash` — 执行 research_wiki.py 命令
+
+### Called by
+- `/ideate` Phase 5
+- 用户手动调用

--- a/.qoder/skills/exp-pilot-run/SKILL.md
+++ b/.qoder/skills/exp-pilot-run/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: exp-pilot-run
+description: 预实验执行 — 读取 Pilot Spec YAML，撰写预实验代码，运行实验(运行前需向用户确认，申请用户手动检查)，返回结果。由 /ideate Phase 5 调用。不修改 wiki 页面，不判定 pass/fail。
+---
+
+# /exp-pilot-run
+
+> **用法**：`<idea-slug> [--env local|remote]`
+
+
+> 执行由 Pilot Spec YAML 文件描述的预实验。
+> 从 `experiments/pilot/{slug}.yaml` 读取 spec，撰写预实验代码，运行实验(运行前需向用户确认，申请用户手动检查)，返回原始结果给调用者。
+> **不论是哪种运行模式，在准备好实验代码，准备部署运行前需向用户确认，申请用户手动检查代码、实验配置(如数据集路径，接口参数选择，API 配置等)相关信息，确认无误后运行，否则需执行修改直到用户确认执行**
+> 支持 **local**（本地 GPU）和 **remote**（通过 `tools/remote.py` SSH 部署）两种模式。
+> 不修改任何 wiki 页面。不判定 pass/fail — 结果由 `/exp-pilot-eval` 评估。
+
+## Inputs
+
+- `idea-slug`：用于定位 `experiments/pilot/{slug}.yaml` 的 slug
+- `--env local|remote`（可选，默认 `local`）：部署环境
+  - `local`：在本地 GPU 直接运行
+  - `remote`：通过 SSH 部署到远程机器（需要 `config/server.yaml`）
+
+## Outputs
+
+- 预实验代码：`experiments/pilot/code/{slug}/`（train.py, config.yaml, run.sh, requirements.txt）
+- 预实验结果：`experiments/pilot/code/{slug}/results/seed_{N}.json`
+- 预实验日志：`experiments/pilot/code/{slug}/pilot.log`
+- **PILOT_REPORT**（输出到终端）— 结果表格、运行详情、异常
+- 返回原始结果和关键指标给调用者
+- 不修改任何 wiki 页面
+
+## Wiki Interaction
+
+### Reads
+- `experiments/pilot/{slug}.yaml` — Pilot Spec（所有配置）**如果在对应位置不存在所选择idea的Pilot Spec，提醒用户，并按照 /ideate Phase 5 中创建Pilot Spec的步骤进行创建**
+- `wiki/papers/*.md` — 相关论文的方法描述（实现参考）
+
+### Writes
+- `experiments/pilot/code/{slug}/` — 预实验代码目录
+  - `experiments/pilot/code/{slug}/train.py` — 主训练/评估脚本
+  - `experiments/pilot/code/{slug}/config.yaml` — 超参数配置文件
+  - `experiments/pilot/code/{slug}/run.sh` — 启动封装脚本
+  - `experiments/pilot/code/{slug}/requirements.txt` — 依赖
+  - `experiments/pilot/code/{slug}/results/seed_{N}.json` — 结果文件
+  - `experiments/pilot/code/{slug}/pilot.log` — 运行日志
+
+### Graph edges created
+- 无。预实验不创建 graph edges。
+
+## Workflow
+
+**前置**：确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）。
+
+---
+
+**Phase 1: 准备**
+
+1. **读取 Pilot Spec**：
+   **如果在对应位置不存在所选择idea的Pilot Spec，提醒用户，并按照 /ideate Phase 5 中创建Pilot Spec的步骤进行创建**
+   - 加载 `experiments/pilot/{slug}.yaml`
+   - YAML 有 `pilot_spec:` 根键；所有字段嵌套在其下
+   - 验证 `pilot_spec:` 下必填字段存在：`implementation`、`setup`、`metrics`、`baseline`、`success_criterion`
+   - 从 `pilot_spec:` 提取：repo、entry_point、modifications、files_to_create、setup（model, dataset, hardware, framework, batch_size, max_steps, learning_rate, seeds, other_hparams）、metrics、baseline、success_criterion、hypothesis、approach_sketch
+
+2. **加载实现上下文**：
+   - 使用 `pilot_spec.hypothesis` 和 `pilot_spec.approach_sketch` 作为主要实现指南（idea 页面由 `/ideate` Phase 4 在预实验之前写入）
+   - 读取相关论文的方法描述（算法细节，来自 `wiki/papers/` 若存在）
+   - 读取源论文 repo 获取基础代码参考
+
+3. **检验数据集以及其余配置**
+   - 数据集在 pilot spec 的 setup 中有指定
+   - 获取数据集路径(根据 --env 参数选择在本地或远程获取)，**可向用户询问本地(远程)的数据集的路径以及自行检索**
+   - 若 数据集不存在，向用户提示，明确**下载数据集的需求**，向用户确认**安装路径**及**下载渠道**
+   - 检查数据集是否完整、可用，明确数据集附带的一些结构、使用说明
+   - 其余配置如：调用LLM的模型名称，url，api key等
+
+4. **编写预实验代码**，写入 `experiments/pilot/code/{slug}/`：
+
+   **代码的编写模块化思想，除非实验规模较小，逻辑简单，否则不要把大量代码放在一个文件里**
+
+   > **预实验目的提醒**：目标是**检测明显失败**（发散、严重退化、根本性不兼容），**不是衡量最终性能**。遵循 Pilot Spec 的缩减配置：batch size = 论文的 1/4–1/8，训练步数 = 完整训练的 10–30%，以便通过较低成本在一定程度上判定idea执行的价值，始终包含 baseline 对比。不要试图优化取得最优结果 — 通过预实验仅意味着"没有明显崩溃""从前中期整体表现看,相较baseline，有提升，基本持平，略差都是可以接受的"。
+
+   预实验代码可能参考的路径:
+   - A路径：可能是在原本的method的论文的repo，基于这个repo进行修改得到预实验代码
+   - B路径：基于有机融合的idea实现组合版（比如看性能/cost是不是达到balance）
+   - C路径：检测共性盲点，打破假设基于新设定，看现有方法在新设定下是不是都失败
+
+   - `train.py`：根据 Pilot Spec 的 `setup` 配置生成训练/评估脚本，包含：
+     - 参数解析（argparse，spec 中所有超参数可配置）
+     - 数据加载（支持 spec 的 `setup.dataset`）
+     - 模型初始化（支持 spec 的 `setup.model` 和 baseline 模型）
+     - 训练/推理循环（遵循 `setup.max_steps` 缩短训练）
+     - 指标计算（对应 spec 的 `metrics` 列表）
+     - 结果保存（JSON 格式，路径：`experiments/pilot/code/{slug}/results/seed_{N}.json`）
+     - 随机种子控制
+   - 其余所需的utils、tools 等代码文件夹或者文件（如 `utils.py`、`data_loader.py` 等）
+   - `config.yaml`：spec 中的所有超参数（learning_rate, batch_size, max_steps 等）
+   - `run.sh`：启动封装脚本（含 CUDA_VISIBLE_DEVICES、logging、conda 激活）
+   - `requirements.txt`：依赖（若与主项目不同）
+
+5. **Sanity check（小规模验证）**：
+   - 用极小规模运行（10 steps / 小 subset）
+   - 验证：代码无 crash、数据加载正确、GPU 可用、loss 有限
+   - 若 sanity 失败 → 修复代码，重试一次；仍然失败则报告错误并停止
+
+
+**Gate： 用户手动检查**
+
+> **注意**：在准备好实验代码，准备部署运行前需向用户确认，申请用户手动检查代码、实验配置相关信息，确认无误后运行，否则需执行修改直到用户确认执行
+
+
+**Phase 2: 运行**
+
+> **预实验目的提醒**：这是一次**短期诊断性运行** — 不是完整实验。运行应快速完成（缩减步数）。若发散或挂起超过预期时间的 2x，这本身就是一个有用的信号。直接报告；不要尝试挽救性重跑。
+
+#### 本地模式（`--env local` 或默认）
+
+1. **检查 GPU**：`nvidia-smi` 确认 GPU 可用、显存足够。若 `setup.hardware` 为 `cpu`/`none`/空且生成代码无 CUDA/GPU 关键字，跳过 GPU 检查直接进入步骤 2。
+2. **估算运行时间**：根据 `setup.hardware`（GPU 型号）、`setup.model`（参数量）、`setup.dataset`（规模）和 `setup.max_steps`（缩减步数）：
+
+   | 典型预实验场景 | 预估时长 |
+   |---------------|---------|
+   | 单 GPU + 小数据集（CIFAR / 小型 NLP benchmark） | 5 – 30 分钟 |
+   | 单 A100 + 中等数据集（ImageNet / GLUE） | 30 分钟 – 2 小时 |
+   | 多 GPU 或大模型微调（≥7B） | 1 – 4 小时 |
+
+
+3. **启动**：
+   ```bash
+   screen -dmS pilot-{slug} bash -c \
+     "cd $(pwd) && bash experiments/pilot/code/{slug}/run.sh 2>&1 | tee experiments/pilot/code/{slug}/pilot.log"
+   ```
+   - 提醒用户："预实验已启动"
+
+4. **监控直到完成**：
+   在终端启用**monitor**对预实验进程进行轮询监控
+
+#### 远程模式（`--env remote`）
+
+**前置条件**：用户已配置 `config/server.yaml`。
+
+1. **确认连接**：`python3 tools/remote.py status`
+   - 若不可达 → 报告错误，建议检查 `config/server.yaml`
+
+2. **查找空闲 GPU**：`python3 tools/remote.py gpu-status`（若 `setup.hardware` 为 `cpu`/`none`/空且代码无 CUDA/GPU 关键字则跳过）
+   - 若无空闲 GPU → 报告各 GPU 使用情况，建议等待或使用 `--env local`
+
+3. **同步代码**：`python3 tools/remote.py sync-code`
+   - 将 pilot 代码目录推送到远程 `work_dir`
+
+4. **估算运行时间**（与本地模式相同的估算逻辑 — 参见上方表格）
+   - 按比例设定轮询间隔（同一表格）
+
+5. **安装依赖**（首次或 requirements 变更时）：
+   ```bash
+   python3 tools/remote.py setup-env --requirements experiments/pilot/code/{slug}/requirements.txt
+   ```
+
+6. **启动远程预实验**：
+   ```bash
+   python3 tools/remote.py launch \
+     --name "pilot-{slug}" \
+     --cmd "bash experiments/pilot/code/{slug}/run.sh" \
+     --gpu {gpu_index} \
+     --log-file "experiments/pilot/code/{slug}/pilot.log"
+   ```
+   - 提醒用户："预实验已启动（远程）"
+
+7. **监控直到完成**：
+  在终端启用**monitor**对预实验进程进行轮询监控
+
+**Phase 3: 收集与报告**
+
+1. **验证运行完成**：确认 screen session `pilot-{slug}` 已结束。若监控后仍在运行，报告并等待。
+
+2. **拉取远程结果**（仅远程模式）：
+   ```bash
+   python3 tools/remote.py pull-results \
+     --remote-path "experiments/pilot/code/{slug}/results/" \
+     --local-path "./experiments/pilot/code/{slug}/results/"
+
+   python3 tools/remote.py pull-results \
+     --remote-path "experiments/pilot/code/{slug}/pilot.log" \
+     --local-path "./experiments/pilot/code/{slug}/"
+   ```
+   若部分文件拉取失败 → 报告缺失的文件，继续使用可用数据。
+
+3. **检查结果文件**：`experiments/pilot/code/{slug}/results/seed_*.json`
+   - 列出可用的结果文件
+   - 若无结果文件存在 → 报告错误 "未产生结果文件（运行可能已崩溃）"
+   - 若结果文件存在但不完整（部分 seeds）→ 使用可用 seeds，在报告中注明
+
+4. **读取预实验日志**：`experiments/pilot/code/{slug}/pilot.log`
+   - 扫描错误、警告、OOM、发散信号
+   - 提取运行时行为上下文供最终报告
+   - 记录 Phase 2 监控期间检测到的异常
+
+5. **解析结果**：
+   - 读取每个结果文件（JSON）
+   - 计算每个 metric 的 mean ± std（跨 seeds）
+   - 与 baseline 的 `expected_value`（来自 Pilot Spec）对比
+   - 计算 delta：`pilot_mean - baseline_expected`
+
+6. **输出 PILOT_REPORT 到终端**：
+   ```markdown
+   # Pilot Report: {slug}
+
+   ## Results
+   | Metric | Baseline | Pilot (mean±std) | Δ |
+   |--------|----------|------------------|---|
+   | {metric} | {baseline-value} | {mean}±{std} | {delta} |
+
+   ## Run Details
+   - Steps completed: {max_steps}
+   - Runtime: {elapsed}
+   - Seeds completed: {N}/{total}
+   - Environment: {local | remote}
+   - Log: experiments/pilot/code/{slug}/pilot.log
+
+   ## Anomalies
+   - {运行期间检测到的异常列表，或"无"}
+
+   ## Next Steps
+   - 进入 /exp-pilot-eval 进行判定评估和 wiki 更新
+   ```
+
+7. **返回**原始结果和关键指标给调用者（如 `/ideate` Phase 5）。**不修改任何 wiki 页面** — 预实验结果由 `/exp-pilot-eval` 评估，不由本 skill 负责。
+
+## Constraints
+
+- **不需要 wiki 实验页面**：从 `experiments/pilot/{slug}.yaml` 读取配置
+- **不写入 wiki 页面**：结果返回给调用者；idea 页面更新由 `/exp-pilot-eval` 负责
+- **代码统一写入 `experiments/pilot/code/{slug}/`**：不写到项目根目录或其他位置
+- **结果文件必须保存**：所有预实验结果以 JSON 格式保存在 `experiments/pilot/code/{slug}/results/seed_{N}.json`
+- **多 seed 结果取均值**：报告 mean ± std，不报告单次运行
+- **sanity check 必须通过**：Phase 1 sanity 失败则报告错误并停止（除非用户明确 override）
+- **graph edges 不在此 skill 创建**：预实验不创建 graph edges
+- **自动修复最多尝试 1 次**：防止无限重启循环
+
+## Error Handling
+
+- **Pilot Spec 找不到**：报告错误，建议先运行 `/ideate` 生成 spec
+- **Pilot Spec 缺少字段**：报告缺失的必填字段，建议重新运行 `/ideate`
+- **GPU 不可用**：报告错误，建议等待 GPU 释放
+- **sanity check 失败**：详细报告错误信息，尝试自动修复一次，仍失败则报告错误并停止
+- **结果文件缺失**：报告错误 "未产生结果文件（运行可能已崩溃）"
+- **screen session 超时**：若 session 超过预期时间的 2x 仍存在，警告用户但不强制终止
+- **远程连接失败**：报告 SSH 错误，建议检查连接配置和 `config/server.yaml`
+- **远程 GPU 不可用**：报告各 GPU 使用情况，建议等待或使用 `--env local`
+- **远程结果拉取失败**：报告缺失的文件，继续使用可用的本地数据
+
+## Dependencies
+
+### Skills (via Skill tool)
+- 无
+
+### Tools (via Bash)
+- `nvidia-smi` — 本地 GPU 状态
+- `screen` — 本地后台运行管理
+- `python3 tools/remote.py <command>` — 远程操作（status, gpu-status, sync-code, setup-env, launch, check, tail-log, pull-results）
+
+### Configuration
+- `config/server.yaml` — 远程服务器配置（仅 `--env remote` 时需要）
+
+### Qoder Native
+- `Read` — 读取 Pilot Spec 和 wiki 页面
+- `Write` — 写入预实验代码到 `experiments/pilot/code/{slug}/`
+- `Bash` — 执行预实验代码、监控进程
+
+### Called by
+- `/ideate` Phase 5
+- 用户手动调用

--- a/.qoder/skills/exp-run/SKILL.md
+++ b/.qoder/skills/exp-run/SKILL.md
@@ -1,0 +1,421 @@
+---
+name: exp-run
+description: 实验执行全流程：准备代码 → 部署运行(运行前需向用户确认，申请用户手动检查) → 监控状态 → 收集结果，支持三种运行模式
+---
+
+# /exp-run
+
+> **用法**：`<experiment-slug> [--review] [--collect] [--full] [--env local|remote]`
+
+
+> 执行 wiki/experiments/ 中已规划的实验。
+> **不论是哪种运行模式，在准备好实验代码，准备部署运行前需向用户确认，申请用户手动检查代码、实验配置(如数据集路径，接口参数选择，API 配置等)相关信息，确认无误后运行，否则需执行修改直到用户确认执行**
+> **三种运行模式**，适应不同场景：
+> - **默认（deploy）**：仅 Phase 1-2，部署后立即返回，适合需要数小时/天的实验。
+> - **`--collect`**：仅 Phase 3-4，检查已部署实验是否完成，完成则收集结果（`--check` 为 alias）。
+> - **`--full`**：完整 Phase 1-4，适合几分钟内即可完成的本地快速实验。
+>
+> 推荐流程：`/exp-run <slug>` 部署 → `/exp-status` 监控 → `/exp-run <slug> --collect` 收集。
+
+## Inputs
+
+- `experiment`：wiki/experiments/ 中的 slug
+  - deploy 模式：status 必须为 `planned`
+  - --collect 模式：status 必须为 `running`
+  - --full 模式：status 必须为 `planned`
+- `--review`（可选）：Phase 1 中启用 Review LLM code review 审查实验代码（deploy / full 模式有效）
+- `--collect`（可选）：collect 模式——检查实验是否完成，完成则收集结果；`--check` 是 alias
+- `--full`（可选）：完整模式——执行全部 4 个 Phase（适合快速本地实验）
+- `--env local|remote`（可选，默认 `local`）：部署环境
+  - `local`：本机 GPU 直接运行
+  - `remote`：通过 SSH 部署到远程机器（需 `config/server.yaml`）
+
+## Outputs
+
+- **deploy 模式**：
+  - 实验代码：`experiments/code/{slug}/`（Phase 1 生成）
+  - `wiki/experiments/{slug}.md` — status: planned → running
+  - **DEPLOY_REPORT**（输出到终端）— 部署确认、session 信息、下一步指引
+  - `wiki/log.md` — 追加部署日志
+- **collect 模式**（实验已完成时）：
+  - `wiki/experiments/{slug}.md` — status: running → completed，填充 outcome/key_result/date_completed
+  - **RUN_REPORT**（输出到终端）— 结果摘要、metrics 对比、下一步建议
+  - `wiki/log.md` — 追加收集日志
+- **collect 模式**（实验仍在运行时）：
+  - 仅输出进度报告到终端，不修改 wiki
+- **full 模式**：同 deploy + collect 的全部输出
+
+## Wiki Interaction
+
+### Reads
+- `wiki/experiments/{slug}.md` — 实验配置：setup、metrics、baseline、hypothesis、linked_idea
+- `wiki/ideas/{linked-idea}.md` — 关联 idea 的 approach sketch（指导代码实现，理解实验目的）
+- `wiki/papers/*.md` — 相关论文的方法细节和超参数（参考实现）
+- `wiki/experiments/*.md` — 同一 idea 的其他实验（参考 setup、避免重复错误）
+
+### Writes
+- `experiments/code/{slug}/` — 实验代码目录（Phase 1 生成，deploy / full 模式）
+  - `experiments/code/{slug}/train.py` — 主训练/推理脚本
+  - `experiments/code/{slug}/config.yaml` — 超参数配置文件
+  - `experiments/code/{slug}/run.sh` — 启动封装脚本（含 CUDA_VISIBLE_DEVICES 等）
+  - `experiments/code/{slug}/requirements.txt` — 依赖（若与主项目不同）
+- `wiki/experiments/{slug}.md` — 更新 status、outcome、key_result、date_completed、run_log、remote 块（deploy / collect 模式）
+- `wiki/log.md` — 追加操作日志
+
+### Graph edges created
+- **无**。实验与 idea 之间的 tested_by 边已在 /exp-design 中创建。
+
+## Workflow
+
+**前置**：确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）。
+
+---
+
+### Deploy 模式（默认，status == planned）
+
+**Phase 1: 准备（Prepare）**
+
+1. **读取实验页面**：
+   - `wiki/experiments/{slug}.md`：提取 setup（model, dataset, hardware, framework）、metrics、baseline、hypothesis
+   - 验证 status == `planned`
+   - 若 status 为 `running`，提示用户使用 `--collect` 模式
+   - 若 status 为 `completed`/`abandoned`，拒绝执行
+
+2. **加载实现上下文**：
+   - 读取关联 idea 的 approach sketch（实现指南）
+   - 读取相关论文的方法描述（算法细节）
+   - 读取同一 idea 的其他实验（参考代码结构）
+
+3. **检验数据集以及其余配置**
+   - 数据集在`wiki/experiments/{slug}.md`的setup 中有指定
+   - 获取数据集路径(根据 --env 参数选择在本地或远程获取)，**可向用户询问本地(远程)的数据集的路径以及自行检索**
+   - 若 数据集不存在，向用户提示，明确**下载数据集的需求**，向用户确认**安装路径**及**下载渠道**
+   - 检查数据集是否完整、可用，明确数据集附带的一些结构、使用说明
+   - 其余配置如：调用LLM的模型名称，url，api key等
+
+4. **编写实验代码**，统一写入 `experiments/code/{slug}/`：
+   **代码的编写模块化思想，除非实验规模较小，逻辑简单，否则不要把大量代码放在一个文件里**
+   - `train.py`：根据 setup 配置生成训练/评估脚本，作为程序的入口，包含：
+     - 参数解析（argparse，所有超参数可配置）
+     - 数据加载（支持 setup.dataset）
+     - 模型初始化（支持 setup.model 和 baseline 模型）
+     - 训练/推理循环
+     - 指标计算（对应 metrics 列表）
+     - 结果保存（JSON 格式，路径：`results/{slug}/seed_{N}.json`）
+     - 随机种子控制（多 seed 运行）
+     - Checkpoint 保存/恢复（`checkpoints/{slug}/`）
+   - 其余所需的utils、tools 等代码文件夹或者文件（如 `utils.py`、`data_loader.py` 等）
+   - `config.yaml`：所有超参数（learning_rate, batch_size, epochs, seeds 等）
+   - `run.sh`：封装完整启动命令（含 CUDA_VISIBLE_DEVICES、logging、conda 激活）
+   - `requirements.txt`：实验专属依赖（若与主项目 requirements 不同）
+
+5. **可选 Review LLM code review**（`--review`）：
+   ```
+   llm-review.chat:
+     system: "You are a senior ML engineer reviewing experiment code.
+              Focus on: correctness of the training loop, proper evaluation protocol,
+              fair baseline comparison, reproducibility (seeds, determinism),
+              proper metric computation, and common pitfalls (data leakage,
+              wrong split, gradient accumulation bugs)."
+     message: |
+       ## Experiment
+       {experiment title and hypothesis}
+
+       ## Code
+       {generated code}
+
+       ## Expected Behavior
+       {setup details from wiki page}
+
+       Review for correctness and potential issues.
+   ```
+   根据 Review LLM 反馈修正代码。
+
+6. **Sanity check（小规模验证）**：
+   - 用极小规模运行（1 epoch / 100 steps / 小 subset）
+   - 验证：代码无 crash、数据加载正确、GPU 可用、loss 下降
+   - 若 sanity 失败 → 修复代码，重试一次；仍然失败则报告错误并停止
+
+
+**Gate： 用户手动检查**
+
+> **注意**：在准备好实验代码，准备部署运行前需向用户确认，申请用户手动检查代码、实验配置(数据集路径，接口参数选择，API 配置等)相关信息，确认无误后运行，否则需执行修改直到用户确认执行
+
+
+**Phase 2: 部署（Deploy）**
+
+#### Local 模式（`--env local` 或默认）
+
+1. **检查 GPU**：`nvidia-smi` 确认 GPU 可用、显存足够。若 `setup.hardware` 为 `cpu`/`none`/空且生成代码无 CUDA/GPU 关键字，跳过 GPU 检查直接进入步骤 2。
+2. **启动**：
+   ```bash
+   screen -dmS exp-{slug} bash -c \
+     "cd $(pwd) && bash experiments/code/{slug}/run.sh 2>&1 | tee logs/exp-{slug}.log"
+   ```
+3. 更新 `wiki/experiments/{slug}.md`：
+   - status: `running`
+   - run_log: `logs/exp-{slug}.log`
+4. **估算运行时长**，写入 frontmatter：
+   根据 `setup.hardware`（GPU 型号/数量）、`setup.model`（参数量）、`setup.dataset`（规模）合理估算：
+
+   | 典型场景 | 估算范围 |
+   |----------|----------|
+   | 单 GPU + 小数据集（CIFAR / 小 NLP benchmark） | 0.5 – 3h |
+   | 单 A100 + 中等数据集（ImageNet / GLUE） | 4 – 12h |
+   | 多 GPU 或大模型 fine-tuning（≥7B） | 8 – 48h |
+
+   ```bash
+   python3 tools/research_wiki.py set-meta \
+     wiki/experiments/{slug}.md started "{YYYY-MM-DDTHH:MM}"
+   python3 tools/research_wiki.py set-meta \
+     wiki/experiments/{slug}.md estimated_hours {N}
+   ```
+5. 追加日志：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ \
+     "exp-run | deployed {slug} | env: local | session: exp-{slug} | eta: {N}h"
+   ```
+
+#### Remote 模式（`--env remote`）
+
+**前提**：用户已配置 `config/server.yaml`。
+
+1. **确认连通**：`python3 tools/remote.py status`
+   - 若不可达 → 报错并建议检查 config/server.yaml
+2. **查找空闲 GPU**：`python3 tools/remote.py gpu-status`（若 `setup.hardware` 为 `cpu`/`none`/空且代码无 CUDA/GPU 关键字则跳过）
+   - 若无空闲 GPU → 报告各 GPU 占用情况，建议等待
+3. **同步代码**：`python3 tools/remote.py sync-code`
+4. **安装依赖**（首次或 requirements 有变化）：`python3 tools/remote.py setup-env`
+5. **启动远程实验**：
+   ```bash
+   python3 tools/remote.py launch \
+     --name "exp-{slug}" \
+     --cmd "bash experiments/code/{slug}/run.sh" \
+     --gpu {gpu_index}
+   ```
+6. 更新 `wiki/experiments/{slug}.md` frontmatter —— 以下字段已由 /exp-design 写入完整 CLAUDE.md 模板,都是空值:
+   ```bash
+   # 顶层 scalar 字段 —— 用 set-meta
+   python3 tools/research_wiki.py set-meta wiki/experiments/{slug}.md status running
+   python3 tools/research_wiki.py set-meta wiki/experiments/{slug}.md run_log "logs/exp-{slug}.log"
+   ```
+
+   嵌套 `remote:` 块无法通过 `set-meta` 更新（set-meta 只处理顶层 scalar 字段）。直接用 `Edit` 工具就地替换这五个空的子字段值。文件里已有的 block 形如：
+   ```yaml
+   remote:
+     server: ""
+     gpu: ""
+     session: ""
+     started: ""
+     completed: ""
+   ```
+   用 5 次 Edit 调用（每个子字段一次）设置 `server`、`gpu`、`session`、`started`。`completed: ""` 留空由 Phase 4 填写。如果发现文件里没有 `remote:` block,说明 /exp-design 没写完整的 CLAUDE.md 模板;停下来报 bug,不要在这里追加 block（追加会让字段顺序偏离 canonical 模板,破坏后续 edit 的匹配）。
+7. **估算运行时长**，写入 frontmatter（同 local 模式估算逻辑）：
+   ```bash
+   python3 tools/research_wiki.py set-meta \
+     wiki/experiments/{slug}.md started "{YYYY-MM-DDTHH:MM}"
+   python3 tools/research_wiki.py set-meta \
+     wiki/experiments/{slug}.md estimated_hours {N}
+   ```
+8. 追加日志：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ \
+     "exp-run | deployed {slug} | env: remote | server: {host} | gpu: {gpu} | eta: {N}h"
+   ```
+
+**输出 DEPLOY_REPORT 到终端**：
+
+```markdown
+# Deploy Report: {experiment title}
+
+### Status: DEPLOYED ✅
+
+- Session: exp-{slug}
+- Environment: local | remote ({host} GPU {gpu})
+- Log file: logs/exp-{slug}.log
+- Code: experiments/code/{slug}/
+- Estimated: ~{N}h（预计完成于 {YYYY-MM-DD HH:MM}）
+
+### Next Steps
+
+1. Monitor progress: `/exp-status`
+2. Check this experiment: `/exp-run {slug} --collect`
+3. In /research pipeline: progress saved to wiki/outputs/pipeline-progress.md
+
+### Quick Commands
+```bash
+# Local: check if still running
+screen -ls | grep exp-{slug}
+
+# Local: tail log
+tail -f logs/exp-{slug}.log
+```
+```
+
+---
+
+### Collect 模式（`--collect` 或 `--check`，status == running）
+
+**Phase 3: 监控/检查运行状态（Monitor）**
+
+1. **读取部署信息**：从 `wiki/experiments/{slug}.md` frontmatter 获取环境（local 或 remote）和 session 名。
+
+2. **检查进程是否还活着**：
+   - **Local**：`screen -ls | grep exp-{slug}`
+   - **Remote**：`python3 tools/remote.py check --name "exp-{slug}"`，解析 `alive` 字段
+
+3. **若实验仍在运行（alive == true）**：
+   - 获取最近日志：
+     - Local：`tail -30 logs/exp-{slug}.log`
+     - Remote：`python3 tools/remote.py tail-log --name "exp-{slug}" --lines 30`
+   - **异常检测**：
+     - NaN loss：检测 `loss: nan`
+     - OOM：`CUDA out of memory`
+     - Traceback：Python 异常堆栈
+     - Inf loss：`loss: inf`
+   - **自动修复尝试**（若检测到异常，最多 1 次）：
+     - NaN/爆炸 → 从最近 checkpoint 恢复，降低学习率
+     - OOM → 减小 batch size，重启
+   - **输出进度报告**（不修改 wiki，仅报告）：
+     ```
+     Experiment {slug}: RUNNING
+     Progress: step {N} / epoch {E}
+     Latest metric: {metric} = {value}
+     Anomalies: {none | NaN detected | ...}
+     Estimated remaining: ~{N} hours
+     Run `/exp-status` to monitor all running experiments.
+     ```
+   - **返回**（不执行 Phase 4）
+
+4. **若实验已完成（alive == false / session gone）**：
+   - 继续执行 Phase 4
+
+**Phase 4: 收集结果（Collect Results）**
+
+1. **拉取远程结果**（仅 remote 模式）：
+   ```bash
+   python3 tools/remote.py pull-results \
+     --remote-path "results/{slug}/" \
+     --local-path "./results/{slug}/"
+
+   python3 tools/remote.py pull-results \
+     --remote-path "logs/exp-{slug}.log" \
+     --local-path "./logs/"
+   ```
+
+2. **检查结果文件存在**：`results/{slug}/seed_*.json`
+
+3. **解析结果**：
+   - 读取结果文件（JSON）
+   - 计算每个 metric 的 mean ± std（跨 seeds）
+   - 与 baseline 对比，计算提升幅度
+
+4. **更新实验页面** `wiki/experiments/{slug}.md`：
+   - status: `completed`
+   - outcome: `succeeded` / `failed` / `inconclusive`
+     - succeeded：所有 success criteria 满足
+     - failed：核心指标未达标
+     - inconclusive：结果混合或方差过大
+   - key_result: 一句话总结核心发现
+   - date_completed: 今天日期
+   - 填充 `## Results` section：完整结果表格
+   - 填充 `## Analysis` section：初步分析
+   - 若 remote 模式：更新 `remote.completed` 时间戳
+
+5. **追加日志**：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ \
+     "exp-run | completed {slug} | outcome: {outcome} | key: {key_result}"
+   ```
+
+6. **输出 RUN_REPORT 到终端**：
+   ```markdown
+   # Run Report: {experiment title}
+
+   ## Outcome: {succeeded / failed / inconclusive}
+
+   ## Results
+   | Metric | Baseline | Ours (mean±std) | Δ |
+   |--------|----------|-----------------|---|
+   | {metric} | {baseline-value} | {mean}±{std} | +{delta} |
+
+   ## Key Finding
+   {key_result}
+
+   ## Next Steps
+   - Run `/exp-eval {slug}` to update the linked idea in wiki
+   - {if succeeded: proceed to next experiment in plan}
+   - {if failed: analyze failure, consider /exp-design revision}
+   ```
+
+---
+
+### Full 模式（`--full`，status == planned）
+
+依次执行全部 4 个 Phase（Phase 1 → Phase 2 → Phase 3 → Phase 4），中间不返回。
+
+适用场景：本地 CPU/GPU 几分钟内可完成的快速实验（sanity check、toy dataset 验证等）。
+
+Phase 3 中不需要先检查 "是否还在运行"，而是等待 screen session 真正结束后再执行 Phase 4：
+```bash
+# 等待 session 结束（轮询）
+while screen -ls | grep -q "exp-{slug}"; do
+  sleep 30
+done
+# session 消失，进入 Phase 4
+```
+
+---
+
+## Constraints
+
+- **deploy 模式只接受 planned 实验**：若 status 为 running，提示使用 --collect；若为 completed，拒绝执行
+- **collect 模式只接受 running 实验**：若 status 为 planned，提示先 deploy；若为 completed，提示已完成
+- **collect 模式：alive 时不写 wiki**：仅报告进度，不修改任何 wiki 文件
+- **代码统一写入 experiments/code/{slug}/**：不写到项目根目录或其他位置
+- **不修改 idea 状态**：实验结果只写入 experiments/ 页面；idea 的 status 由 /exp-eval 负责更新
+- **sanity check 必须通过**：Phase 1 sanity 失败则不部署（除非用户明确 override）
+- **结果文件必须保存**：所有实验结果以 JSON 格式保存在 `results/{slug}/seed_{N}.json`
+- **多 seed 结果取均值**：报告 mean ± std，不报告单次运行
+- **graph edges 不在此 skill 创建**：tested_by 边已在 /exp-design 中创建
+- **自动修复最多尝试 1 次**：防止无限重启循环
+
+## Error Handling
+
+- **experiment 找不到**：提示用户检查 slug，列出 wiki/experiments/ 中的候选（status=planned 或 running）
+- **deploy 模式但 status == running**：提示 "已在运行中，使用 `/exp-run {slug} --collect` 检查状态"
+- **collect 模式但 status == completed**：提示 "已完成，直接运行 `/exp-eval {slug}`"
+- **GPU 不可用**：报告错误，建议用 --env remote 或等待 GPU 释放
+- **Review LLM 不可用**（--review 模式）：跳过 code review，在 DEPLOY_REPORT 中标注「unreviewed」
+- **sanity check 失败**：详细报告错误信息，尝试自动修复一次，仍失败则停止并建议手动调试
+- **远程连接失败**：报告 SSH 错误，建议检查连接配置和 config/server.yaml
+- **结果文件缺失**（collect 模式）：报告哪些 seeds 缺失结果，对已有结果正常汇总；若成功 seeds < 2 则标记 inconclusive
+- **实验 crash**（collect 模式检测到 traceback）：在报告中附上 crash 信息和建议修复方向
+- **--full 模式等待超时**：若 screen session 超过预期时间的 2x 仍存在，警告用户但不强制终止
+
+## Dependencies
+
+### Skills（via Skill tool）
+- 无直接调用子 skill
+
+### Tools（via Bash）
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+- `python3 tools/remote.py <command>` — 远程操作（status, gpu-status, sync-code, setup-env, launch, check, tail-log, pull-results）
+- `nvidia-smi` — 本地 GPU 状态
+- `screen` — 本地后台运行管理
+
+### Configuration
+- `config/server.yaml` — 远程服务器配置（仅 `--env remote` 时需要）
+
+### MCP Servers
+- `llm-review.chat` — Phase 1 代码审查（可选，`--review` 时使用）
+
+### Qoder Native
+- `Read` — 读取 wiki 页面和日志文件
+- `Write` — 写入 `experiments/code/{slug}/` 下的实验代码
+- `Bash` — 执行部署命令、监控进程
+
+### Called by
+- `/research` Stage 3a（deploy 模式）和 Stage 3c（collect 模式）
+- `/exp-status --collect-ready`（collect 模式）
+- 用户手动调用

--- a/.qoder/skills/exp-status/SKILL.md
+++ b/.qoder/skills/exp-status/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: exp-status
+description: 查看所有运行中实验的状态，可选自动收集已完成实验并推进流水线
+---
+
+# /exp-status
+
+> **用法**：`[--pipeline <slug>] [--collect-ready] [--auto-advance]`
+
+
+> 统一的实验状态监控入口。
+> 扫描所有 `running` 实验，对每个实验执行实时状态检查（screen session / SSH），
+> 输出状态表（alive / anomaly / completed），引导用户下一步操作。
+>
+> 与 `/research --auto` 配合时作为 CronCreate 调度的定期检查器：
+> 当 pipeline 的所有实验都完成时，自动触发 `/research --start-from stage4`。
+
+## Inputs
+
+- 无参数（默认）：检查所有 `running` 实验，输出状态表
+- `--pipeline <slug>`（可选）：只检查属于指定 pipeline 的实验，额外输出 pipeline 整体进度
+- `--collect-ready`（可选）：对所有"session 已消失"的实验自动调用 `/exp-run --collect` 收集结果
+- `--auto-advance`（可选，需配合 `--pipeline <slug>`）：若 pipeline 所有实验均已 `completed`，
+  自动触发 `/research --start-from stage4`，无需用户手动运行
+
+## Outputs
+
+- **状态报告**（终端输出，所有模式）：running/anomaly/completed 三种状态的实验列表
+- `wiki/experiments/{slug}.md` — `--collect-ready` 触发 Phase 4 时更新（outcome/key_result/status）
+- `wiki/outputs/pipeline-progress.md` — `--auto-advance` 时更新 current_stage → stage4（由 /research --start-from stage4 内部完成）
+- `wiki/log.md` — 追加状态检查日志
+
+## Wiki Interaction
+
+### Reads
+- `wiki/experiments/*.md` — status、remote frontmatter（server/session/started）、date_planned
+- `wiki/outputs/pipeline-progress.md` — `--pipeline` 模式下识别目标实验和 monitoring_cron_id
+
+### Writes
+- `wiki/experiments/{slug}.md` — `--collect-ready` 模式下通过 /exp-run --collect 触发更新
+- `wiki/outputs/pipeline-progress.md` — `--auto-advance` 触发 Stage 4 时由 /research 更新
+- `wiki/log.md` — 追加状态检查日志
+
+### Graph edges created
+- 无（通过 /exp-run --collect 间接触发的结果写入不产生新 edges）
+
+## Workflow
+
+**前置**：确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）。
+
+### Step 1: 收集目标实验列表
+
+1. **确定检查范围**：
+   - 若指定 `--pipeline <slug>`：
+     - 读取 `wiki/outputs/pipeline-progress.md`，提取 `stage3a_deployed` 字段的 slug 列表
+     - 若文件不存在或 slug 不匹配：报错，建议先运行 `/research` 或手动指定
+   - 否则：
+     - 用 Glob 扫描 `wiki/experiments/*.md`，过滤 `status == running` 的实验
+
+2. **若无 running 实验**：
+   - 输出友好提示：
+     ```
+     No running experiments found.
+     - To start an experiment: /exp-run <slug>
+     - To see all experiments: check wiki/experiments/
+     ```
+   - 返回
+
+### Step 2: 逐实验状态检查
+
+对每个目标实验并行（或依次）执行：
+
+1. **读取实验页面**：从 `wiki/experiments/{slug}.md` 获取：
+   - `remote` 块（有则为 remote 实验）
+   - `run_log` 路径
+   - `started`（来自 `remote.started` 或 `date_planned`，用于计算 elapsed）
+   - 部署环境（有 remote 块 → remote，否则 → local）
+
+2. **检查进程状态**：
+   - **Local**：`screen -ls | grep "exp-{slug}"`
+     - 有结果 → `alive: true`
+     - 无结果 → `alive: false`（session 已消失）
+   - **Remote**：`python3 tools/remote.py check --name "exp-{slug}"`
+     - 解析 JSON：`alive`、`last_lines`、`anomalies`
+
+3. **若 alive == true**：
+   - 获取最近日志（最多 20 行）：
+     - Local：`tail -20 {run_log}`
+     - Remote：使用 `check` 命令返回的 `last_lines`
+   - 提取最新 metric（loss、accuracy、step 等——grep 最后一个 metric 行）
+   - 检测异常（NaN/OOM/Traceback/Inf）：使用 `remote.py check` 的 `anomalies` 字段（remote），或手动 grep（local）
+   - 计算 elapsed time（当前时间 - started）
+   - 分类为：`running` 或 `anomaly`
+
+4. **若 alive == false**：
+   - 分类为：`completed_pending_collect`（session 消失但 wiki 状态还是 running）
+   - 若 wiki status 已经是 `completed`：归为 `collected` 类
+
+5. **汇总结果**：构建状态字典 `{slug: {state, elapsed, latest_metric, anomalies}}`
+
+### Step 3: 输出状态报告
+
+```markdown
+# Experiment Status — {YYYY-MM-DD HH:MM}
+
+### 🔄 Running ({N})
+| Experiment | Elapsed | Latest | Env |
+|-----------|---------|--------|-----|
+| [[exp-foo-baseline]] | 2.3h | loss: 0.42 | local |
+| [[exp-foo-validation]] | 1.1h | step: 1200 | remote (gpu1) |
+
+### ⚠️ Anomaly Detected ({N})
+| Experiment | Elapsed | Issue | Action |
+|-----------|---------|-------|--------|
+| [[exp-foo-ablation]] | 0.8h | NaN loss at step 500 | Run `/exp-run exp-foo-ablation --collect` to inspect |
+
+### ✅ Completed — Pending Collect ({N})
+| Experiment | Finished (estimate) |
+|-----------|---------------------|
+| [[exp-foo-sanity]] | session gone |
+
+### 📦 Already Collected ({N})
+| Experiment | Outcome |
+|-----------|---------|
+| [[exp-foo-old]] | succeeded |
+
+---
+### Actions
+```bash
+# Collect all completed experiments at once:
+/exp-status --collect-ready
+
+# Collect a specific experiment:
+/exp-run exp-foo-sanity --collect
+
+# Pipeline progress (if in /research):
+/exp-status --pipeline {pipeline-slug}
+```
+```
+
+追加日志：
+```bash
+python3 tools/research_wiki.py log wiki/ \
+  "exp-status | running: {N}, anomaly: {M}, pending-collect: {K}"
+```
+
+### Step 4: --collect-ready 自动收集（若指定）
+
+对每个 `completed_pending_collect` 实验，调用 `/exp-run --collect`：
+
+```
+Skill: exp-run
+Args: "{slug} --collect"
+```
+
+依次（不并行，避免并发写入 wiki）收集每个完成的实验。
+
+收集完成后，重新输出更新的状态报告。
+
+### Step 5: --auto-advance Pipeline 推进（若同时指定 --pipeline 和 --auto-advance）
+
+1. **检查 pipeline 完成条件**：
+   - 读取 `wiki/outputs/pipeline-progress.md` 的 `stage3a_deployed` 列表
+   - 检查每个 slug 对应的 `wiki/experiments/{slug}.md` 的 status
+   - **条件成立**：所有 experiments 的 status == `completed`
+
+2. **若条件不成立**（仍有 running 或 pending-collect 实验）：
+   - 输出当前进度：`Pipeline {slug}: {M}/{N} experiments completed`
+   - 返回（不推进）
+   - cron 将在 30 分钟后再次运行
+
+3. **若条件成立（所有实验已 completed）**：
+
+   a. **输出通知并触发 Stage 4**：
+   - 输出：
+     ```
+     ✅ All experiments completed for pipeline {slug}!
+     Advancing to Stage 4 (Verdict & Iteration)...
+     ```
+   - 追加日志：
+     ```bash
+     python3 tools/research_wiki.py log wiki/ \
+       "exp-status | pipeline {slug}: all experiments done, advancing to stage4"
+     ```
+   - 触发下一阶段：
+     ```
+     Skill: research
+     Args: "--start-from stage4"
+     ```
+
+## Constraints
+
+- **只读非 --collect-ready 模式**：无 `--collect-ready` 时不修改任何 wiki 文件
+- **`--auto-advance` 必须配合 `--pipeline`**：单独使用 `--auto-advance` 无效，报错提示
+- **状态检查不阻塞**：每个实验的检查应快速完成（单次 SSH check 或 screen -ls）
+- **anomaly 不自动修复**：`/exp-status` 只报告 anomaly，修复由用户手动调用 `/exp-run --collect` 处理
+- **pipeline-progress.md 必须存在**：`--pipeline` 模式下，文件不存在则报错
+
+## Error Handling
+
+- **无运行中实验（No running experiments）**：友好提示，不报错，给出下一步建议
+- **`--pipeline` 但 pipeline-progress.md 不存在**：报错 "Pipeline progress file not found. Run `/research <direction>` first or check wiki/outputs/"
+- **`--auto-advance` 无 `--pipeline`**：报错 "–-auto-advance requires --pipeline <slug>"
+- **SSH 连接失败**（remote 实验）：标记该实验为 `check_failed`，在报告中注明，继续检查其他实验
+- **screen -ls 无输出**：不代表实验失败，可能是轻微延迟；标记为 `completed_pending_collect`
+- **`/exp-run --collect` 失败**（`--collect-ready` 模式）：记录失败，继续收集其他实验，最后报告失败列表
+
+## Dependencies
+
+### Skills（via Skill tool）
+- `/exp-run` — `--collect-ready` 模式下调用 collect 阶段
+- `/research` — `--auto-advance` 触发 Stage 4
+
+### Tools（via Bash）
+- `python3 tools/remote.py check --name "exp-{slug}"` — remote 实验状态检查
+- `python3 tools/remote.py tail-log --name "exp-{slug}" --lines 20` — remote 日志获取
+- `python3 tools/research_wiki.py set-meta <path> <field> <value>` — 更新 pipeline-progress
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+- `screen -ls` — local 进程状态
+- `tail -20 {log}` — local 日志获取
+
+### Qoder Native
+- `Read` — 读取实验页面和 pipeline-progress
+- `Write` — pipeline-progress 状态更新
+- `Glob` — 扫描 wiki/experiments/*.md
+- `Bash` — screen/tail 等系统命令
+- `Skill` — 调用 /exp-run --collect 和 /research
+
+### Called by
+- CronCreate 调度（由 `/research --auto` Stage 3b 创建：每 30 分钟触发一次）
+- 用户手动调用
+- `/research` Stage 3b（交互模式下建议用户调用）

--- a/.qoder/skills/ideate/SKILL.md
+++ b/.qoder/skills/ideate/SKILL.md
@@ -1,0 +1,535 @@
+---
+name: ideate
+description: 多阶段研究 idea 生成管道：景观扫描 → 双模型脑暴 → 筛选与验证 → 写入 wiki → 预实验
+---
+
+# /ideate
+
+> **用法**：`[research-direction-or-topic] [--max-ideas N] [--skip-validation] [--skip-pilot] [--auto]`
+
+
+> 基于 wiki 知识库和外部搜索，通过 5 阶段管道生成高质量研究 idea。
+> Phase 1 扫描研究景观（wiki + WebSearch + S2），Phase 2 双模型脑暴（Claude + Review LLM 独立生成），
+> Phase 3 初步筛选 + 深度验证（可行性、novelty、review），Phase 4 将 ideas 写入 wiki（包括被淘汰的 ideas，记录原因作为 anti-repetition 记忆），
+> Phase 5 对幸存 ideas 进行预实验（idea 页面已存在）并更新结果。
+
+## Inputs
+
+- `direction`（可选）：研究方向、关键词或具体问题描述。若不指定，则从 open_questions.md 自动选择最有价值的方向。
+- `--max-ideas N`（可选，默认 3）：最终写入 wiki 的 idea 数量上限
+- `--skip-validation`：跳过 Phase 3 步骤 2 深度验证（跳过 /novelty 和 /review，快速模式仅做初步筛选）
+- `--skip-pilot`：跳过 Phase 5 预实验（快速模式，仅做 Phase 1-4）
+- `--auto`：全自动模式，不暂停等待用户确认（用于 /research 调用）
+
+## Outputs
+
+- `wiki/ideas/{slug}.md` — 每个 idea 一个页面（status: proposed），包含 top ideas 和被淘汰的 ideas
+- `wiki/graph/edges.jsonl` — 新增 idea → concept/topic 的关系边
+- `wiki/graph/context_brief.md` — 重建后的压缩上下文
+- `wiki/graph/open_questions.md` — 重建后的知识缺口图
+- **IDEA_REPORT**（输出到终端）— 管道执行摘要、排名结果、novelty 评分
+
+## Wiki Interaction
+
+### Reads
+- `wiki/graph/context_brief.md` — 全局上下文
+- `wiki/graph/open_questions.md` — 知识缺口，驱动 idea 方向
+- `wiki/ideas/*.md` — 已有 ideas，特别是 status=failed 的 ideas 及 failure_reason（banlist）
+- `wiki/papers/*.md` — 已有论文方法和结果
+- `wiki/concepts/*.md` — 技术概念，寻找跨领域组合机会
+- `wiki/methods/*.md` — 可复用 method，圈定候选灵感来源
+- `wiki/topics/*.md` — 研究方向地图，SOTA 和 open problems（含 `### Known gaps` 与 `### Methodological gaps`）
+- `wiki/experiments/*.md` — 已有实验结果，避免重复
+
+### Writes
+- `wiki/ideas/{slug}.md` — 创建新 idea 页面
+- `wiki/graph/edges.jsonl` — 添加 idea → concept/topic 的关系边（addresses_gap, inspired_by）
+- `wiki/graph/context_brief.md` — 重建
+- `wiki/graph/open_questions.md` — 重建
+- `wiki/log.md` — 追加操作日志
+
+### Graph edges created
+- `addresses_gap`：idea → concept/topic（idea 针对的知识缺口 — `origin_gaps` 字段）
+- `inspired_by`：idea → paper/method/concept（idea 的灵感来源）
+
+## Workflow
+
+**前置**：
+1. 确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）
+2. **检查 wiki 成熟度**：
+   ```bash
+   python3 tools/research_wiki.py maturity wiki/ --json
+   ```
+   根据 maturity level 调整后续行为：
+   - **cold**：Phase 1 外部搜索扩展（WebSearch 查询从 5 增至 8，S2/DeepXiv limit 从 20 增至 30），
+     跳过 wiki 内部上下文加载（为空无意义），标注 "cold-start mode: heavier external search"
+   - **warm**：标准行为（当前默认）
+   - **hot**：Phase 1 外部搜索缩减（WebSearch 查询从 5 降至 2，S2/DeepXiv limit 从 20 降至 10），
+     Phase 3 gap_alignment_bonus 从 +2 提升到 +3，优先解决 topic / concept open-problem 章节中已经枚举的 gap
+3. **Snapshot wiki 状态**（用于结束时的 Growth Report）：
+   保存 maturity 返回的 JSON 到内存变量 `maturity_before`
+
+### Phase 1: 景观扫描（Landscape Scan）
+
+目标：构建目标领域的全面视角，包括已有工作、知识缺口和最新进展。
+
+1. **加载 wiki 内部上下文**：
+   - 读取 `wiki/graph/context_brief.md`（全局压缩上下文）
+   - 读取 `wiki/graph/open_questions.md`（知识缺口列表）
+   - 读取所有 `wiki/ideas/*.md`，提取：
+     - status=failed 的 ideas → **banlist**（含 failure_reason）
+     - status=proposed/in_progress 的 ideas → **active list**（避免重复）
+   - 读取 `wiki/topics/*.md` 与 `wiki/concepts/*.md`：收集 `## Open problems` 下（包括 `### Known gaps` 与 `### Methodological gaps`）的 bullet → **gap candidates list**
+   - 若 `direction` 指定，过滤与方向相关的子集
+
+2. **外部搜索**（使用 Agent tool 并行）：
+   - **WebSearch**：搜索目标方向最近 6 个月的论文和进展（3-5 个查询）
+   - **Semantic Scholar**：
+     ```bash
+     python3 tools/fetch_s2.py search "<direction-keywords>" --limit 20
+     ```
+     对 top 5 高引论文获取详情
+   - **DeepXiv 语义搜索**：
+     ```bash
+     python3 tools/fetch_deepxiv.py search "<direction-keywords>" --mode hybrid --limit 20
+     ```
+     对 top 5 高相关结果获取 TLDR 和关键词：
+     ```bash
+     python3 tools/fetch_deepxiv.py brief <arxiv_id>
+     ```
+     语义搜索补充 S2 关键词搜索可能遗漏的概念相关论文。
+   - **DeepXiv 热门论文**：
+     ```bash
+     python3 tools/fetch_deepxiv.py trending --days 14
+     ```
+     热门论文指示社区关注热点，有助于发现趋势性 gap。
+   - **arXiv 最新**：`site:arxiv.org <direction> 2025 2026`
+   - **若 DeepXiv 不可用**：跳过 DeepXiv 搜索和 trending，仅依赖 S2 + WebSearch（回退到原有行为）。
+
+3. **汇总景观报告**（内部使用，不写入 wiki）：
+   - 当前 SOTA 方法及性能
+   - 已知的 open problems / 未解决的 challenges
+   - 最近的趋势和热点
+   - wiki 中的知识缺口（from gap_map）
+   - 被禁止的方向（from banlist）
+
+### Phase 2: 双模型脑暴（Dual-Model Brainstorm）
+
+目标：通过 Claude 和 Review LLM 独立生成 ideas，利用不同模型的视角差异获得多样性。
+
+**遵循 `shared-references/cross-model-review.md`**：Claude 和 Review LLM 独立生成，不互相看到对方的结果。
+
+1. **Claude 生成 6-10 个 ideas**：
+   - 输入：景观报告 + wiki gaps + active list + banlist
+   - **结构化生成路径** — 每个 idea 必须遵循以下四条路径之一：
+
+     | 路径 | 名称 | 读取的 wiki 字段 | 产出形态 |
+     |------|------|------------------|----------|
+     | A | 景观驱动 (Landscape-driven) | `direction` + Phase 1 景观报告（不依赖已有方法） | "基于 topic/research 描述直接设计" |
+     | B | 增量改进 (Incremental) | `wiki/methods/*.md` 中的 `method.limitations` | "在方法 M 上修复局限 L" |
+     | C | 有机融合 (Combination) | 同 topic 下两个 method 的 `tradeoff_profile`（`wiki/methods/*.md`） | "组合 M1 + M2 的优势" |
+     | D | 共性盲点 (Innovation) | 同 topic 下 N 个 method 的 `assumptions` 交集（`wiki/methods/*.md`） | "打破共有假设 P" |
+     | E | 跨域迁移 (Cross-domain transfer) | 跨 topic 的 method 的 `mechanism` 相似度（`wiki/methods/*.md`） | "把机制 M 从领域 X 迁移到 Y" |
+
+     对每条路径，先提取相关 wiki 字段，再生成 idea。每个 idea 必须声明来自哪条路径（A/B/C/D/E）。
+
+   - 补充策略（在路径 A–E 之上叠加）：
+     - 填补 gap_map 与 topic / concept open-problem 章节中的空白
+     - SOTA 的已知 limitation → 改进方向
+   - 每个 idea 包含：title、hypothesis（1-2 句）、approach sketch（3-5 句）、`origin_gaps`（idea 针对的 concept / topic slug）、estimated feasibility（高/中/低）、generation_path（A/B/C/D/E）
+
+2. **Review LLM 独立生成 4-6 个 ideas**（并行执行）：
+   ```
+   llm-review.chat:
+     system: "You are a creative ML researcher brainstorming research ideas.
+              Generate novel, concrete, and feasible ideas based on the given context.
+              Each idea MUST follow one of the five structured generation paths below.
+              For each idea, provide: title, hypothesis (1-2 sentences),
+              approach sketch (3-5 sentences), feasibility assessment,
+              and generation_path (A/B/C/D/E)."
+     message: |
+       ## Structured Generation Paths
+
+       Each idea must follow exactly one of these paths:
+
+       | Path | Name | Wiki input | Output form |
+       |------|------|------------|-------------|
+       | A | Landscape-driven | direction + landscape report (no dependency on existing methods) | "Design directly from topic/research description" |
+       | B | Incremental | method.limitations | "Fix limitation L in method M" |
+       | C | Combination | tradeoff_profile of two methods under same topic | "Combine strengths of M1 + M2" |
+       | D | Innovation | Intersection of assumptions across N methods under same topic | "Break shared assumption P" |
+       | E | Cross-domain transfer | mechanism similarity across different topics | "Transfer mechanism M from domain X to Y" |
+
+       ## Research Landscape
+       {landscape report from Phase 1 — gaps, SOTA, trends}
+
+       ## Methods (for paths B–E)
+       {wiki/methods/*.md — limitations, tradeoff_profile, assumptions, mechanism fields}
+
+       ## Knowledge Gaps
+       {gap_map entries}
+
+       ## Banlist (DO NOT revisit these)
+       {failed ideas with failure_reason}
+
+       ## Active Ideas (avoid duplicating)
+       {proposed/in_progress ideas}
+
+       Generate 4-6 novel research ideas that address the gaps above.
+       Focus on ideas that are: (1) genuinely novel, (2) feasible within 3-6 months,
+       (3) directly address a knowledge gap.
+       Each idea MUST declare its generation_path (A/B/C/D/E).
+   ```
+
+3. **合并与去重**：
+   - 将 Claude 和 Review LLM 的 ideas 合并（10-16 个候选）
+   - 去除高度相似的 ideas（方法核心相同的合并，保留更具体的版本）
+   - 去除与 banlist 重叠的 ideas
+   - 去除与 active list 高度重复的 ideas
+   - 输出：8-12 个候选 ideas
+
+### Phase 3: 筛选与验证（Filter & Validation）
+
+目标：淘汰不可行或不够新颖的 ideas，然后深度验证幸存者。
+
+**步骤 1 — 初步筛选**（对所有 8-12 个候选 idea 执行）：
+
+1. **可行性检查**：
+   - GPU/计算需求是否在合理范围内（参考 wiki 中已有 experiments 的 setup）
+   - 数据可获取性（公开数据集 vs 私有数据）
+   - 实现复杂度（能否在 3-6 个月内完成）
+   - 标记为 feasibility: 高/中/低
+
+2. **快速 novelty 筛查**（每个 idea 2-3 个 WebSearch）：
+   - `"<idea-core-method>" + "<task>"` 精确搜索
+   - `<component-1> + <component-2>` 组件组合搜索
+   - 若找到高度相似的已发表工作 → 淘汰或标记
+
+3. **wiki 对齐检查**：
+   - idea 是否解决 gap_map 中的已知缺口？（+分）
+   - idea 是否针对某个 concept 的 `## Open problems` 或某个 topic 的 methodological gap？（+分）
+   - idea 是否基于 wiki 已有知识（papers / methods / concepts）构建？（+分）
+
+4. **筛选决策**：
+   - 淘汰条件：feasibility=低 AND novelty 筛查发现相似已发表工作
+   - 淘汰条件：与 banlist 的 failure_reason 高度相关
+   - 保留：feasibility >= 中 AND 未被淘汰
+   - 输出：4-6 个幸存 ideas
+
+**步骤 2 — 深度验证**（对幸存 ideas 执行；若 `--skip-validation` 则跳过）：
+
+（跳过时：直接进入 Phase 4: 写入 Wiki，所有幸存 ideas 默认 priority = 3）
+
+1. **调用 /novelty `--write`**（逐个执行）：
+   ```
+   对每个幸存 idea：
+   Skill: novelty
+   Args: "<idea-slug>" --write
+   ```
+   `--write` 标志会把得到的 `novelty_score`（1-5）写入 idea frontmatter。记录该分数用于 IDEA_REPORT。
+
+2. **调用 /review**（对 top ideas）：
+   ```
+   Skill: review
+   Args: "<idea-full-description>" --difficulty hard --focus method
+   ```
+   记录 review score（1-10）和 weaknesses
+
+3. **综合排名**：
+   - 最终得分 = novelty_score × 2 + review_score + gap_alignment_bonus
+   - gap_alignment_bonus：+2 若 idea 直接针对 gap_map 条目
+   - 若 novelty_score <= 2 → 降级为「modify needed」
+   - 若 review_score <= 4 → 降级为「major issues」
+
+4. **验证后筛选**：
+   - 淘汰 novelty_score <= 2 且 review_score <= 4 的 ideas
+   - 输出：排名后的幸存者（通过初步筛选和深度验证）
+
+5. **若 `--auto` 未设置**：在终端展示排名结果，等待用户确认或调整
+
+### Phase 4: 写入 Wiki
+
+将验证后的 ideas 写入 wiki（包括被淘汰的 ideas，记录淘汰原因）。
+
+1. **写入 top ideas**（status: proposed）：
+   对排名前 `--max-ideas` 个 ideas：
+   ```bash
+   # 生成 slug
+   python3 tools/research_wiki.py slug "<idea-title>"
+   ```
+   创建 `wiki/ideas/{slug}.md`，**严格遵循 schema** — frontmatter 对齐 `runtime/schema/entities.yaml::ideas`，正文对齐 `runtime/templates/ideas.md.tmpl`：
+   ```yaml
+   ---
+   title: "<idea 标题>"
+   slug: "<idea-slug>"
+   status: proposed
+   origin: "ideate: <驱动该 idea 的 gap / open problem / 论文的简短描述>"
+   origin_gaps: []           # [[concept-slug]] 或 [[topic-slug]] 列表 — 该 idea 针对的 concept / topic
+   tags: []                  # 2-5 个主题标签（从 origin_gaps / direction 继承）
+   target_venue: ""          # NeurIPS / ICLR / ICML / ACL / COLM — 未定时留空
+   novelty_score: ""         # 1-5 — Phase 3 中 深度验证 由 /novelty --write 写入；否则留空
+   priority: 3               # 1-5 — 见下方 Priority 计算
+   pilot_result: ""          # 留空；预实验在 Phase 5 运行，结果由 /exp-pilot-eval 填入。
+   linked_experiments: []    # 留空，由 /exp-design 创建 experiment 后填写
+   date_proposed: YYYY-MM-DD
+   date_resolved: ""         # 留空，validated/failed 时填写
+   ---
+   ```
+
+   **Priority 计算**（把 Phase 3 验证信号映射到 1-5 分）：
+   - 若 `--skip-validation`：默认 `priority = 3`（跳过 novelty/review 评分）
+   - 否则从 `novelty_score`（/novelty 给出的 1-5）开始
+   - `+1` 若 `gap_alignment_bonus > 0`（直接命中 gap_map 条目）
+   - `-1` 若 `review_score <= 4`（major issues 降权）
+   - Clamp 到 `[1, 5]`
+
+   **正文结构**（必须与 `runtime/templates/ideas.md.tmpl` 严格一致 — 不要改名）：
+   ```markdown
+   ## Motivation
+   哪个 gap / open problem / 论文限制驱动了这个 idea。用 `[[slug]]` 引用 wiki 页面。
+
+   ## Hypothesis
+   1-2 句话陈述可验证的命题。
+
+   ## Approach sketch
+   3-5 句描述提出的方法。任何借用现有工作的组件用 `[[paper-slug]]`、`[[method-slug]]` 或 `[[concept-slug]]` 标注。
+
+   ## Novelty argument
+   为何该 idea 真正新颖 —— /novelty 找到的最相近 prior work 是哪一项，差异维度在哪里。一段简短文字。
+
+   ## Target venue
+   计划投稿目标（如 NeurIPS 2026 / ICLR / ICML / ACL / COLM）。仍在打磨范围的 idea 可留空。
+
+   ## Risks
+   可行性评级（high/medium/low）+ top 2-3 风险。包含 /review 揭示的主要弱点。
+
+   ## Pilot results
+   （留空 — 由 /exp-pilot-run和/exp-pilot-eval 后填写）
+
+   ## Lessons learned
+   （留空 — 由 /exp-eval 在 idea 达到终态后填写）
+   ```
+
+2. **写入被淘汰的 ideas**（status: failed）：
+   对 Phase 3 中被淘汰的 ideas，也用**上方同一模板**创建 `wiki/ideas/{slug}.md`，应用以下覆盖：
+   - `status: failed`
+   - `priority: 1`（被淘汰的 ideas 永远不会阻塞更高优先级的工作）
+   - `date_resolved: YYYY-MM-DD`（今天）
+   - `failure_reason: "[filter] <具体淘汰原因>"` — `[filter]` 前缀区分 Phase 3 筛选淘汰与 /exp-eval 的实验后失败。预实验失败（Phase 5）由 `/exp-pilot-eval` 直接写入已有的 idea 页面。
+   - `## Motivation` 和 `## Hypothesis` 仍需填写（供未来 banlist 匹配）；`## Approach sketch` 可简略；`## Expected outcome` 和 `## Risks` 可说明淘汰原因
+   - 这些 failed ideas 成为未来 ideate 的 banlist
+
+3. **添加 graph edges**：
+   ```bash
+   # 对每个 idea：origin_gaps 中的每个 concept/topic 都加一条 addresses_gap 边
+   python3 tools/research_wiki.py add-edge wiki/ \
+     --from "ideas/{slug}" --to "concepts/{origin-gap-slug}" \
+     --type addresses_gap --evidence "Generated by ideate"
+   # ...gap 目标是 topic 时改为 topics/{origin-gap-slug}。
+
+   python3 tools/research_wiki.py add-edge wiki/ \
+     --from "ideas/{slug}" --to "papers/{source-paper}" \
+     --type inspired_by --evidence "Inspired by method in {paper-title}"
+   ```
+
+4. **重建派生数据**：
+   ```bash
+   python3 tools/research_wiki.py rebuild-context-brief wiki/
+   python3 tools/research_wiki.py rebuild-open-questions wiki/
+   ```
+
+5. **追加日志**：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ \
+     "ideate | {N} ideas proposed, {M} ideas filtered out | direction: {direction}"
+   ```
+
+6. **输出 IDEA_REPORT 到终端**：
+   ```markdown
+   # Idea Generation Report
+
+   ## Pipeline Summary
+   - Direction: {direction}
+   - Phase 1: Scanned {N} external papers, {M} wiki gaps identified
+   - Phase 2: Generated {X} candidates (Claude: {a}, Review LLM: {b})
+   - Phase 3: {Y} survived filter & validation (from {X})
+   - Phase 4: {K} ideas written to wiki
+
+   ## Top Ideas (ranked)
+
+   | Rank | Idea | Novelty | Review | Gap Align | Pilot | Status |
+   |------|------|---------|--------|-----------|-------|--------|
+   | 1 | [[slug]] | 4/5 | 7/10 | +2 | pass | proposed |
+   | 2 | [[slug]] | 3/5 | 6/10 | +0 | pass | proposed |
+
+   ## Filtered Out
+   | Idea | Reason | Status |
+   |------|--------|--------|
+   | [[slug]] | 已有相似发表工作 | failed [filter] |
+   | [[slug]] | 方法在预实验中发散 | failed [pilot] |
+   | [[slug]] | GPU 需求过高 | failed [filter] |
+
+   ## Suggested Next Steps
+   - If --skip-pilot is not specified, run the pilot experiment for further screening.
+   - Run `/exp-design {top-idea-slug}` to design experiments
+   - Run `/novelty` on any idea before investing time
+
+   ## Wiki Growth
+   | Metric | Before | After | Delta |
+   |--------|--------|-------|-------|
+   | Papers | {before} | {after} | +{delta} |
+   | Methods | {before} | {after} | +{delta} |
+   | Ideas | {before} | {after} | +{delta} |
+   | Edges | {before} | {after} | +{delta} |
+   | Maturity | {before_level} | {after_level} | {unchanged/upgraded} |
+   （仅展示 delta != 0 的行。数据来自前置 step 3 的 `maturity_before` 与此处重新调用 `maturity --json` 的对比。）
+   ```
+
+7. **若用户输入了 `--skip-pilot`则跳过预实验部分，否则记得向用户确定要进行预实验，并让用户选择幸存idea中需要进行预实验的idea**
+
+
+### Phase 5: 预实验（Pilot Experiments）
+
+（若 `--skip-pilot` 则跳过，管道在 Phase 4 后结束）
+
+目标：对幸存的idea中**用户选择的**进行轻量级预实验，在投入完整实验前检测明显失败。
+
+**按 `generation_path` 的预实验策略**：
+
+| 路径 | 预实验方式 |
+|------|-----------|
+| A (景观驱动) | 基于 topic/research 描述直接实现提出的方法。在小规模 benchmark 上运行，验证 idea 可行且产生非退化输出。与简单 baseline 对比。 |
+| B (增量改进) | 从原方法的论文 repo 出发，应用提出的修复并运行最小评估。与原方法对比验证局限是否被解决。 |
+| C (有机融合) | 实现 M1 + M2 的组合版本。在小规模 benchmark 上运行，检查性能/成本 tradeoff 是否达到预期平衡（不被纯 M1 或纯 M2 支配）。 |
+| D (共性盲点) | 在新设定下（共有假设 P 被打破时）运行现有方法。验证它们确实失败或退化，确认 gap 真实存在。 |
+| E (跨域迁移) | 在目标领域实现迁移的机制。运行最小评估，检查机制是否兼容且产生非退化输出。 |
+
+**Pilot Spec — 结构化输出**（GPU 资源充足时**可并行执行多个预实验**）：
+
+写预实验代码前，为用户选择的idea 生成结构化 Pilot Spec 块并写入 `experiments/pilot/{slug}.yaml`。此 spec 是预实验代码生成的契约（类比 `/exp-design` 实验页面供 `/exp-run` 消费）。包含以下字段：
+
+```yaml
+# Pilot Spec for: {idea-slug}
+pilot_spec:
+  hypothesis: "<1-2 句可测试命题>"
+  approach_sketch: "<3-5 句方法描述>"
+  implementation:
+    repo: "<基础代码 repo URL 或 'from-scratch'>"
+    entry_point: "<主脚本>"
+    modifications: "<具体代码改动>"
+    files_to_create:
+      - "<文件>: <用途>"
+  setup:
+    model: "<模型>"
+    dataset: "<数据集>"
+    hardware: "<GPU>"
+    framework: "<PyTorch/JAX/TF>"
+    batch_size: "<缩减的 batch size，通常为论文的 1/4 到 1/8>"
+    max_steps: "<缩短的训练步数，完整步数的 10-30%>"
+    learning_rate: "<lr>"
+    seeds: "<种子数，预实验默认 1>"
+    other_hparams: "<关键超参数>"
+  metrics:
+    - name: "<指标>"
+      why: "<为什么用这个指标>"
+  baseline:
+    method: "<baseline 方法>"
+    source: "<论文 repo 或 wiki slug>"
+    expected_value: "<已知性能>"
+  success_criterion:
+    pass: "<量化条件>"
+    fail: "<量化条件>"
+    inconclusive: "<其他>"
+```
+
+**预实验要求**：
+- **减小 batch size**：使用能产生有意义梯度的最小 batch size（通常为论文报告 batch size 的 1/4 到 1/8）
+- **缩短训练**：训练到前中期（完整训练步数的 10-30%），非完整收敛
+- **目标**：检测明显的退化或失败，而非追求 SOTA
+- **对比**：始终包含 baseline（路径 A 用简单默认 baseline，路径 B 用原方法，路径 C 用纯 M1/M2，路径 D 用现有方法，路径 E 用目标领域 SOTA）
+- **success_criterion**：必须是量化可判定的条件
+
+**通过 `/exp-pilot-run` 运行预实验**：
+
+用户选择的幸存 idea 写入 Pilot Spec 到 `experiments/pilot/{slug}.yaml` 后：
+
+```
+Skill: exp-pilot-run
+Args: "{idea-slug}"
+```
+
+`/exp-pilot-run` 读取 Pilot Spec，写入预实验代码到 `experiments/pilot/code/{slug}/`，运行实验，返回 PILOT_REPORT：
+- **Results**：指标值 vs baseline（mean ± std）
+- **Details**：完成步数、运行时间、日志路径
+
+**通过 `/exp-pilot-eval` 评估预实验结果**：
+
+`/exp-pilot-run` 返回 PILOT_REPORT 后，评估结果并更新 idea 页面（已在 Phase 4 创建）：
+
+```
+Skill: exp-pilot-eval
+Args: "{idea-slug}"
+```
+
+`/exp-pilot-eval` 读取预实验结果，应用判定逻辑（宽松阈值——目的是检测明显失败，非衡量最终性能），更新 idea 页面：
+- **Pass**：设置 `pilot_result: "pass — ..."`，status 不变
+- **Fail**：设置 `failure_reason: "[pilot] ..."`，status 转为 `failed`，同时设置`pilot_result: "fail — ..."`
+- **Inconclusive**：设置 `pilot_result: "inconclusive — needs full experiment"`，status 不变
+
+**若 `--auto` 未设置**：在终端展示预实验结果，对边界情况等待用户确认
+
+**所有预实验完成后**：输出最终 IDEA_REPORT（见 Phase 4 Step 6）
+## Constraints
+
+- **wiki cold 时自动切换 cold-start mode**：外部搜索扩展（WebSearch 8 查询，S2/DeepXiv limit 30），不阻塞执行
+- **所有 idea 必须有 wiki 依据**：每个 idea 至少引用 2 个 wiki 页面（paper / concept / method / topic）
+- **必须加载 banlist**：Phase 1 必须读取 failed ideas 的 failure_reason，Phase 2/3/4 必须检查重叠
+- **Review LLM 独立性**：Phase 2 中 Review LLM 不看 Claude 的 idea 列表（cross-model-review.md）
+- **被淘汰的 ideas 也写入 wiki**：status=failed + failure_reason，作为 anti-repetition 记忆
+- **不凭空编造**：所有 ideas 必须基于 wiki 已有知识或外部搜索结果推导，不编造不存在的论文或方法
+- **slug 唯一性**：创建前检查 wiki/ideas/ 中是否已存在相同 slug
+- **graph edges 使用 tools/research_wiki.py**：不手动编辑 edges.jsonl
+
+## Error Handling
+
+- **wiki 为空**：正常执行外部搜索（Phase 1 Source B/C/D），但跳过 wiki 内部上下文，提示用户先建立知识库
+- **WebSearch 不可用**：跳过外部搜索，仅基于 wiki 内部知识生成（降级模式，在报告中标注）
+- **Semantic Scholar API 不可用**：跳过 S2 搜索，依赖 DeepXiv + WebSearch 补偿
+- **DeepXiv API 不可用**：跳过 DeepXiv 搜索和 trending，依赖 S2 + WebSearch（回退到原有行为）
+- **Review LLM 不可用**：Phase 2 仅用 Claude 生成（无双模型多样性，在报告中标注）
+- **/novelty 失败**：Phase 3 中单个 idea 的 novelty 失败时，标注「novelty unverified」继续
+- **/review 失败**：Phase 3 中 review 失败时，标注「unreviewed」继续，建议用户手动 /review
+- **预实验失败**：标记为 failed 并在 failure_reason 中加 `[pilot]` 前缀，其余 ideas 继续
+- **所有预实验都失败**：idea 页面已存在（Phase 4 已写入），报告建议用户查看预实验日志并调整方案
+- **slug 冲突**：若 wiki/ideas/ 中已存在相同 slug，追加数字后缀（如 `sparse-lora-v2`）
+- **所有 ideas 都被淘汰**：仍写入 wiki（status: failed），报告中建议用户扩大搜索方向或 /ingest 更多论文
+
+## Dependencies
+
+### Tools（via Bash）
+- `python3 tools/research_wiki.py maturity wiki/ --json` — 检查 wiki 成熟度 + Growth Report
+- `python3 tools/research_wiki.py slug "<title>"` — 生成 slug
+- `python3 tools/research_wiki.py add-edge wiki/ ...` — 添加 graph edge
+- `python3 tools/research_wiki.py rebuild-context-brief wiki/` — 重建 query_pack
+- `python3 tools/research_wiki.py rebuild-open-questions wiki/` — 重建 gap_map
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+- `python3 tools/fetch_s2.py search "<query>" --limit 20` — Semantic Scholar 搜索
+- `python3 tools/fetch_deepxiv.py search "<query>" --mode hybrid --limit 20` — DeepXiv 语义搜索
+- `python3 tools/fetch_deepxiv.py brief <arxiv_id>` — 获取论文 TLDR
+- `python3 tools/fetch_deepxiv.py trending --days 14` — 热门论文趋势
+
+### Skills（via Skill tool）
+- `/novelty` — Phase 3 深度 novelty 验证
+- `/review` — Phase 3 跨模型审查
+- `/exp-pilot-run` — Phase 5 预实验执行
+- `/exp-pilot-eval` — Phase 5 预实验结果评估与 idea 页面更新
+
+### MCP Servers
+- `llm-review.chat` — Phase 2 Review LLM 独立脑暴
+
+### Qoder Native
+- `WebSearch` — Phase 1 外部搜索、Phase 3 快速 novelty 筛查、Phase 5 预实验验证
+- `Agent` tool — Phase 1 并行搜索、Phase 2 并行脑暴
+
+### Shared References
+- `.qoder/skills/shared-references/cross-model-review.md` — Phase 2 Review LLM 独立性原则

--- a/.qoder/skills/ingest/SKILL.md
+++ b/.qoder/skills/ingest/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: ingest
+description: 把一篇论文 ingest 进 wiki —— 建立 papers + concepts + methods + people 页面，并完成所有双向交叉引用与 graph edge。当用户说 "ingest"、"加入这篇论文"、丢 `.pdf` / `.tex` / arXiv URL 或要求把论文折叠进知识库时触发。
+---
+
+# /ingest
+
+> **用法**：`<local-path-or-arXiv-URL> [--discover] [--visualize]`
+
+
+把一篇论文转化成一组正确链接的 wiki 页面。`/ingest` 的职责是写出 well-shaped 的实体与正确的双向链接；语义层面的审计（反向链接对称性、dangling node、字段取值合规）留给 `/check`。
+
+按需打开下列本地参考文件：
+
+- `references/pdf-preprocessing.md` —— 直接 PDF 输入时的 arXiv-ID 恢复、tex 抓取、prepare-paper 交接流程
+- `references/dedup-policy.md` —— concept / method 的合并与新建决策规则，以及 `/ingest` 形状检查与 `/check` 语义审计的边界
+- `references/cross-references.md` —— 正向/反向链接矩阵与 paper-to-paper edge 类型选择
+- `references/init-mode.md` —— `/init` 的 manifest 交接与并行安全约束
+- `references/error-handling.md` —— 来源解析、API 与 slug 冲突的 fallback
+
+写 wiki 页面 frontmatter 字段去 `runtime/schema/entities.yaml`,正文章节顺序去 `runtime/templates/{kind}.md.tmpl`;`index.md`、`log.md`、`graph/` 形状去 `runtime/schema/conventions.yaml` 与 `runtime/schema/edges.yaml`。
+
+## Inputs
+
+- `source`：四种之一 —— arXiv URL（例如 `https://arxiv.org/abs/2106.09685`）、本地 `.tex`、本地 `.pdf`、或 `/init` 通过 `.checkpoints/init-sources.json` 交接的 `canonical_ingest_path`（见 `references/init-mode.md`）
+- `--discover`（可选，默认 **关闭**）：在最终 report 之后调用 `/discover --anchor <this-paper's-arxiv-id>`，把 shortlist 作为 "接下来可能想 ingest 的相关论文" 附在 report 里。从不自动 ingest 推荐结果。INIT MODE 下自动跳过。视为用户可见参数：不得仅根据仓库状态擅自开启。
+- `--visualize`（可选，默认 **关闭**）：在 Step 7 rebuild 之后通过 `tools/visualize.py generate-canvas` 重新生成 Canvas 可视化产物。INIT MODE 下自动跳过 —— 由上层 `/init` 在 fan-in 时统一处理可视化。视为用户可见参数：不得仅根据仓库状态擅自开启。（交互式网页 Graph 视图位于 SPA 的 `app/modules/graph.js`，由 `tools/serve.py` 服务，直接读取 `wiki/graph/`，不需要每次 ingest 单独重生成。）
+
+## Outputs
+
+- 一篇完整链接的论文页面及其关联实体（concepts、methods、people）
+- 通过 `tools/research_wiki.py` 追加的 graph edges 与 citations
+- 终端汇总报告（新增页面数、建议后续 ingest 的论文）
+
+## Wiki Interaction
+
+### Reads
+
+- `wiki/index.md`，用于获取所有已存在 slug 与 tag
+- `wiki/papers/*.md`，用于识别已 ingest 过的论文
+- `wiki/concepts/*.md`、`wiki/foundations/*.md`，用于 dedup 匹配
+- `wiki/methods/*.md`，用于针对已有可复用 method 的 dedup 匹配
+- `wiki/people/*.md`，用于识别已有作者
+- `wiki/topics/*.md`，用于将论文归入已有 topic
+- `wiki/graph/open_questions.md`，用于识别论文是否填补了已知 gap
+
+### Writes
+
+- `wiki/papers/{slug}.md` —— CREATE
+- `wiki/concepts/{slug}.md` —— CREATE（新建）或 EDIT（追加 `key_papers`、aliases、variants）
+- `wiki/methods/{slug}.md` —— CREATE（仅当 method 为命名、可复用、可被多篇论文引用时新建）或 EDIT（追加 `source_papers`）
+- `wiki/people/{slug}.md` —— CREATE（仅当 importance ≥ 4）或 EDIT（追加到 `## Recent work`）
+- `wiki/topics/{slug}.md` —— 只允许 EDIT，`/ingest` 不得 CREATE 新 topic
+- `wiki/graph/edges.jsonl` —— 通过工具 APPEND
+- `wiki/graph/citations.jsonl` —— 通过工具 APPEND
+- `wiki/graph/context_brief.md` —— REBUILD（INIT MODE 下跳过）
+- `wiki/graph/open_questions.md` —— REBUILD（INIT MODE 下跳过）
+- `wiki/index.md` —— APPEND
+- `wiki/log.md` —— 通过工具 APPEND
+- `wiki/canvases/*.canvas` —— CREATE/OVERWRITE（仅当 `--visualize` 开启且非 INIT MODE）
+
+### 会新增的 Graph edges
+
+- `paper → concept`：`introduces_concept` / `uses_concept` / `extends_concept` / `critiques_concept`，并写 `confidence`
+- `paper → foundation`：`derived_from`（foundation 是终端节点，无反向链接）
+- `paper → paper`：`same_problem_as` / `similar_method_to` / `builds_on` / `challenges`，并写 `confidence`
+- bibliographic `paper → paper`：`graph/citations.jsonl` 中的 `cites`
+
+`tools/research_wiki.py add-edge` 会拒绝缺少 confidence/evidence 的
+paper-paper 与 paper-concept semantic edge，也会拒绝新写入 legacy
+paper-to-concept 或 paper-to-paper 类型。
+
+## Workflow
+
+**前置条件**：工作目录下同时存在 `wiki/`、`raw/`、`tools/`。先解析一次 Python interpreter 并复用：
+
+```bash
+# 通过 git 找到项目根，让 worktree 中的 subagent 也能定位 .venv。
+# .venv 被 gitignore，subagent 的 cwd 在 ../.worktrees/<branch>/ 时本地没有
+# .venv——若不解析项目根，PYTHON_BIN 会回退到系统 python3，既丢失 .env 里的
+# API key，也丢失安装的依赖（deepxiv-sdk 等）。
+# git rev-parse --git-common-dir 无论 cwd 位于哪个 worktree 都返回主仓库的
+# .git 目录；其父目录即项目根。
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null || true)
+PROJECT_ROOT=""
+if [ -n "$GIT_COMMON_DIR" ]; then
+  PROJECT_ROOT=$(cd "$(dirname "$GIT_COMMON_DIR")" 2>/dev/null && pwd)
+fi
+
+if   [ -x "$PROJECT_ROOT/.venv/bin/python" ];         then PYTHON_BIN="$PROJECT_ROOT/.venv/bin/python"
+elif [ -x "$PROJECT_ROOT/.venv/Scripts/python.exe" ]; then PYTHON_BIN="$PROJECT_ROOT/.venv/Scripts/python.exe"
+elif [ -x .venv/bin/python ];                         then PYTHON_BIN=.venv/bin/python
+elif [ -x .venv/Scripts/python.exe ];                 then PYTHON_BIN=.venv/Scripts/python.exe
+else                                                       PYTHON_BIN=python3
+fi
+export PYTHON_BIN
+```
+
+### Step 1: 解析来源
+
+1. 如果 `/init` 交接了 `canonical_ingest_path`，进入 **INIT MODE** 并原样消费该路径，不要重新扫描 `raw/`。详见 `references/init-mode.md`。
+2. 如果来源是 arXiv URL，先提取 arXiv ID；可用时通过 `"$PYTHON_BIN" tools/fetch_s2.py paper <arxiv-id>` 恢复标题，然后运行 `"$PYTHON_BIN" tools/init_discovery.py download --raw-root raw --arxiv-id <arxiv-id> --title "<title-or-arxiv-id>"`。后续从返回的 `canonical_ingest_path` 继续。该 helper 会先尝试 arXiv source，再 fallback 到 PDF；不要用 `fetch_arxiv.py` 处理单篇论文，因为它只用于 RSS。
+3. 如果来源是本地 `.tex`，直接使用。
+4. 如果来源是本地 `.pdf`，先走 `references/pdf-preprocessing.md` 的预处理流程，在 `raw/tmp/` 下生成 prepared `.tex`，再继续。
+
+raw 持久化规则：已经在 `raw/discovered/`、`raw/tmp/`、`raw/papers/` 中的文件，不得被复制或重写到别的 raw 子目录。
+
+### Step 2: 论文身份与 enrichment
+
+1. 生成 paper slug：
+
+   ```bash
+   "$PYTHON_BIN" tools/research_wiki.py slug "<paper-title>"
+   ```
+
+2. 冲突检查：若 `wiki/papers/{slug}.md` 已存在且 arXiv ID 或标题一致，报告并退出；若不一致，按 `references/error-handling.md` 处理冲突。
+3. 有 arXiv ID 时查询 Semantic Scholar：
+
+   ```bash
+   "$PYTHON_BIN" tools/fetch_s2.py paper <arxiv-id>
+   ```
+
+   用于填写 `venue`、`year`、`s2_id`、citation count，以及 `importance`（1-5）的评估依据。
+4. 可选 DeepXiv enrichment，失败则静默跳过：
+
+   ```bash
+   "$PYTHON_BIN" tools/fetch_deepxiv.py brief <arxiv-id>
+   "$PYTHON_BIN" tools/fetch_deepxiv.py head <arxiv-id>
+   "$PYTHON_BIN" tools/fetch_deepxiv.py social <arxiv-id>
+   ```
+
+   `brief` 用于 seed Key idea；`head` 用于对照 tex 解析的章节结构；`social` 作为 importance 的辅助信号。
+
+### Step 3: 写 paper 页面
+
+打开 `runtime/schema/entities.yaml`(papers 段)看字段集,`runtime/templates/papers.md.tmpl` 看正文章节顺序。填写全部必需 frontmatter 字段;`cited_by` 本步骤留空,Step 5 再回填。
+
+新 schema 要求新 ingest 必须填写、但目前 lint 不强制的三个 frontmatter 字段（已有页面不会因此失效，但新 ingest 必须填）：
+
+- `tldr` —— 一句话概括论文，适合做搜索/预览行。**不**是多段摘要；只一句。
+- `contribution_type` —— 贡献类型列表，从封闭集合 `[method, theory, benchmark, analysis, application, system, position, survey]` 中选。一篇论文可能多选（例如 method + benchmark）。不得自创取值。
+- `datasets` —— 论文使用或引入的数据集 / benchmark 名称列表（例如 `MMLU`、`BFCL`、`AppWorld`）。论文不引入任何具体数据集时填 `[]`，不得伪造。
+
+写入前对即将输出的 frontmatter 做一次**形状检查** —— 仅限以下范围：
+
+- 每个必需字段都存在且非空
+- `importance` ∈ {1,2,3,4,5}；concept 的 `maturity` 在合法集合内；method 的 `type` 在合法集合内
+- `contribution_type` 各项都在上述枚举内
+- YAML 可解析
+
+形状检查刻意保持狭窄：反向链接对称性、dangling node、跨实体一致性是 `/check` 的工作，不是本 skill 的。
+
+正文章节按以下顺序：`Problem & Context`、`Key idea`、`Method`、`Experiment & Results`、`Limitations`、`Open questions`、`My take`、`Related`。
+
+章节语义：
+
+- **Problem & Context** —— 论文要攻破的问题 **以及** 论文出现之前该领域的状态。两件事合一节。
+- **Experiment & Results** —— 实验设置、主要 metric 与结果合一节。不要止步于"打败 baseline"；引用具体数字与对应条件。
+
+### Step 4: concept / method / people
+
+按 `references/dedup-policy.md` 执行。简要步骤：
+
+1. 每个 concept 候选先调用 `find-similar-concept`。
+2. 每个 method 候选（命名的、可复用的、可能被其他论文引用的技术）查 `wiki/methods/`，按 name + tags 匹配是否已有条目。**没有** `find-similar-method` 工具 —— 直接扫目录，按 `runtime/schema/entities.yaml` 中 `methods.name` 字段做手工 title/alias 比对。
+3. 默认合并到 top 结果。只有在没有可接受候选且论文 importance 确实证明新建合理时才新建页面。论文页面上的 `## Method` 正文章节**始终**填写（这是这篇论文自身的方法叙述）；只有当技术可命名、可复用、且很可能被其他论文引用时，才另开 `wiki/methods/{slug}.md`。
+4. 每写一条正向链接，同一 turn 内写入其反向链接。义务矩阵见 `references/cross-references.md`。
+5. 仅当 importance ≥ 4 才允许新建 `wiki/people/{slug}.md`；否则只能向已有作者页面的 `## Recent work` 追加 `[[paper-slug]]`。people 实体使用 `research_areas`（list_str）与 `type.kind` 枚举（`researcher` / `team` / `organization`）；只有 byline 本身就指向该 team 或 organization 时才把 `type.kind` 设为 `team` 或 `organization`（不要从研究者的所属机构推断）。
+6. 新建 `wiki/concepts/{slug}.md` 时，若该 concept 明显归属某个已有 topic（例如所有"self-improving coding agents"子题），设置 `parent_topic: <topic-slug>`（裸 slug，**不要** `[[wikilink]]` 包装 —— `parent_topic` 是 `link` 类型，不是 `list_link`）。topic 页的反向 `## Concepts` body 区在同一 turn 内追加。
+7. 新建或更新 `wiki/methods/{slug}.md` 时，对该方法实现的任何 concept（通常是同篇论文引入的 concept）写入 `realizes_concepts: [[c1], [c2], ...]`。每个 concept 页的反向 `## Realized by` body 区在同一 turn 内追加。
+
+### Step 5: paper-to-paper edge 与 `cited_by`
+
+INIT MODE 下整步跳过 —— 由上层 `/init` 在 fan-in 时统一处理。
+
+```bash
+"$PYTHON_BIN" tools/fetch_s2.py references <arxiv-id>
+"$PYTHON_BIN" tools/fetch_s2.py citations <arxiv-id>
+```
+
+- 对于 references 中 arXiv ID 或标题能解析到 `wiki/papers/{slug}.md` 的条目，在 `graph/citations.jsonl` 写一条 bibliographic `cites` 记录。
+- 只有当原文给出清晰信号时，才在 `graph/edges.jsonl` 写 semantic paper-to-paper edge。选型规则见 `references/cross-references.md`。若没有能干净对应的语义关系，只保留 `cites` 记录。
+- 对于 citations 中已在 wiki 的引用者，在本论文的 `cited_by` 追加引用者 slug。
+- 在最终报告中列出未匹配的高引用 references，供用户决定是否后续 `/ingest`。
+
+### Step 6: topic 与 index
+
+1. 将论文的 tags 对 `wiki/topics/*.md` 做匹配。对每个命中 topic：
+   - importance ≥ 4 → 追加到 `## Seminal works`，**同时**把 `[[paper-slug]]` 追加到 topic frontmatter 的 `key_papers` 列表
+   - importance < 4 → 按年份追加到 `## SOTA tracker` 或 `## Recent work`（不更新 frontmatter）
+   - 若论文直接回应了 topic 中列出的 open problem（`## Open problems` / `### Known gaps` / `### Methodological gaps` 下），在对应行上标注
+2. `/ingest` 不得新建 topic 页面 —— topic 创建属于 `/init` 与 `/edit`。
+3. 在 `wiki/index.md` 对应分类下追加新增或编辑过的条目。格式:每个 entity kind 是顶层 YAML 键(对应 `runtime/schema/entities.yaml`),其下挂 `- slug: <slug>`。
+
+### Step 7: 日志与 rebuild
+
+```bash
+"$PYTHON_BIN" tools/research_wiki.py log wiki/ "ingest | added papers/<slug> | updated: <list>"
+```
+
+非 INIT MODE 下再执行：
+
+```bash
+"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/
+```
+
+### Step 7.5: 可选的可视化（仅当 `--visualize` 开启）
+
+只有用户显式传 `--visualize` 时才执行本步。INIT MODE 下也一律跳过 —— `/init` 父流程在 fan-in 时统一重生成 Canvas，单个子代理不应重复执行从而引入并发写。
+
+开启后，重新生成 Canvas（best-effort；visualize 失败不应让 `/ingest` 失败）：
+
+```bash
+"$PYTHON_BIN" tools/visualize.py generate-canvas wiki/ \
+  || echo "WARN: visualize generate-canvas failed; run /visualize manually" >&2
+```
+
+`--obsidian` 不在这里重新生成 —— `wiki/.obsidian/graph.json` 是项目级静态配置，只有在 `config/visualize.json` 调色板变化时才需要重写；那种情况下手动跑 `/visualize --obsidian`。
+
+### Step 8: 汇报
+
+输出一个紧凑 summary：新建的页面、编辑的页面、新增的 graph edge、发现的 contradiction（如有）、尚未 ingest 的高引用 references（后续 `/ingest` 建议）。末尾一行：
+
+```
+Wiki: +1 paper, +{N} methods, +{M} concepts, +{K} edges
+```
+
+### Step 9: 可选的 discovery（仅当 `--discover` 显式开启）
+
+如果用户没有显式传 `--discover`，跳过本步骤。INIT MODE 下也一律跳过 —— 是否在 fan-in 之后跑 discovery，是 `/init` 父流程的决定，不是单个子代理的决定。
+
+开启时，用刚 ingest 论文作为单 anchor 调用 `/discover`：
+
+```bash
+"$PYTHON_BIN" tools/discover.py from-anchors \
+  --id <arxiv-id-of-this-paper> \
+  --wiki-root wiki \
+  --limit 10 \
+  --output-checkpoint .checkpoints/ \
+  --markdown
+```
+
+把 markdown 输出附在 report 下一个 "接下来可能想 ingest 的相关论文" 小节里。**不要**自动 ingest 列表里的任何东西 —— 由用户挑选。若 discovery 失败（S2 故障、所有通道返回空），在 report 里一行说明并继续 —— discovery 失败不应让一次成功的 `/ingest` 也算失败。
+
+## Constraints
+
+- `raw/papers/`、`raw/notes/`、`raw/web/` 归用户所有且只读。直接本地 `/ingest` 可在 `raw/tmp/` 下新增 prepared sidecar；直接 arXiv ingest 可把源归档写到 `raw/discovered/`。INIT MODE 下 `raw/` 全部只读。
+- `wiki/graph/` 由工具维护。仅通过 `tools/research_wiki.py` 修改。
+- slug 始终来自 `tools/research_wiki.py slug`，不得手写。
+- 每一条正向链接必须在同一 turn 内写入其反向链接 —— 这是 wiki 的双向链接不变量。唯一例外是指向 `wiki/foundations/` 的链接，foundations 是终端节点。
+- 在 INIT MODE 下，不要向已有页面（由 sibling worktree 或 scaffold 创建的）写入反向链接。只通过 `tools/research_wiki.py add-edge` 记录关系；上层 `/init` 在 fan-in 时统一回填反向链接。
+- 来源优先级：`.tex` > `.pdf` > vision API fallback。只要有可用 `.tex`，就不从 PDF ingest。
+- ingest 对新实体保守：
+  - importance < 4：每篇论文最多 **1** 个新 concept、**1** 个新 method
+  - importance ≥ 4：每篇论文最多 **3** 个新 concept、**2** 个新 method
+  - 超出上限的候选，必须合并到最接近的已有条目，或整体跳过交给 `/check` 标记。规则与理由：`references/dedup-policy.md`。
+- `methods/` 页面只有当技术**命名了**、**可复用**、且**可能被未来论文引用**时才合理新建。论文页面自身的 `## Method` 正文章节捕捉了这篇论文的方法叙述；除非该方法值得被复用，不要把它复制成一个 method 实体。
+- `/ingest` 只对自己写出的内容做形状检查（必需字段、枚举取值、YAML 可解析），到此为止。反向链接对称性、dangling node、完整语义审计属于 `/check`，不要在本 skill 内重复实现。
+- 必须假设有其他 `/ingest` 在并行 worktree 中同时运行 —— 批量 ingest 已在路线图上。所有对共享文件（`graph/edges.jsonl`、`graph/citations.jsonl`、`index.md`、`log.md`）的写入必须经过 `tools/research_wiki.py` 或采用 append-only 语义。详见 `references/init-mode.md`。
+- INIT MODE 下跳过 `fetch_s2.py citations`、`fetch_s2.py references`，以及 `rebuild-*` 命令 —— 由上层 `/init` 在 fan-in 后统一运行。
+- INIT MODE 下也跳过 Step 7.5 的可视化重生成（无论 `--visualize` 是否开启）；由上层 `/init` 在 fan-in 时统一调用 visualize，避免 sibling worktree 间的并发写。
+
+## Error Handling
+
+详见 `references/error-handling.md`。要点：来源解析按 tex → PDF → vision API → 报告用户的顺序 fallback；S2 不可用时 `importance` 默认取 3 并跳过 citation 回填；DeepXiv 不可用时静默跳过 enrichment；slug 冲突追加数字后缀。
+
+## Dependencies
+
+### Tools（via Bash）
+
+- `"$PYTHON_BIN" tools/research_wiki.py slug "<title>"`
+- `"$PYTHON_BIN" tools/research_wiki.py find-similar-concept wiki/ "<title>" --aliases "<a,b,c>"`
+- `"$PYTHON_BIN" tools/research_wiki.py add-edge wiki/ --from <id> --to <id> --type <type> --evidence "<text>" [--confidence high|medium|low]`
+  - paper-paper 与 paper-concept semantic edge 必须带 `--confidence high|medium|low`。
+- `"$PYTHON_BIN" tools/research_wiki.py add-citation wiki/ --from papers/<citing> --to papers/<cited> --source semantic_scholar`
+- `"$PYTHON_BIN" tools/research_wiki.py log wiki/ "<message>"`
+- `"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/`
+- `"$PYTHON_BIN" tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"] [--arxiv-id "<recovered-arxiv-id>"]`
+- `"$PYTHON_BIN" tools/init_discovery.py download --raw-root raw --arxiv-id <id> --title "<title-or-id>"` —— 单篇论文下载到 `raw/discovered/`，优先 arXiv source，fallback 到 PDF
+- `"$PYTHON_BIN" tools/fetch_s2.py paper|citations|references <arxiv-id>`
+- `"$PYTHON_BIN" tools/fetch_deepxiv.py brief|head|social <arxiv-id>`
+- `"$PYTHON_BIN" tools/discover.py from-anchors --id <arxiv-id> --wiki-root wiki --limit 10 --output-checkpoint .checkpoints/ --markdown` —— 仅当 `--discover` 开启
+- `"$PYTHON_BIN" tools/visualize.py generate-canvas wiki/` —— 仅当 `--visualize` 开启且非 INIT MODE
+
+### Shared References
+
+- `.qoder/skills/shared-references/citation-verification.md`
+
+### Skills
+
+- `/init` —— 通过 INIT MODE 并行调用 `/ingest` 子代理
+- `/check` —— 在 `/ingest` 完成后审计 wiki，负责所有 `/ingest` 故意不做的语义检查
+- `/discover` —— 可选后续，当 `--discover` 开启时运行；产出用户可能想接着 ingest 的相关论文 shortlist
+- `/visualize` —— Step 7.5（`--visualize` 开启且非 INIT MODE 时）通过直接调用 `tools/visualize.py` 重新生成 Canvas + HTML（best-effort）
+
+### External APIs
+
+- Semantic Scholar（via `tools/fetch_s2.py`）
+- DeepXiv（via `tools/fetch_deepxiv.py`，可选；不可用时自动降级）
+- arXiv（源下载）

--- a/.qoder/skills/ingest/references/cross-references.md
+++ b/.qoder/skills/ingest/references/cross-references.md
@@ -1,0 +1,85 @@
+# /ingest 交叉引用
+
+在任何 wiki 页面上写链接时，打开此参考。每一条正向链接都有反向义务（指向 foundation 的除外）。下表是合同。
+
+## 正向 → 反向义务
+
+对应根 `CLAUDE.md`（"Cross-Reference 规则"）中的矩阵，裁剪到 `/ingest` 实际写入的 edge：
+
+| 正向操作（你在页面 A 上写什么） | 必须同步的反向操作（在同一 turn 里你在页面 B 上写什么） |
+|--------------------------------|--------------------------------------------------------|
+| `papers/P` 写 `Related: [[concept-K]]` | `concepts/K` 的 `key_papers` 追加 `P` |
+| `papers/P` 写 `[[person-R]]`（任意正文章节） | `people/R` 的 `## Recent work` 追加 `[[P]]` |
+| `concepts/K` 写 `key_papers: [[paper-P]]` | `papers/P` 的 `## Related` 追加 `K` |
+| `methods/M` 写 `source_papers: [[paper-P]]` | `papers/P` 的 `## Related` 追加 `M` |
+| `methods/M` 写 `parent_methods: [[method-N]]` | `methods/N` 的 `child_methods` 追加 `M`（反之亦然） |
+| 任意页面写 `[[foundation-X]]` | **不写反向链接** —— foundation 是终端节点 |
+
+写了正向却没写反向，是 `/check` 报 `missing-field` 的最常见来源。把两边放在同一 turn 内做，整类错误就被消灭。
+
+## Foundation 是终端节点
+
+`/ingest` 不得修改 foundation 页面。没有 `key_papers` 字段，也没有任何形式的反向引用。一篇论文链到 foundation，只留下两处痕迹：
+
+- 论文页面 `## Related` 中的 `[[foundation-slug]]`
+- `wiki/graph/edges.jsonl` 中一条 `paper → foundation`、type 为 `derived_from` 的 edge
+
+foundation 仅由 `/prefill` 创建。`/ingest` 永远不新建 foundation —— 即便某个 concept 候选看起来像是 foundational 却没有匹配。这种情况下，走普通 concept 路径（必要时新建 concept 页面），让用户日后需要时自行 seed foundation。
+
+## paper-to-concept 语义 edge
+
+paper 与 concept 的关系是使用、引入、扩展或批评。每条 paper-to-concept 语义 edge 都必须带 `--confidence high|medium|low`。
+
+edge 类型选择：
+
+- **`introduces_concept`** —— 严格的新颖性：论文明确把该 concept 作为贡献来提出、命名或定义。
+- **`uses_concept`** —— 默认选项：论文依赖已有 concept，但没有实质修改它。
+- **`extends_concept`** —— 论文修改、泛化、特化或形式化已有 concept。
+- **`critiques_concept`** —— 论文指出某个 concept 的限制、失败模式或错误假设。
+
+在 `introduces_concept` 与 `uses_concept` 之间不确定时，选 `uses_concept`。在 `uses_concept` 与 `extends_concept` 之间不确定时，也选 `uses_concept`。不要再写 `paper → concept` 的 `supports` 或普通 `extends`。
+该工具会拒绝缺少 confidence/evidence 的新写入，也会拒绝 legacy paper-to-concept edge 类型。
+
+## paper-to-paper edge
+
+bibliographic 层与 semantic 层分开：
+
+- 当 reference 能解析到已有 `wiki/papers/{slug}.md` 时，总是写 `graph/citations.jsonl`，`type: cites`
+- 只有论文文本给出清晰语义信号时，才写 `graph/edges.jsonl`
+- 不要把每条 citation 都强行解释成 semantic edge
+
+paper-to-paper semantic edge 应该保持稀疏。它要求两篇论文的贡献之间有具体关系，而不是仅仅共享主题、模态、架构族、benchmark 族或高层方法词。如果同一句描述可以同时套到 wiki 里几十篇论文上，就不要写 paper-to-paper edge；交给 topic/concept 链接和 citation 层表达。
+
+semantic edge 类型选择：
+
+- **`same_problem_as`** —— 对称；两篇论文处理同一个具体任务、研究问题或问题形式化，因此它们的答案可以直接比较。不要因为都属于 "attention"、"video generation" 或 "LLM evaluation" 这类宽泛方向就使用它。当两篇论文从不同角度攻同一问题（即原 `complementary_to` 情景）时，也用这个类型。
+- **`similar_method_to`** —— 对称；两篇论文共享有辨识度的机制、形式化、训练策略或算法设计。不要因为都"使用 transformer"、"使用 diffusion" 或 "使用 RL" 就使用它。
+- **`builds_on`** —— 有方向；当前论文直接依赖、改造或扩展另一篇论文的具体方法、形式化、数据集、结果或系统。包含"improves on"情景 —— 当前论文宣称在质量/效率/适用范围上优于前作时也写 `builds_on`。不要用于模糊的 inspiration。
+- **`challenges`** —— 有方向；当前论文削弱、质疑或给出反证，挑战另一篇论文的结果、假设或 framing。
+
+注：`compares_against` / `improves_on` / `surveys` / `complementary_to` 已被移除。
+比较 baseline 归入 `cites`；"improves on" 是 `builds_on` 的子集；
+survey 关系由 `papers.contribution_type` 包含 `survey` 派生。
+
+所有 paper-to-paper semantic edges 都必须带 `--confidence high|medium|low`。对称类型由 `tools/research_wiki.py add-edge` 自动规范 endpoint 顺序并写入 `symmetric: true`。
+该工具会拒绝缺少 confidence/evidence 的新写入，也会拒绝 legacy paper-paper edge 类型。
+
+- **无 / 跳过** —— 以上都不能干净对应时，跳过 semantic edge。graph 噪声比缺一条 edge 更糟。
+
+不确定时，跳过。paper-to-paper semantic edge 用于高信号的局部关系，不用于按领域聚类。
+
+## 正反两侧原子写入
+
+`/ingest` 写的每一条链接，反向都应在同一 turn 内落地。具体做法：
+
+1. 决定建立此链接。
+2. 在源页面写正向条目。
+3. 在目标页面写反向条目。
+4. 若该链接对应一条 semantic graph edge（paper↔concept、paper↔paper、paper→foundation），通过 `tools/research_wiki.py add-edge` 写出。
+5. 若一条 paper reference 能解析到已有 paper 页面，通过 `tools/research_wiki.py add-citation` 写出 bibliographic 记录。
+
+这种做法让 `/check` 下一轮不会报半吊子链接。也让回滚变简单：若某篇论文 ingest 被中止，直接撤销该论文的编辑就能把两侧同时撤销。
+
+## `/ingest` 在此处不做的检查
+
+`/ingest` 边写边写反向链接，但不会审计 wiki 中既有链接是否仍有反向。那是全图审计，属于 `/check`。不要在 ingest 过程中全量读 `wiki/` 去查已有的反向缺失 —— 时间与 token 成本都不小，而且与 `/check` 做重复工作。

--- a/.qoder/skills/ingest/references/dedup-policy.md
+++ b/.qoder/skills/ingest/references/dedup-policy.md
@@ -1,0 +1,73 @@
+# /ingest 去重策略
+
+准备新建或更新一个 concept、method 或 foundation 链接前，打开此参考。
+
+## 心智模型
+
+一个健康的 ΩmegaWiki 里，concept 与 method 的数量远少于 paper。每个 concept 由许多深化或扩展它的 paper 共享；每个 method 由许多复用或扩展它的 paper 共享。如果 `/ingest` 默认为每篇论文都新建 concept / method，wiki 会迅速沦为一堆近似重复的页面 —— 综述生成、gap 检测、idea novelty、citation 推理全部会被这种噪声破坏。
+
+默认动作是**合并**。例外才是**新建**，并且每次新建都必须有清晰的理由。
+
+## 何时打开此参考
+
+- `/ingest` Step 4：识别论文引入或扩展的 concept 时。
+- `/ingest` Step 4：识别论文引入的 method（命名、可复用、可被引用）时。
+- 任何想"为保险起见"新建 concept / method 却没先查重的时刻。
+
+## 强制工具调用
+
+新建 concept 前，先调用去重工具：
+
+```bash
+"$PYTHON_BIN" tools/research_wiki.py find-similar-concept wiki/ "<candidate title>" --aliases "<a,b,c>"
+```
+
+返回按相似度排序的 JSON 列表。`find-similar-concept` 同时扫描 `wiki/concepts/` 与 `wiki/foundations/`，并给每条结果打 `entity_type` 标签。工具是相似度的真相来源；不要用肉眼重新估算分数。
+
+method 没有 `find-similar-method` 工具。直接扫 `wiki/methods/*.md`：阅读每个已有 method 的 `name`、`tags` 与 `## Mechanism` 摘要，手工判断候选是否就是同一项技术换了个名字。使用与 concept 相同的合并偏好（默认合并；只在确实不同时才新建）。
+
+跳过查重是 wiki 膨胀最常见的原因。即便你觉得本 session 早些时候已经读过相关页面，也仍要查重 —— 换句话说的近似重复很容易从人工扫描里滑过。
+
+## 决策规则
+
+concept 读取 top 结果的 `score`：
+
+- **top 结果是 foundation 且 score ≥ 0.40** —— 走 foundation link 路径。候选是教科书级背景知识，不是新机制。在 `edges.jsonl` 写一条 `derived_from` edge，在 paper 的 `## Related` 里写 `[[foundation-slug]]`。不得修改 foundation 页面（foundation 是终端节点，见 `references/cross-references.md`）。foundation link 不计入每篇论文的新建上限。
+- **score ≥ 0.80** —— 合并。候选与 top 是同一概念。把本论文追加到已有页面的 `key_papers`，补 graph edge，写反向链接。concept 默认用 `uses_concept`；只有论文实质修改、泛化或特化该 concept 时才用 `extends_concept`；只有明确批评时才用 `critiques_concept`。不要新建文件。
+- **score 0.40–0.80** —— 阅读 top 的 `## Definition` 再决定。默认合并。只有当你能指出具体的技术差异时才新建：不同机制、不同形式化。若候选是已有 concept 的有意义子类，合并并在 `## Variants` 追加一条 bullet，而不是拆分。
+- **score < 0.40 或结果为空** —— 无已有匹配。允许新建，但要遵守下面的每篇上限。
+
+method 把 "score" 替换为人工判断：同名 + 同机制 ⇒ 合并（追加 `source_papers`）；不同机制 ⇒ 仅当新技术可命名、可复用、且很可能被未来论文引用时才新建。无论是否新建 `methods/` 页面，论文页面自身的 `## Method` 正文章节都捕捉这篇论文的方法叙述。
+
+过度合并代价低：合并错了的页面可以日后拆分，历史保留。过度新建代价高：近似重复会静默污染所有下游 skill，事后难以察觉。
+
+## 每篇论文的新建上限
+
+上限的目的是让默认行为保守。它不是要填满的配额。
+
+- importance < 4：最多 **1** 个新 concept、**1** 个新 method
+- importance ≥ 4：最多 **3** 个新 concept、**2** 个新 method
+- foundation link 不计入。
+
+后续候选若会超过上限，就合并到最接近的已有条目 —— 即使其分数低于通常的合并阈值。若确实没有可安全合并的候选，就整体跳过该实体 —— `/check` 会在后续扫描里把缺口暴露出来，用户可决定是否 `/edit` 补齐。
+
+## 只做形状检查，不做语义审计
+
+确实要新建或编辑 concept / method 页面时，对它跑与 paper 页面相同的狭窄形状检查：
+
+- 每个必需 frontmatter 字段存在且非空
+- concept：`maturity` ∈ {`stable`, `active`, `emerging`, `deprecated`}；`definition` 是单句（正文 `## Definition` 可以展开）
+- method：`type` ∈ {`architecture`, `training`, `inference`, `evaluation`, `data`, `benchmark`, `system`, `optimization`, `prompting`, `protocol`, `other`}
+- YAML 可解析
+
+该检查能避免 `/check` 下一轮把明显残缺的页面全部捞出。超出这个范围的一切 —— 反向链接对称性、concept 的 `linked_ideas` 是否被对向引用、method 的 `parent_methods` 链是否一致 —— 属于 `/check`。把这些审计搬进 `/ingest` 只会拖慢 skill 并与 `/check` 做重复工作。
+
+## `/check` 负责的、`/ingest` 不负责的
+
+- 跨实体反向链接对称性（A 链接到 B ⇒ B 是否链回 A）
+- dangling node 检测（被引用但缺失的页面，或存在但不可达的页面）
+- ideas 与 experiments 的 status 一致性
+- edge 类型合法性与 edge 去重
+- 上述一切的分级修复建议
+
+你可以信任 `/check` 去发现这些并产出修复报告。`/ingest` 聚焦在**写入点**做出 well-shaped 的实体与正确的正向/反向链接即可。

--- a/.qoder/skills/ingest/references/error-handling.md
+++ b/.qoder/skills/ingest/references/error-handling.md
@@ -1,0 +1,57 @@
+# /ingest 错误处理
+
+某个步骤失败时打开此参考。`/ingest` 倾向于优雅降级：记录发生了什么、继续能继续的部分、在最终报告里把缺口暴露给用户。
+
+## 来源解析
+
+- **`.tex` 解析失败**：若同目录下有 PDF，fallback 到 PDF。
+- **PDF 文本提取失败**：对前几页走 vision API 恢复 title 与 abstract，再带上恢复的 title 走 `references/pdf-preprocessing.md` 的预处理流程。
+- **完全没有可读来源**：停机并报告。不得仅凭 title 就创建论文页面 —— 无内容支撑的论文页面是噪声。
+- **INIT MODE 输入不可读**：不得尝试重新 prepare（INIT MODE 下 `raw/` 只读）。停机、记录失败，让上层 `/init` 在 fan-in 时决定重试或跳过。
+
+## 外部 API
+
+- **Semantic Scholar 不可用**（`fetch_s2.py paper` 报错）：跳过 S2 enrichment，`importance` 默认取 3，并在报告中说明该值为临时值。本轮 ingest 的 citation 回填步骤整体跳过。
+- **DeepXiv 不可用**（`fetch_deepxiv.py` 报错）：静默跳过 enrichment。DeepXiv 是可选项，缺它只是 plainer ingest，不是降级 ingest。除非用户专门问起 DeepXiv，不要在用户报告中提及。
+- **arXiv 源抓取失败**：论文在 arXiv 上但源归档不存在或超时，走 PDF 路径。在最终报告中记录一条 warning。
+
+## slug 冲突
+
+- **生成的 slug 与一个具有不同 arXiv ID 或 title 的已有页面撞名**：停机并报告。不得静默追加数字后缀 —— 两个不同论文落到同一 slug，是 wiki 命名问题的信号，应由用户解决。
+- **生成的 slug 与同一篇论文的已有页面撞名**：该论文已 ingest，报告并退出。
+- **单次 ingest 内，某个 concept / method 生成的 slug 与另一不同页面撞名**：通过工具内置冲突处理追加数字后缀（`-2`、`-3`……）。这是唯一允许追加后缀的场景 —— 两种真正不同的想法在确定性规则下生成同一 slug。
+
+## wiki 未初始化
+
+若 `wiki/` 不存在或为空，执行：
+
+```bash
+"$PYTHON_BIN" tools/research_wiki.py init wiki/
+```
+
+然后重跑 `/ingest`。不得在未初始化的 wiki 里创建页面；`index.md` 与 `graph/` 脚手架必须先就位。
+
+## ingest 过程中的部分失败
+
+若某次 ingest 在部分写入后失败（论文页面已写入，但 concept 去重或 graph edge 失败）：
+
+- 不得回滚已成功的写入
+- 通过 `tools/research_wiki.py log` 追加一条日志，说明哪些步骤完成、哪些未完成
+- 在用户报告中暴露未完成的步骤，让用户通过 `/edit` 或 `/check --fix` 收尾
+- INIT MODE 下，若 ingest 成功完成，子代理必须在退出前于 worktree 内 commit（见 `references/init-mode.md`）。若 ingest 部分失败，**不要** commit 不完整状态；让上层 `/init` 在 fan-in 时处理该失败的 worktree
+
+## 停机 vs 继续
+
+以下情况直接停机：
+
+- 完全无法读取来源
+- 论文已 ingest（slug + arXiv ID 与已有页面一致）
+- slug 冲突会静默覆盖另一个不同的已有论文
+
+以下情况带 warning 继续：
+
+- 某一项 enrichment 源（S2 或 DeepXiv）宕机
+- reference list 无法解析（跳过 Step 5；论文 ingest 主体仍可完成）
+- 单个 concept / method 去重调用偶发失败（重试一次；仍失败就跳过该候选并记录）
+
+核心原则：保留了一个 well-shaped 论文页面的部分 ingest，比什么都没写的干净 abort 更有用。部分状态可以通过 `/check` 与 `/edit` 恢复；丢失的部分状态则不可恢复。

--- a/.qoder/skills/ingest/references/init-mode.md
+++ b/.qoder/skills/ingest/references/init-mode.md
@@ -1,0 +1,58 @@
+# /ingest INIT MODE 与并行安全
+
+当 `/ingest` 被 `/init` 作为并行子代理调用，或你需要理解并发 ingest 会对共享文件做什么时，打开此参考。
+
+## 何时处于 INIT MODE
+
+只要 `/ingest` 的来源路径来自 `.checkpoints/init-sources.json`，就处于 INIT MODE。上层 `/init` 会为每篇论文在隔离的 `git worktree` 内跑一个 `/ingest`，流程见 `skills/init/references/parallel-ingest.md`。
+
+在 INIT MODE 下：
+
+- 来源始终是 `/init` 已经 prepare 过的 `canonical_ingest_path`（用户自有论文是 `raw/tmp/...`，外部引入论文是 `raw/discovered/...`）
+- `raw/` 严格只读 —— 不得写 `raw/tmp/`、`raw/discovered/`，也不得写 `raw/` 下任何路径
+- **跳过** `fetch_s2.py citations <arxiv-id>` 与 `fetch_s2.py references <arxiv-id>` —— 由上层 `/init` 在 fan-in 时统一做 citation sweep
+- **跳过** `rebuild-context-brief` 与 `rebuild-open-questions` —— 上层在所有子代理 merge 后统一运行一次
+- **跳过** 易冲突的 topic 写入 —— 多个并行 ingest 同时 append 相同 topic 会引发 merge 冲突。让上层在 fan-in 后处理 topic 更新，或交给 `/edit`。
+- **跳过对已有页面的反向链接编辑** —— 不要向已有 concept 页面追加 `key_papers`，不要向已有 paper 页面的 `## Key papers` 或 `## Related` 追加内容，也不要向已有 people 页面追加内容。只通过 `tools/research_wiki.py add-edge` 记录关系。上层 `/init` 在 fan-in 后统一重建这些反向链接。
+
+其余一切（paper 页面创建、通过 `find-similar-concept` 做 concept 去重、通过手工扫描 `wiki/methods/` 做 method 去重、people 页面创建、paper 的 `## Related` 链接、concept / method / foundation 的 graph edge）在每个子代理内正常执行。
+
+## 如何识别 INIT MODE
+
+`/init` 会在子代理 prompt 中传入 canonical path。任一下列信号出现即判定为 INIT MODE：
+
+- 来源路径以 `raw/tmp/` 或 `raw/discovered/` 开头，**且** `.checkpoints/init-sources.json` 引用到该路径
+- 子代理 prompt 显式写出 "INIT MODE"
+
+两个信号都缺失时，按用户直接调用处理，跑完整 workflow（包含 citation、rebuild，以及 `raw/tmp/` prepare 的必要步骤）。
+
+## 并行安全写入
+
+即便不在 INIT MODE 下，也应假设有另一个 `/ingest` 在并发运行 —— 批量 ingest 已在路线图上。三条规则能让并发写入安全：
+
+1. **共享文件的每次写入都经过工具。** `graph/edges.jsonl`、`graph/citations.jsonl`、`index.md`、`log.md` 分别通过 `tools/research_wiki.py add-edge`、`add-citation`、index 更新命令、`log` 写入。工具层使用 append 语义，仓库 `.gitattributes` 对这几条路径声明了 `merge=union`，并行 worktree 可以无冲突地 merge。
+2. **slug 的分配是确定性的。** `tools/research_wiki.py slug "<title>"` 对同一 title 始终给出同一 slug，和 worktree 无关。冲突由工具内部以数字后缀解决，不允许临时自行重命名。
+3. **绝不对共享文件加锁或整体改写。** 把 `wiki/index.md`、`wiki/graph/edges.jsonl` 或 `wiki/graph/citations.jsonl` 作为整体块替换写回，会在 worktree merge 时覆盖并行 peer 的工作。用工具命令即可，它们做 append。
+
+## 并行创建新页面
+
+当两个并行 `/ingest` 子代理都需要同一个 concept slug 时，两边都会尝试创建，fan-in merge 会失败。缓解措施：
+
+- 每篇论文的新建上限（见 `references/dedup-policy.md`）让冲突面本就很小
+- `/init` 在上层按顺序 merge worktree branch；第二个 worktree 写同一 slug 时，顺序 merge 会作为冲突暴露出来，由上层在 fan-in 时采用先到先得并对后者重跑 `find-similar-concept`
+- 不要在 ingest 过程中跨 worktree 自行协调 —— worktree 的隔离是设计目的
+
+如果在非 INIT 直连 ingest 下发现 slug 冲突（即已有论文页面使用同一 slug 但 arXiv ID 不同），按 `references/error-handling.md` 停机并报告，不得强行写入。
+
+## `/ingest` 不为 `/init` 做的事
+
+- 不 stash，也不切换 branch。
+- 不 merge worktree，也不跑 `dedup-edges`、`rebuild-index`、`lint.py --fix`。这些是 fan-in 操作，归 `/init`。
+
+在 INIT MODE 下，`/ingest` **必须**在成功完成后于 worktree 内提交结果：
+- 将 `wiki/` 下所有新建或修改的文件加入暂存区
+- commit 前先执行 `git branch --show-current`，确认当前 branch 是 worktree branch（包含 `init-` 前缀），而不是 base branch。若在 base branch 上，停止并报告，不要 commit
+- 执行 `git commit -m "ingest: <论文标题>"`（或含义类似的提交信息）
+- 不要 push；上层 `/init` 会在 fan-in 时合并该分支
+
+若 ingest 过程中部分失败（partial failure），**不要** commit 不完整状态。让上层 `/init` 在 fan-in 时处理该失败的 worktree。

--- a/.qoder/skills/ingest/references/pdf-preprocessing.md
+++ b/.qoder/skills/ingest/references/pdf-preprocessing.md
@@ -1,0 +1,58 @@
+# /ingest PDF 预处理
+
+当 `/ingest` 接收到本地 `.pdf` 且需要转换成 prepared `.tex` 以便后续 ingest 时，打开此参考。INIT MODE 下跳过 —— `/init` 已经做过等价的批量预处理并交接了 canonical path。
+
+## 为什么要做预处理
+
+裸 PDF 作为 ingest 来源质量不佳：文本提取不稳定，公式与图表标题容易丢失，reference list 也经常不可靠。如果论文在 arXiv 上，把它解析到 arXiv ID 并抓取 TeX 源就能显著改善。即便没有 arXiv 源，我们也要把 PDF 统一规范成 synthetic `.tex`，让 `/ingest` 的其余步骤基于统一的输入形状运行。
+
+这与 `tools/init_discovery.py prepare` 在 `/init` 批量处理本地 PDF 时执行的流水线是同一套 —— 此处是把它单篇、就地执行一遍。
+
+## 恢复顺序
+
+严格按此顺序执行，遇到第一个产出可信结果的步骤即停止。
+
+1. **agent 先读 PDF 本身。**
+   调用任何工具前，先打开 PDF 并记录：
+   - 可信的论文标题（优先使用首页标题，不要用 PDF metadata —— 后者经常是错的）
+   - 若首页或 header 明确印出 arXiv ID，也记录该 ID
+   两者皆可为空。不要臆测。
+2. **文件名 / 路径中的 arXiv ID 提取。**
+   `prepare_paper_source.py` 本身会以正则匹配文件名或所在目录中的 arXiv ID，无需你自己做 —— 只要把 PDF 路径交给它即可。
+3. **基于标题的 Semantic Scholar 查找。**
+   仅当 agent 提供了可信标题时触发。由 `prepare_paper_source.py` 在传入 `--title` 后内部处理。
+4. **arXiv 源抓取。**
+   当 arXiv ID 已知（来自步骤 1 或 2），helper 将 TeX 源下载到 `raw/tmp/papers/.../<slug>-arxiv-src/` 并用它作为 prepared source。
+5. **synthetic `.tex` fallback。**
+   如果以上都无法匹配到 arXiv，helper 会在 `raw/tmp/` 下生成一份从 PDF 文本提炼的 synthetic `.tex`。该文件对 ingest 来说够用，但会被明确标记为 fallback。
+
+## 调用
+
+拿到（可能为空的）标题与 arXiv ID 后，执行：
+
+```bash
+"$PYTHON_BIN" tools/prepare_paper_source.py \
+  --raw-root raw \
+  --source <pdf-path> \
+  [--title "<agent-recovered-title>"] \
+  [--arxiv-id "<agent-recovered-arxiv-id>"]
+```
+
+- 只有 agent 确实可信才传 `--title`。不要把从 PDF metadata 或文件名派生的标题当作权威输入 —— helper 本身会对这些做 sanitize，若把它们当权威会污染 Semantic Scholar 查找。
+- 只有 agent 从页面上读到 arXiv ID 才传 `--arxiv-id`。文件名中的 ID 由 helper 自动识别。
+- 两者都不可信时，同时省略这两个参数。helper 会干净地 fallback。
+
+helper 在 `raw/tmp/` 下写出一个 prepared 条目，并在 stdout 打印一份含 `prepared_path`、`title`、`arxiv_id` 与任何 warning 的 JSON 记录。后续 `/ingest` 步骤以 `prepared_path` 为来源。
+
+## 标题权威性
+
+当 agent 提供了可信标题时，该标题即是论文页面 `title` 字段的权威取值。从抓取到的 TeX 或 PDF metadata 中 sanitize 出来的标题只是 fallback 显示字符串，不得覆盖 agent 标题。这很重要：agent 标题是成功触发 S2 查找的那一个，如果让解析到的 TeX 标题覆盖它，会造成微妙的身份漂移。
+
+## 输出
+
+成功的预处理产出 `raw/tmp/` 下的一个 prepared source 条目：
+
+- 若已抓到 arXiv 源：`raw/tmp/papers/<slug>-arxiv-src/` 目录，包含原始 `.tex` 树
+- 否则：`raw/tmp/papers/<slug>.tex` synthetic 文件，由 PDF 文本提炼
+
+从这一点开始，把 prepared 条目当作普通的用户提供的本地 `.tex` 对待即可。不要把 PDF 复制回 `raw/papers/`；原始 PDF 路径仍属用户自有产物。

--- a/.qoder/skills/init/SKILL.md
+++ b/.qoder/skills/init/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: init
+description: 基于用户素材与可选外部发现搭建 ΩmegaWiki，并用并行 `/ingest` 完成最终论文集的消化
+---
+
+# /init
+
+> **用法**：`[topic] [--no-introduction]`
+
+
+> 从 `raw/` 搭建 wiki：先做确定性 prepare，再跑 planner-guided discovery；`raw/notes/` 与 `raw/web/` 可种下 provisional scaffold；论文消化仍走并行 `/ingest` fan-out / fan-in。
+
+按需打开这些本地参考文件：
+
+- `references/prepare-and-discovery.md` — prepare 流程、最终选择、fetch 与 source-manifest 规则
+- `references/planner-policy.md` — planner 行为与 LLM 裁剪期望
+- `references/parallel-ingest.md` — worktree 隔离、子代理 prompt 合同、merge 与清理
+
+## Inputs
+
+- `topic`（可选）：研究方向关键词；当 `raw/` 已定义 seed set 时可省略
+- `--no-introduction`（可选）：禁用外部发现；仅在用户明确要求时使用
+- 用户自有素材：`raw/papers/`、`raw/notes/`、`raw/web/`
+
+## Outputs
+
+- `wiki/` 骨架与 provisional 页面（Summary、topics、ideas、concepts）
+- `raw/tmp/` 与 `raw/discovered/` 预处理来源
+- 并行 `/ingest` 产出的最终论文页面
+- `.checkpoints/init-*.json` 清单，用于恢复与重放
+- 更新后的 `wiki/index.md`、`wiki/log.md`、`wiki/graph/*`
+- 重新生成的可视化产物：`wiki/.obsidian/graph.json`（按实体类型的 colorGroups）与 `wiki/canvases/*.canvas`（best-effort，见 Step 6）。交互式网页 Graph 视图由 `tools/serve.py`（SPA）提供服务，不再单独生成产物。
+
+## Wiki Interaction
+
+### Reads
+
+- `raw/papers/`、`raw/notes/`、`raw/web/`
+- `.checkpoints/init-prepare.json` 与 `.checkpoints/init-sources.json`，供 resume、planning 与 fan-out 使用
+- `wiki/index.md` 以及已有 `wiki/topics/`、`wiki/ideas/`、`wiki/concepts/`、`wiki/methods/`，用于去重与 scaffold 对齐
+
+### Writes
+
+- `wiki/` scaffold 与 provisional 页面
+- `raw/tmp/` 与 `raw/discovered/`
+- `wiki/index.md`、`wiki/log.md`、`wiki/graph/*`
+- `.checkpoints/init-prepare.json`、`.checkpoints/init-plan.json`、`.checkpoints/init-sources.json` 与 `init-session` checkpoint metadata
+
+### Graph edges created
+
+- `/init` 本身只在 provisional 页面需要时写入少量 scaffold 级别的 edges
+- 论文驱动的 edges 全部委托给 `/ingest`
+
+## Workflow
+
+**前置条件**：当前目录为项目根，且包含 `wiki/`、`raw/`、`tools/`。设 `WIKI_ROOT=wiki/`。先解析一次 `PYTHON_BIN`，并在整个 `/init` 流程里复用它，确保运行时使用与 `setup.sh` 安装依赖时相同的解释器：
+
+```bash
+# 通过 git 找到项目根，让 worktree 中的 subagent 也能定位 .venv。
+# .venv 被 gitignore，subagent 的 cwd 在 ../.worktrees/<branch>/ 时本地没有
+# .venv——若不解析项目根，PYTHON_BIN 会回退到系统 python3，既丢失 .env 里的
+# API key，也丢失安装的依赖（deepxiv-sdk 等）。
+# git rev-parse --git-common-dir 无论 cwd 位于哪个 worktree 都返回主仓库的
+# .git 目录；其父目录即项目根。
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null || true)
+PROJECT_ROOT=""
+if [ -n "$GIT_COMMON_DIR" ]; then
+  PROJECT_ROOT=$(cd "$(dirname "$GIT_COMMON_DIR")" 2>/dev/null && pwd)
+fi
+
+if   [ -x "$PROJECT_ROOT/.venv/bin/python" ];         then PYTHON_BIN="$PROJECT_ROOT/.venv/bin/python"
+elif [ -x "$PROJECT_ROOT/.venv/Scripts/python.exe" ]; then PYTHON_BIN="$PROJECT_ROOT/.venv/Scripts/python.exe"
+elif [ -x .venv/bin/python ];                         then PYTHON_BIN=.venv/bin/python
+elif [ -x .venv/Scripts/python.exe ];                 then PYTHON_BIN=.venv/Scripts/python.exe
+else                                                       PYTHON_BIN=python3
+fi
+export PYTHON_BIN
+```
+
+### Step 1: 初始化 wiki 结构
+
+```bash
+"$PYTHON_BIN" tools/research_wiki.py init wiki/
+```
+
+创建标准目录、`graph/`、`outputs/`、`index.md` 与 `log.md`。这里不要重复写第二条 init 日志。
+
+### Step 2: 把本地输入 prepare 到 `raw/tmp/`
+
+```bash
+"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --pdf-titles-json .checkpoints/init-pdf-titles.json --output-manifest .checkpoints/init-prepare.json
+```
+
+- 在运行 `prepare` 前，先读取每个本地 PDF，并把恢复 handoff 写入 `.checkpoints/init-pdf-titles.json`。格式既可以是 `{ "raw/papers/foo.pdf": "Recovered Paper Title" }`，也可以是在已知可信 arXiv ID 时写成 `{ "raw/papers/foo.pdf": { "title": "Recovered Paper Title", "arxiv_id": "2401.00001" } }`
+- 使用 `"$PYTHON_BIN" tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"] [--arxiv-id "<recovered-arxiv-id>"]` 做本地论文规范化
+- 本地 PDF 的恢复顺序必须严格遵守：handoff 进来的 arXiv ID 或 filename/path 中的 arXiv ID -> agent 恢复出的标题经 Semantic Scholar 搜索 -> 抓取到的 arXiv 源码 -> synthetic `.tex`
+- 如果 agent 已经提供了 PDF 标题，就把这个标题当作 prepared manifest 的 authoritative title；抓取源码里提取出的标题只能作为经过清洗后的 fallback metadata，不能反过来覆盖 agent 标题
+- prepare 阶段不得把 PDF metadata 或正文文本当作 arXiv-ID hint
+- metadata 或 filename 中的标题最多只是 provisional display label，不能当作可信 identity，也不能作为标题检索输入
+- notes/web 保持原始来源路径，`/init` 在 planning 阶段直接读取
+- 本地论文若存在 usable 的 prepared 结果，其 `canonical_ingest_path` 必须指向 `raw/tmp/`；否则回退到原始 `raw/papers/...`
+- decode / 标题恢复 / arXiv 源码抓取失败时记录 warning，而不是中止 `/init`
+- prepare 的细化决策树与来源优先级见 `references/prepare-and-discovery.md`
+
+### Step 3: 生成 discovery plan、裁剪最终论文集，并写出 source manifest
+
+```bash
+"$PYTHON_BIN" tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json
+```
+
+- `mode=seeded` 取决于 prepare manifest 中是否存在可解析本地论文；否则为 `bootstrap`
+- `plan` 必须读取 `.checkpoints/init-prepare.json`，而不是重新扫描 `raw/`
+- skill 层只保留定性 planner 策略：优先 relevance、freshness、connectivity 与 survey coverage
+- 在 seeded 模式且 introduced 容量有限时，不要让偏旧且 citation 很高的 anchor 抢走太多名额
+- 在 bootstrap 模式下，如果确实有助于覆盖面，可以保留一篇偏旧 canonical anchor
+- 若 DeepXiv search 可用，要在工具打分里使用返回的 `relevance_score`，而不是只在文字里提一句
+- 精确 ranking weights、shortlist 常量与 threshold 计算都属于 `tools/init_discovery.py`；把工具视为实现层唯一权威，不要在 LLM 推理里重述或覆盖这些常量
+- 在 `fetch` 前读取 `.checkpoints/init-plan.json`，并把 over-picked 的 `shortlist` 明确裁成最终 **8-10** 篇
+- 在 `fetch` 前必须给出明确的最终选择结果，至少包含 `shortlist_count`、`final_count` 与按 shortlist 顺序排列的最终 `candidate_id` 列表
+- 若 `final_count` 不在 **8-10** 范围内，则必须先停止并修正最终选择，再执行 `fetch`；`--no-introduction` 或“用户已提供超过 10 篇可解析论文”除外
+- 若传入 `--no-introduction`，只有在用户明确要求只使用本地论文时，才走这一分支；即便如此也仍要执行 `fetch`（不给外部 ID），以写出 `.checkpoints/init-sources.json`
+- planner 行为、trim 期望与 source-of-truth 边界详见 `references/planner-policy.md`
+
+然后执行：
+
+```bash
+"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id> --id <candidate-id>
+```
+
+- `/init` 下载的论文只允许写入 `raw/discovered/`，绝不写入 `raw/papers/`
+- 若某篇候选已经由 prepared local source 覆盖，则禁止重复抓取
+- `.checkpoints/init-sources.json` 是下游 ingest 顺序的唯一真相源
+
+### Step 4: 在论文 ingest 前建立 scaffold 页面
+
+创建一篇 `wiki/Summary/{area}.md`、若干 `wiki/topics/{slug}.md`，以及来自 notes/web 的 provisional `ideas/`、`concepts/`，必要时还包括 `methods/`。
+
+规则：
+
+- notes/web 对“用户意图”是权威，对“文献置信度”不是权威
+- 每个 notes/web 派生页面都必须在 frontmatter 后立即写入这一行：
+
+```markdown
+Provisional note: seeded from raw/notes or raw/web during /init; pending validation from ingested papers.
+```
+
+- `topics/`：方向被明确提到或反复出现时创建
+- `ideas/`：用户明确提出或强烈暗示研究方向 / 假设时创建
+- `concepts/`：技术机制在 notes/web 中反复出现，或在 notes/web 与最终论文集中各出现至少一次时创建
+- `methods/`：除非用户在 notes/web 中显式命名了一项可复用、可被引用的 method，否则 `/init` 不创建 `methods/`；把论文中的 method 推升为可复用 method 实体是 ingest 的职责
+- `/prefill` 只是可选背景预填充，不属于 `/init`
+- `/init` 不得直接创建 `people/` 页面，也不得自动创建 foundations
+
+### Step 5: 通过 worktree 隔离并行 ingest 论文
+
+本步骤的论文来源只能来自 `.checkpoints/init-sources.json`：
+
+- `origin=user_local`：优先 ingest `raw/tmp/` 中的 canonical prepared `.tex`；prepare 失败时回退到原始 `raw/papers/...`
+- `origin=introduced`：ingest `raw/discovered/` 中抓取到的目录或 PDF
+
+并行 ingest 合同：
+
+- fan-out 前先 stash 无关脏文件，再把 `stash_ref`、`base_branch`、`base_commit` 写入 checkpoint metadata
+- fan-out 前必须先提交刚创建的 scaffold 与 init manifests，确保 `BASE_COMMIT` 真的包含后续子代理要继承的页面、manifest 与 handoff metadata
+- 创建 worktree 前先验证 `.gitattributes` 对 `wiki/log.md`、`wiki/graph/edges.jsonl`、`wiki/graph/citations.jsonl`、`wiki/index.md` 使用了 `merge=union`
+- `/init` 的 worktree 模式必须运行在一个命名分支上，不能处于 detached HEAD
+- 每个 worktree 都必须从 `BASE_COMMIT` 拉出，而不是复用已经签出的 `BASE_BRANCH`
+- 子代理 prompt 只能使用**相对路径**，且子代理的 shell 工作目录必须是 worktree 路径（`$WT_PATH`），不能是主仓库根目录
+- 只对一个 handoff 进来的 source path 执行 `/ingest`，不得绕过 `/ingest`
+- 在 INIT MODE 下，必须原样消费 handoff 给它的 canonical path
+- 跳过 `fetch_s2.py citations`
+- 跳过 `fetch_s2.py references`
+- 跳过每个子代理自己的 `rebuild-index`
+- 跳过每个子代理自己的 `rebuild-context-brief`
+- 跳过每个子代理自己的 `rebuild-open-questions`
+- 跳过易冲突 topic 写入
+- 子代理退出前必须在各自 worktree 内提交 ingest 结果，避免 fan-in 时 merge 到空 branch
+- worktree 命令、merge 顺序、fan-in 与清理见 `references/parallel-ingest.md`
+
+### Step 6: fan-in、rebuild 与最终报告
+
+全部子代理完成后：
+
+- 在 `BASE_BRANCH` 上按顺序 merge worktree branches
+- concept / method 冲突默认保守合并，不要扩散 near-duplicate 页面
+- 执行：
+
+```bash
+"$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/
+"$PYTHON_BIN" tools/research_wiki.py dedup-citations wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/
+"$PYTHON_BIN" tools/lint.py --wiki-dir wiki/ --fix
+```
+
+接着通过 Semantic Scholar 回填 `cites` 边 —— `fetch_s2.py references` 在每个 worktree 内被跳过（并发安全考虑），必须在此处串行补回。best-effort：S2 故障不可阻塞 `/init`。
+
+```bash
+"$PYTHON_BIN" tools/backfill_citations.py --wiki-dir wiki/ \
+  || echo "WARN: citation backfill failed or partial; check stderr above" >&2
+```
+
+随后重新生成可视化产物（best-effort；visualize 失败不可阻塞 `/init`）。`generate-obsidian-config` 会从 `config/visualize.json` 重写 `wiki/.obsidian/graph.json`，让按实体类型的 colorGroups 与运行时配置保持同步 —— Obsidian 的图谱视图在 `colorGroups` 为空时显示为无色节点，所以这一步保证图谱在每次重建后仍然可读。交互式网页 Graph 视图是 SPA 的 `#/graph` 路由（由 `tools/serve.py` 服务）；本阶段不生成单独的 HTML 文件。
+
+```bash
+"$PYTHON_BIN" tools/visualize.py generate-obsidian-config wiki/ \
+  || echo "WARN: visualize generate-obsidian-config failed; run /visualize manually" >&2
+"$PYTHON_BIN" tools/visualize.py generate-canvas wiki/ \
+  || echo "WARN: visualize generate-canvas failed; run /visualize manually" >&2
+```
+
+报告中必须分开列出：
+
+- 通过 `raw/tmp/` prepared path ingest 的用户论文
+- 因 prepare 失败而回退到原始 `raw/papers/` 的用户论文
+- `raw/discovered/` 中的 introduced 论文
+- 由 notes/web 种下的 provisional 页面
+- `/ingest` 新建的页面
+- `/ingest` 更新过的页面
+- 被跳过或失败的论文
+
+若 `stash_ref` 存在，在最后再 pop。若 stash pop 失败，保留 checkpoint 并在报告中说明。
+
+## Constraints
+
+- 不得仅根据仓库状态推断 `--no-introduction`。只有当用户明确要求禁用外部发现时，才可使用它。
+- `raw/papers/`、`raw/notes/`、`raw/web/` 是用户自有输入
+- `raw/tmp/` 与 `raw/discovered/` 是生成型 handoff 区；直接本地 `/ingest` 也可以在 `raw/tmp/` 下准备可复用的 local sidecar
+- `/init` 只能把外部论文写到 `raw/discovered/`；`/init` 与直接本地 `/ingest` 可以把生成的 prepared local source 写到 `raw/tmp/`
+- `/prefill` 是可选背景预填充，不属于 `/init`
+- 只有 `/prefill` 可以自动创建 foundations
+- `/init` 不得直接创建 `people/` 页面
+- notes/web 派生页面必须包含上面的 exact provisional notice
+- 对 concept 合并与 method 抽取，论文证据永远高于 notes/web
+- 所有论文 ingest 必须通过并行 `/ingest` 子代理执行
+- Step 5 必须读取 `.checkpoints/init-sources.json`，不得临时扫描目录
+- 精确的 planner 常量属于 `tools/init_discovery.py`，不属于重复写在 skill 文档中的常量
+
+## Error Handling
+
+- **`raw/papers/` 无可解析论文**：自动切换到 bootstrap 模式
+- **`raw/notes/` 与 `raw/web/` 为空**：跳过 provisional seeding，继续
+- **prepare 阶段的 PDF decode 失败**：保留本地来源，把 warning 记入 `.checkpoints/init-prepare.json`，必要时回退到原始路径
+- **没有恢复出可信 PDF 标题**：省略 `--title`，只允许走 filename/path arXiv-ID 恢复，然后直接回退到 synthetic `.tex`；metadata 或 filename 标题只用于显示
+- **`raw/notes/` 或 `raw/web/` 中检测到中文内容**：继续执行，但要保留 planner warning，说明 note/web 提取与排序可能更不可靠，并把 rankings 与 provisional 页面视为较低置信度
+- **S2 或 DeepXiv 不可用**：planner 使用剩余来源并继续执行；把 warning 保留在 checkpoint plan 中，并在最终报告里注明 discovery 降级
+- **某篇外部论文下载失败**：保留其余最终论文集，报告失败项
+- **单篇 ingest 失败**：写 checkpoint，跳过该篇，继续其他论文，并在最终报告中列出
+- **当前 checkout 处于 detached HEAD**：在 worktree fan-out 前停止，并要求用户先切换到或创建一个命名分支
+- **stash pop 失败**：保留 checkpoint metadata，并给出手动恢复提示
+- **可视化重生成失败**：警告并继续，绝不让 `/init` 失败。用户可单独跑 `/visualize --canvas` 排查，或直接通过 `python tools/serve.py` 浏览 SPA Graph 视图
+
+## Dependencies
+
+### Tools（via Bash）
+
+- `"$PYTHON_BIN" tools/research_wiki.py init wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py checkpoint-set-meta wiki/ init-session <key> <value>`
+- `"$PYTHON_BIN" tools/research_wiki.py checkpoint-save/load/clear wiki/ init-session ...`
+- `"$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py dedup-citations wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/`
+- `"$PYTHON_BIN" tools/research_wiki.py log wiki/ "<message>"`
+- `"$PYTHON_BIN" tools/visualize.py generate-obsidian-config wiki/`
+- `"$PYTHON_BIN" tools/visualize.py generate-canvas wiki/`
+- `"$PYTHON_BIN" tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"]`
+- `"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --pdf-titles-json .checkpoints/init-pdf-titles.json --output-manifest .checkpoints/init-prepare.json`
+- `"$PYTHON_BIN" tools/init_discovery.py plan [--topic "<topic>"] --mode auto --raw-root raw --wiki-root wiki --prepared-manifest .checkpoints/init-prepare.json --allow-introduction <true|false> --output-plan .checkpoints/init-plan.json`
+- `"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id>`
+- `"$PYTHON_BIN" tools/lint.py --wiki-dir wiki/ --fix`
+
+### Skills
+
+- `/ingest` — 每个子代理只 ingest 一篇论文，且运行在 INIT MODE
+- `/visualize` — Step 6 fan-in 直接调用 `tools/visualize.py` 重新生成 Obsidian 颜色组与 Canvas（best-effort）；用户也可以稍后手动调用 `/visualize` 做 `--focus` 视图，或在改了 `config/visualize.json` 后重新渲染
+
+### `init_discovery.py` 内部使用的外部 API
+
+- Semantic Scholar
+- DeepXiv（可选）
+- arXiv 下载端点

--- a/.qoder/skills/init/references/parallel-ingest.md
+++ b/.qoder/skills/init/references/parallel-ingest.md
@@ -1,0 +1,71 @@
+# /init Parallel Ingest
+
+当 `/init` 需要把来源交给并行 `/ingest` 子代理并把结果 merge 回来时，打开此参考文件。
+
+## Fan-out 前的安全步骤
+
+- 运行 `git status --short`。
+- 将 `wiki/`、`raw/papers/`、`raw/tmp/`、`raw/discovered/` 与 `.checkpoints/init-*.json` 视作 scaffold 文件。
+- 先 stash 这些路径之外的无关脏文件。
+- 先验证 `.gitattributes` 对 `wiki/log.md`、`wiki/graph/edges.jsonl`、`wiki/graph/citations.jsonl`、`wiki/index.md` 使用了 `merge=union`。
+- fan-out 前先提交 scaffold，确保 `BASE_COMMIT` 真的包含所有生成的页面与 manifests：
+
+```bash
+git add wiki/ raw/papers/ raw/tmp/ raw/discovered/ .checkpoints/init-prepare.json .checkpoints/init-plan.json .checkpoints/init-sources.json
+git commit -m "init: scaffold before parallel ingest" --no-gpg-sign
+BASE_COMMIT=$(git rev-parse HEAD)
+```
+
+- 用 `tools/research_wiki.py checkpoint-set-meta` 记录 `stash_ref`、`base_branch`、`base_commit`。
+- `/init` 的 worktree 模式要求当前位于一个命名分支上；detached HEAD 必须先停止。
+
+## 创建 Worktree
+
+每篇论文的 worktree 都应从 scaffold commit 拉出：
+
+```bash
+WT_BRANCH="init-${BASE_BRANCH//\//-}-<rank>-<paper-slug>"
+WT_PATH="../.worktrees/$WT_BRANCH"
+git worktree add -b "$WT_BRANCH" "$WT_PATH" "$BASE_COMMIT"
+```
+
+- 不要对当前 branch 名直接执行 `git worktree add`；Git 会因为该 branch 已经在主工作区签出而拒绝。
+- 论文顺序以 `.checkpoints/init-sources.json` 的 `shortlist_rank` 为准，而不是重新扫目录或按 citation count。
+
+## 子代理 Prompt 合同
+
+- 子代理的 shell 工作目录必须是 worktree 路径（`$WT_PATH`），而不是主仓库根目录。所有相对路径均从该路径解析。
+- 只对一个相对路径执行 `/ingest`。
+- 不得绕过 `/ingest`。
+- 在 INIT MODE 下，必须原样消费 handoff 给它的 canonical path。
+- 跳过 `fetch_s2.py citations`。
+- 跳过 `fetch_s2.py references`。
+- 跳过每个子代理自己的 `rebuild-index`。
+- 跳过每个子代理自己的 `rebuild-context-brief`。
+- 跳过每个子代理自己的 `rebuild-open-questions`。
+- 跳过易冲突 topic 写入。
+- 退出前必须在各自 worktree 内提交结果，确保 fan-in merge 的是实际 ingest commit。
+
+## Fan-in
+
+全部子代理完成后：
+
+1. 如有需要先切回 `BASE_BRANCH`，再按 planner 顺序在该 branch 上逐个 merge worktree branch。
+2. concept / method 冲突默认保守合并，不要扩散 near-duplicate 页面。
+3. 只 merge 已经产生 ingest commit 的 worktree branch。若某个 branch 没有提交结果，应先停止并修复，而不是硬合并。
+4. 运行：
+
+```bash
+git switch "$BASE_BRANCH"
+git merge --no-ff "$WT_BRANCH" --no-edit
+git worktree remove "$WT_PATH"
+git branch -d "$WT_BRANCH"
+"$PYTHON_BIN" tools/research_wiki.py dedup-edges wiki/
+"$PYTHON_BIN" tools/research_wiki.py dedup-citations wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-index wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-context-brief wiki/
+"$PYTHON_BIN" tools/research_wiki.py rebuild-open-questions wiki/
+"$PYTHON_BIN" tools/lint.py --wiki-dir wiki/ --fix
+```
+
+若 `stash_ref` 存在，在最后再 pop。若 stash pop 失败，保留 checkpoint 并在报告中说明。

--- a/.qoder/skills/init/references/planner-policy.md
+++ b/.qoder/skills/init/references/planner-policy.md
@@ -1,0 +1,27 @@
+# /init Planner Policy
+
+当 `/init` 需要读取 `.checkpoints/init-plan.json`、裁剪 shortlist、或解释 planner 的 warning / error 时，打开此参考文件。
+
+## 行为策略
+
+- seeded 模式下，如果用户省略 `topic`，就从本地论文标题/摘要以及 notes/web 信号里提取 discovery 与 ranking 线索。
+- bootstrap 模式下，如果 `topic` 与 notes/web 关键词都缺失，应把它记为 planner error，而不是发起空搜索。
+- 优先 relevance、freshness、connectivity 与 survey coverage。
+- 如有帮助，优先保留一篇 survey/overview。
+- 在 seeded 模式且 introduced 容量有限时，应让 freshness 主导，并避免偏旧外部非 survey 论文仅凭 citation 优势堆积进入结果。
+- 在 bootstrap 模式或非常宽裕的 seeded 情况下，如果确实有助于覆盖面，可以保留一篇偏旧 canonical anchor。
+- 若检测到中文 notes/web 内容，要保留 planner warning，说明提取与排序可靠性可能较低，并把 provisional 输出视为较低置信度。
+- 若 `SEMANTIC_SCHOLAR_API_KEY` 未配置，也继续执行；但要把公开限速路径记录为 planner warning。
+
+## LLM 裁剪期望
+
+- 在 `fetch` 前读取 `.checkpoints/init-plan.json`，并显式裁剪 over-picked 的 shortlist。
+- 即使 shortlist 看起来已经“差不多”，也不得跳过裁剪步骤。
+- 在 `fetch` 前给出最终选择结果，至少包含 `shortlist_count`、`final_count` 与最终 `candidate_id` 列表。
+- 如果最终数量超出允许范围，就先修正选择，再进入 `fetch`，除非命中已文档化的例外分支。
+
+## 真相源边界
+
+- `tools/init_discovery.py` 是精确 weights、thresholds、shortlist 常量与 scoring math 的唯一实现权威。
+- `SKILL.md` 与本参考文件只描述 orchestration 与行为期望。
+- 不要在这里重复写数字常量，也不要在 LLM 推理里覆盖工具拥有的确定性策略。

--- a/.qoder/skills/init/references/prepare-and-discovery.md
+++ b/.qoder/skills/init/references/prepare-and-discovery.md
@@ -1,0 +1,47 @@
+# /init Prepare And Discovery
+
+当 `/init` 需要 prepare 本地输入、选择最终论文集、或写出 `.checkpoints/init-sources.json` 时，打开此参考文件。
+
+## Prepare 流程
+
+- 执行 `"$PYTHON_BIN" tools/init_discovery.py prepare --raw-root raw --pdf-titles-json .checkpoints/init-pdf-titles.json --output-manifest .checkpoints/init-prepare.json`。
+- prepare 本地 PDF 前，先尽量恢复可信标题，并把结果写入 `.checkpoints/init-pdf-titles.json`。格式既可以是 `{ "raw/papers/foo.pdf": "Recovered Paper Title" }`，也可以是在已知可信 arXiv ID 时写成 `{ "raw/papers/foo.pdf": { "title": "Recovered Paper Title", "arxiv_id": "2401.00001" } }`。
+- `tools/init_discovery.py prepare` 必须把这些恢复出的标题和 ID 传给 `"$PYTHON_BIN" tools/prepare_paper_source.py --raw-root raw --source <local-path> [--title "<recovered-title>"] [--arxiv-id "<recovered-arxiv-id>"]`。
+- `tools/init_discovery.py prepare` 必须委托给同一个 helper 做本地论文规范化，并在已有预处理结果时复用现成的 `raw/tmp/` artifact。
+- 本地 PDF 只允许采用这一条恢复顺序：handoff 进来的 arXiv ID 或 filename/path 中的 arXiv ID -> 在提供可信标题时经 Semantic Scholar 按标题恢复 -> 抓取到的 arXiv 源码 -> synthetic `.tex`。
+- 如果 agent 已经提供了可信 PDF 标题，这个标题就是 prepared manifest 的 authoritative title。抓取到的 TeX 源码标题只能作为清洗后的 fallback metadata，不能覆盖 agent 标题。
+- prepare 阶段不得把 PDF metadata 或正文文本当作 arXiv-ID hint。
+- 恢复成功后，优先使用 `raw/tmp/papers/...-arxiv-src/` 下抓取到的原始 TeX 源码，而不是 synthetic `.tex`。
+- 如果拿不到可信 PDF 标题，就省略 `--title`；如果也拿不到可信 arXiv ID，就省略 `--arxiv-id`；随后只允许走 filename/path arXiv-ID 恢复，然后直接回退到 synthetic `.tex`。metadata 或 filename 标题只用于显示。
+
+## 来源优先级
+
+- 本地来源优先级：原始本地 `.tex` > archive 解出的源码 `.tex` 或抓取到的 arXiv 源码目录 > 由 PDF 生成的 synthetic `.tex` > 原始 `.pdf`。
+- notes/web 保持原始来源路径，`/init` 在 planning 阶段直接读取。
+- 如果 handoff 进来的来源已经在 `raw/tmp/` 或 `raw/discovered/` 下，就把它视为 canonical path，不要再复制进 `raw/papers/`。
+- 本地论文若存在 prepared 结果，其 `canonical_ingest_path` 必须指向 `raw/tmp/`；否则回退到原始 `raw/papers/...`。
+
+## 最终选择与 Fetch
+
+- `plan` 必须读取 `.checkpoints/init-prepare.json`，而不是重新扫描 `raw/`。
+- 先 over-pick 一个 shortlist，再在 `fetch` 前显式裁成文档规定的最终范围。
+- 默认保留所有可解析的用户论文，再用剩余名额选择 introduced 论文。
+- 如果 seeded discovery 最终没有新增外部论文，也要继续用用户自带论文集往下走，而不是把它当成 fatal planner error。
+- 如果用户已提供超过 10 篇可解析论文，则不再新增外部论文。
+- 如果 `--no-introduction` 开启，最终论文集 = 所有可解析本地论文；即便如此也仍要运行 `fetch`（不给外部 ID），以写出 `.checkpoints/init-sources.json`。
+
+执行：
+
+```bash
+"$PYTHON_BIN" tools/init_discovery.py fetch --raw-root raw --plan-json .checkpoints/init-plan.json --prepared-manifest .checkpoints/init-prepare.json --output-sources .checkpoints/init-sources.json --id <candidate-id> --id <candidate-id>
+```
+
+- `/init` 下载的论文只允许写入 `raw/discovered/`，绝不写入 `raw/papers/`。
+- 若某篇候选已经由 prepared local source 覆盖，则禁止重复抓取。
+
+## Source Manifest 合同
+
+- `.checkpoints/init-sources.json` 是 Step 5 ingest 顺序的唯一真相源。
+- 用户本地论文在 `init-sources.json` 中以 `origin=user_local` 记录，并在可用时带上 canonical prepared path。
+- introduced 论文在 `init-sources.json` 中以 `origin=introduced` 记录，其 canonical path 位于 `raw/discovered/`。
+- Step 5 必须原样消费 handoff 过来的 `canonical_ingest_path`。

--- a/.qoder/skills/novelty/SKILL.md
+++ b/.qoder/skills/novelty/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: novelty
+description: 多源 novelty 验证：WebSearch + Semantic Scholar + wiki + Review LLM cross-verify，输出 novelty 评分与建议。可选 --write，把分数写回 idea 页面。
+---
+
+# /novelty
+
+> **用法**：`<idea-description-or-slug> [--quick] [--verbose] [--write]`
+
+
+> 对一个研究想法或方法进行多源 novelty 验证。搜索 WebSearch、Semantic Scholar、
+> wiki 内已有工作和 arXiv 最新预印本，然后由 Review LLM 交叉验证，输出 novelty 评分（1-5）、
+> 最相似已有工作、差异化要点和下一步建议。
+> 可独立使用，也被 /ideate Phase 4 调用。
+
+## Inputs
+
+- `target`：以下之一：
+  - idea 的自由文本描述（一段话或几句话）
+  - wiki 中 ideas/ 页面的 slug（如 `sparse-lora-for-edge-devices`）
+  - 论文标题或 arXiv URL（检查该论文方法的 novelty）
+- `--quick`：快速模式，跳过 Review LLM cross-verify（Step 3），仅做搜索
+- `--verbose`：输出完整搜索结果，不仅是摘要
+- `--write`（可选，默认 **关闭**）：把得到的 `novelty_score` 持久化到 target frontmatter。**仅当 `target` 是 idea slug**（即 `wiki/ideas/{slug}.md` 存在）时生效。自由文本 target 与论文 novelty 检查无论是否带此 flag 都保持只读。视为用户可见参数 —— `/ideate` Phase 4 调用 `/novelty` 时显式传入；不得仅根据仓库状态推断。
+
+## Outputs
+
+- **Novelty Report**（输出到终端）：
+  - Novelty Score（1-5）
+  - 最相似的已有工作列表（top 3-5）
+  - 与每个已有工作的差异化要点
+  - Review LLM 交叉验证意见（除非 --quick）
+  - 推荐行动：proceed / modify / abandon
+- **idea 页面写入（仅当 `--write` 开启且 target 是 idea slug）**：通过 `tools/research_wiki.py set-meta` 更新 `wiki/ideas/{slug}.md` 的 `novelty_score` 字段。其他字段一律不动。
+
+## Wiki Interaction
+
+### Reads
+- `wiki/papers/*.md` — 搜索已有论文中是否有类似方法
+- `wiki/concepts/*.md` — 检查概念重叠
+- `wiki/methods/*.md` — 检查是否已有重叠的 method 实体
+- `wiki/ideas/*.md` — 检查是否与已有 idea 重复（特别是 failed ideas 的 failure_reason）
+- `wiki/graph/context_brief.md` — 获取全局上下文辅助搜索
+
+### Writes
+- `wiki/ideas/{slug}.md`（仅当 `--write` 开启且 target 是 idea slug）—— 设置 `novelty_score`，其余情况不写。
+- `wiki/log.md`（仅当发生写入时）—— 追加 "novelty | wrote novelty_score=N to ideas/{slug}"。
+
+### Graph edges created
+- **无**。
+
+## Workflow
+
+**前置**：确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）。
+
+### Step 1: 提取方法签名
+
+1. **若 target 是 slug**：读取 `wiki/ideas/{slug}.md`，提取 title、Hypothesis、Approach sketch
+2. **若 target 是自由文本**：直接使用
+3. **若 target 是 arXiv URL**：下载摘要，提取方法描述
+4. 从 target 中提取「方法签名」——方法的核心要素：
+   - **What**：做什么（任务/目标）
+   - **How**：用什么方法（技术路线）
+   - **Why novel**：声称的创新点
+5. 生成 3-5 个核心关键词用于后续搜索
+
+### Step 2: 多源搜索
+
+并行执行以下搜索（使用 Agent tool 并发）：
+
+**Source A — Web Search（5+ 查询）：**
+1. 直接查询：`"<method-name>" + "<task>"` 精确短语搜索
+2. 组件查询：`<component-1> + <component-2> + <domain>` 组件组合搜索
+3. Survey 查询：`"survey" OR "review" + <task-area> + 2024 2025`
+4. 竞品查询：`<alternative-approach> + <same-task>`
+5. 最新查询：`<method-keywords> + arXiv + 2025 2026`
+
+**Source B — Semantic Scholar + DeepXiv：**
+```bash
+python3 tools/fetch_s2.py search "<method-keywords>" --limit 20
+python3 tools/fetch_deepxiv.py search "<method-keywords>" --mode hybrid --limit 20
+```
+合并两个来源的结果（按 arxiv_id 去重）。DeepXiv 的混合语义搜索能发现 S2 关键词搜索遗漏的语义相似工作。
+- 对 top 5 结果获取详情和 TLDR：
+```bash
+python3 tools/fetch_s2.py paper <s2_id>
+python3 tools/fetch_deepxiv.py brief <arxiv_id>
+```
+使用 DeepXiv brief 的 TLDR 辅助快速判断方法相似度。
+**若 DeepXiv 不可用**：仅使用 S2 搜索（回退到原有行为）。
+
+**Source C — Wiki 内部搜索：**
+1. 扫描 `wiki/papers/` 所有页面的 Key idea 和 Method 段落
+2. 扫描 `wiki/concepts/` 的 Definition 和 Variants 段落
+3. 扫描 `wiki/ideas/` 的全部内容，特别关注：
+   - status = failed 的 ideas 及其 failure_reason（anti-repetition）
+   - status = proposed/in_progress 的 ideas（避免内部重复）
+4. 读取 `wiki/graph/context_brief.md` 获取全局视角
+
+**Source D — arXiv 近期预印本：**
+- 使用 WebSearch 查询 `site:arxiv.org <method-keywords> 2025 2026`
+
+### Step 3: Review LLM 交叉验证
+
+（若 `--quick` 则跳过此步）
+
+将以下信息提交 Review LLM 进行独立判断：
+
+```
+llm-review.chat:
+  system: "You are a senior ML researcher assessing the novelty of a proposed method.
+           Be rigorous: if the method is essentially a recombination of known techniques
+           with minor changes, score it low. Only score 4-5 if there is a genuinely new
+           insight or formulation."
+  message: |
+    ## Proposed Method
+    {method signature from Step 1}
+
+    ## Existing Similar Work Found
+    {top 5 similar works from Step 2, with title + one-line summary}
+
+    ## Questions
+    1. Is this method genuinely novel, or a minor variation of existing work?
+    2. What is the closest existing work and what's the real difference?
+    3. Novelty score 1-5 with justification.
+    4. If score <= 2, what modification could increase novelty?
+```
+
+### Step 4: 生成 Novelty Report
+
+综合 Step 2 搜索结果和 Step 3 Review LLM 意见，生成结构化报告：
+
+```markdown
+# Novelty Report: {idea title}
+
+## Score: {1-5}/5 — {label}
+
+| Score | Label | 含义 |
+|-------|-------|------|
+| 1 | Published | 已有高度相似的发表工作 |
+| 2 | Very Similar | 存在非常相似的方法，仅细节差异 |
+| 3 | Incremental | 在已有工作基础上有明确的增量贡献 |
+| 4 | Novel Combination | 创新性地组合已有技术，产生新 insight |
+| 5 | Fundamentally New | 提出全新范式或 formulation |
+
+## Closest Prior Work
+
+1. **{title}** ({year}) — {一句话描述相似之处}
+   - 差异：{本方法与之的关键区别}
+   - Wiki 链接：[[slug]]（若存在）
+2. ...
+
+## Review LLM Assessment
+{Review LLM 的独立判断摘要}
+
+## Anti-repetition Check
+- Wiki 中已有 failed ideas：{列出相关 failed ideas 及 failure_reason}
+- Wiki 中已有 in_progress ideas：{列出可能重叠的 ideas}
+
+## Recommendation
+- **{proceed / modify / abandon}**
+- 理由：{一段话}
+- 若 modify：建议的差异化方向：{具体建议}
+```
+
+**评分规则（综合判断）：**
+- Claude 搜索结果 和 Review LLM 意见取较低分（保守原则）
+- 若 wiki 中存在 failed idea 且 failure_reason 与本 idea 相关 → 降 1 分
+- 若 wiki 中存在 in_progress idea 高度重叠 → 标记为 abandon（内部重复）
+
+### Step 5: 持久化分数（仅当 `--write` 开启且 target 是 idea slug）
+
+若 target 是自由文本或 paper slug，或未传 `--write`，整步跳过。否则：
+
+```bash
+python3 tools/research_wiki.py set-meta wiki/ideas/{slug}.md novelty_score {N}
+python3 tools/research_wiki.py log wiki/ "novelty | wrote novelty_score=${N} to ideas/${slug}"
+```
+
+`{N}` 是上面综合规则得到的 1-5 整数。若 `set-meta` 报错（例如该字段在旧 schema 页面里不存在），将错误输出在报告中，不要静默吞掉。
+
+## Constraints
+
+- **默认只读**：未传 `--write` 时，novelty check 只输出终端报告，不修改 wiki 任何内容。
+- **`--write` 是唯一持久化路径**：开启时只写 `novelty_score` 与 `wiki/log.md`。不得修改 idea 页面其他字段（status、priority、正文章节等）。
+- **`--write` 对非 idea target 无效**：target 是自由文本或 paper slug 时，忽略 `--write`，仍输出只读报告。
+- **保守评分**：宁可低估 novelty 也不高估，避免在已有工作上浪费精力
+- **必须检查 failed ideas**：wiki/ideas/ 中 status=failed 的 ideas 是重要的 anti-repetition 信号
+- **搜索覆盖面**：至少 5 个不同的 WebSearch 查询 + Semantic Scholar + wiki 内部搜索
+- **Review LLM 独立性**：提交给 Review LLM 时不包含 Claude 自己的 novelty 判断，让 Review LLM 独立评估
+- **引用真实来源**：报告中列出的所有 prior work 必须是真实存在的（WebSearch/S2 返回的），不得编造
+
+## Error Handling
+
+- **WebSearch 不可用**：跳过 Source A 和 D，仅依赖 S2 + wiki 搜索，在报告中注明覆盖面不足
+- **Semantic Scholar API 不可用**：跳过 S2 部分，依赖 DeepXiv + WebSearch 补偿
+- **DeepXiv API 不可用**：跳过 DeepXiv 部分，依赖 S2 + WebSearch（回退到原有行为）
+- **Review LLM 不可用**：跳过 Step 3，报告标注「Review LLM cross-verify unavailable, single-model assessment only」
+- **Wiki 为空**：正常执行外部搜索，wiki 内部搜索部分标注「wiki empty」
+- **idea slug 不存在**：提示用户检查 slug，列出 wiki/ideas/ 中的可用 slugs
+
+## Dependencies
+
+### Tools（via Bash）
+- `python3 tools/fetch_s2.py search "<query>" --limit 20` — Semantic Scholar 关键词搜索
+- `python3 tools/fetch_s2.py paper <s2_id>` — 获取论文详情
+- `python3 tools/fetch_deepxiv.py search "<query>" --mode hybrid --limit 20` — DeepXiv 语义搜索
+- `python3 tools/fetch_deepxiv.py brief <arxiv_id>` — 获取论文 TLDR 辅助相似度判断
+- `python3 tools/research_wiki.py set-meta wiki/ideas/{slug}.md novelty_score <1-5>` — 仅当 `--write` 开启且 target 是 idea slug
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 写入时追加日志
+
+### MCP Servers
+- `llm-review.chat` — Review LLM 交叉验证（Step 3）
+
+### Qoder Native
+- `WebSearch` — 多查询 web 搜索（Step 2 Source A + D）
+- `Agent` tool — 并行执行多源搜索（Step 2）
+
+### Shared References
+- `.qoder/skills/shared-references/cross-model-review.md`（Phase 2 创建，Review LLM 独立性原则）

--- a/.qoder/skills/paper-compile/SKILL.md
+++ b/.qoder/skills/paper-compile/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: paper-compile
+description: LaTeX 编译 → PDF：latexmk 编译 + 自动修复 + 页数/匿名/字体/[UNCONFIRMED] 检查 + 提交清单
+---
+
+# /paper-compile
+
+> **用法**：`[paper-dir] [--fix] [--checklist]`
+
+
+> 编译 LaTeX 论文为 PDF，自动修复常见错误，验证提交要求。
+> 输入 paper/ 目录（由 /paper-draft 生成），执行 latexmk 编译，
+> 解析错误并尝试自动修复（缺失包、引用未定义、figure 路径），
+> 验证页数限制、匿名合规、字体嵌入、[UNCONFIRMED] 标记清除。
+> 生成提交清单。
+
+## Inputs
+
+- `paper_dir`（可选，默认 `paper/`）：LaTeX 项目目录，包含 `main.tex`
+- `--fix`（可选）：启用自动修复模式（自动安装缺失包、修正路径）
+- `--checklist`（可选）：生成详细提交清单（不编译，只检查）
+
+## Outputs
+
+- `paper/main.pdf` — 编译后的 PDF
+- **COMPILE_REPORT**（输出到终端）— 编译状态、检查结果、提交清单
+- 若 `--fix`：修改的 .tex 文件（自动修复）
+
+## Wiki Interaction
+
+### Reads
+- `wiki/outputs/paper-plan-*.md` — 获取 venue 信息（页数限制、匿名要求）
+- `.qoder/skills/shared-references/citation-verification.md` — [UNCONFIRMED] 标记检查规则
+
+### Writes
+- `paper/main.pdf` — 编译输出
+- `wiki/log.md` — 追加编译日志
+
+### Graph edges created
+- 无
+
+## Workflow
+
+**前置**：确认 `paper/main.tex` 存在。确认 `latexmk` 已安装（`which latexmk`）。
+
+### Step 1: 编译（Compile）
+
+1. **首次编译**：
+   ```bash
+   cd paper/ && latexmk -pdf -interaction=nonstopmode main.tex 2>&1
+   ```
+
+2. **解析编译输出**：
+   - 收集所有 errors（`! ...`）
+   - 收集所有 warnings（`Warning:` / `Overfull` / `Underfull`）
+   - 分类：
+     - **Missing package**：`! LaTeX Error: File 'xxx.sty' not found`
+     - **Undefined reference**：`LaTeX Warning: Reference 'xxx' on page N undefined`
+     - **Undefined citation**：`LaTeX Warning: Citation 'xxx' on page N undefined`
+     - **Missing figure**：`! LaTeX Error: File 'figures/xxx' not found`
+     - **Syntax error**：其他 `!` 开头的错误
+     - **Overfull/Underfull**：排版警告（非阻塞）
+
+3. **若编译成功**（main.pdf 生成）：进入 Step 3
+4. **若编译失败**：进入 Step 2
+
+### Step 2: 自动修复（Auto-Fix）
+
+若 `--fix` 启用，尝试自动修复每种错误类型：
+
+**2a. Missing package**：
+```bash
+# 检查是否为 TeX Live 可安装包
+tlmgr info {package-name} 2>/dev/null
+# 若可安装且用户确认：
+tlmgr install {package-name}
+```
+若无法安装：注释掉 `\usepackage{xxx}` 行并标注 `% TODO: install package {xxx}`
+
+**2b. Undefined reference/citation**：
+- Undefined reference：检查对应 `\label{}` 是否存在，若不存在则添加占位 label
+- Undefined citation：检查 `references.bib` 是否包含该 key
+  - 若不包含：尝试从 wiki papers 匹配并添加 [UNCONFIRMED] 条目
+  - 若包含但 bibtex 未运行：重新运行 `latexmk`（通常 latexmk 自动处理）
+
+**2c. Missing figure**：
+- 检查 `paper/figures/` 中是否存在不同扩展名的文件（.pdf vs .png vs .eps）
+- 若找到：修正 `\includegraphics` 路径
+- 若找不到：替换为占位符 `\missingfigure{xxx}`（需要 `todonotes` 包）
+
+**2d. Syntax error**：
+- 常见修复：未闭合的 `{}`、`\begin{}`/`\end{}` 不匹配、非法字符
+- 尝试定位错误行号，提供具体修复建议
+- 若无法自动修复：报告错误位置和建议
+
+**修复后重新编译**（最多 3 轮 fix-compile 循环）：
+```bash
+cd paper/ && latexmk -pdf -interaction=nonstopmode main.tex 2>&1
+```
+
+### Step 3: 验证检查（Verify）
+
+编译成功后执行以下检查：
+
+**3a. 页数检查**：
+```bash
+# 获取 PDF 页数
+python3 -c "
+import subprocess
+result = subprocess.run(['pdfinfo', 'paper/main.pdf'], capture_output=True, text=True)
+for line in result.stdout.splitlines():
+    if line.startswith('Pages:'):
+        print(line.split(':')[1].strip())
+"
+```
+与 venue 页数限制对比（从 PAPER_PLAN 的 venue 或 academic-writing.md 的 venue 表获取）。
+- 超限：报告超出页数，建议压缩或移至 appendix
+- 不足：报告剩余空间，建议补充内容
+
+**3b. 匿名检查**：
+扫描所有 .tex 文件：
+- 搜索作者姓名（若 `\author{}` 非空 → 警告）
+- 搜索机构名（university, lab, institute → 警告）
+- 搜索 GitHub/GitLab 链接（可能泄露身份 → 警告）
+- 搜索 "our previous work" / "we previously" → 应使用第三人称引用
+- 搜索 `\thanks{}` / `\acknowledgments` → 匿名提交应移除
+
+**3c. [UNCONFIRMED] 标记检查**：
+```bash
+# 扫描 references.bib 和所有 .tex 文件
+grep -rn "VERIFY" paper/
+```
+- 若存在 [UNCONFIRMED] 标记：列出每个，标注为 **提交阻塞项**
+- 参照 citation-verification.md：[UNCONFIRMED] 是提交的硬阻塞
+
+**3d. 字体嵌入检查**：
+```bash
+pdffonts paper/main.pdf
+```
+- 检查 "emb" 列：所有字体应为 "yes"
+- 未嵌入字体：报告字体名，建议在编译选项中添加字体嵌入
+
+**3e. 内容完整性检查**：
+- 搜索 `TODO`、`FIXME`、`XXX` 标记
+- 搜索 `\missingfigure`、空 section（`\section{X}` 后无内容）
+- 搜索未引用的 figures/tables（`\includegraphics` 存在但无 `\ref`）
+- 检查 abstract 是否存在且非空
+
+### Step 4: 生成提交清单和报告
+
+```markdown
+# Compile Report
+
+## Compilation
+- Status: {SUCCESS / FAILED}
+- Compiler: latexmk + pdflatex
+- Rounds: {N} (including auto-fix rounds)
+- Errors: {N} (fixed: {M}, remaining: {K})
+- Warnings: {N} (overfull: {O}, underfull: {U}, other: {W})
+
+## Verification Results
+
+| Check | Status | Details |
+|-------|--------|---------|
+| Page count | {PASS/FAIL} | {N} pages (limit: {L}) |
+| Anonymous | {PASS/WARN} | {details} |
+| [UNCONFIRMED] citations | {PASS/FAIL} | {N} remaining |
+| Fonts embedded | {PASS/FAIL} | {details} |
+| No TODOs | {PASS/WARN} | {N} remaining |
+| Figures referenced | {PASS/WARN} | {details} |
+| Abstract present | {PASS/FAIL} | {details} |
+
+## Submission Checklist
+
+- [ ] PDF compiles without errors
+- [ ] Page count within venue limit ({L} pages)
+- [ ] All [UNCONFIRMED] citations resolved
+- [ ] Anonymous submission (no author info)
+- [ ] All fonts embedded
+- [ ] No TODO/FIXME markers
+- [ ] All figures referenced in text
+- [ ] Abstract present and complete
+- [ ] Supplementary material prepared (if applicable)
+- [ ] Paper title matches submission system
+
+## Blocking Issues
+{list of FAIL items that must be resolved before submission}
+
+## Warnings (non-blocking)
+{list of WARN items for consideration}
+
+## Next Steps
+- {specific actions to resolve blocking issues}
+- Run `/refine paper/main.tex --focus writing` for final polish
+- Manual review of anonymous compliance
+```
+
+追加日志：
+```bash
+python3 tools/research_wiki.py log wiki/ \
+  "paper-compile | {SUCCESS/FAILED} | {pages} pages, {errors} errors, {verify_count} [UNCONFIRMED], {checks_passed}/{checks_total} checks passed"
+```
+
+## Constraints
+
+- **不修改 wiki 内容**：只操作 paper/ 目录和 wiki/log.md
+- **自动修复需 --fix 启用**：默认只报告错误不修复
+- **[UNCONFIRMED] 是硬阻塞**：submission checklist 中 [UNCONFIRMED] 存在 = 不可提交
+- **最多 3 轮 fix-compile**：防止无限修复循环
+- **不删除用户内容**：auto-fix 只添加或修正，不删除用户手写的内容
+- **pdfinfo/pdffonts 依赖**：若未安装，跳过对应检查并标注「tool not available」
+- **匿名检查是启发式的**：可能有 false positive，标注为 WARN 而非 FAIL
+
+## Error Handling
+
+- **main.tex 不存在**：报错，建议先运行 /paper-draft
+- **latexmk 未安装**：报错，提供安装命令（`sudo apt install texlive-full` 或 `brew install --cask mactex`）
+- **编译失败且无法自动修复**：输出完整错误日志 + 定位到具体 .tex 文件和行号
+- **pdfinfo/pdffonts 未安装**：跳过页数/字体检查，在报告中标注
+- **PAPER_PLAN 找不到**：跳过 venue 信息提取，使用默认限制（10 pages），警告用户
+- **权限问题**（tlmgr 需要 sudo）：报告需要手动安装的包列表
+
+## Dependencies
+
+### Tools（via Bash）
+- `latexmk` — LaTeX 编译
+- `pdfinfo` — PDF 页数检查（poppler-utils）
+- `pdffonts` — 字体嵌入检查（poppler-utils）
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+
+### MCP Servers
+- 无
+
+### Qoder Native
+- `Read` — 读取 .tex 文件和编译日志
+- `Edit` — 自动修复 .tex 文件（--fix 模式）
+- `Bash` — 执行编译和检查命令
+- `Grep` — 搜索 [UNCONFIRMED]、TODO、匿名违规
+
+### Shared References
+- `.qoder/skills/shared-references/citation-verification.md` — [UNCONFIRMED] 标记检查规则
+- `.qoder/skills/shared-references/academic-writing.md` — venue 页数限制参考
+
+### Called by
+- `/research` Stage 5（论文编译阶段）
+- 用户手动调用

--- a/.qoder/skills/paper-draft/SKILL.md
+++ b/.qoder/skills/paper-draft/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: paper-draft
+description: 从 PAPER_PLAN 起草 LaTeX 论文：逐 section 从 wiki 取材撰写 + 生成 figures/tables + BibTeX 验证 + de-AI polish
+---
+
+# /paper-draft
+
+> **用法**：`<paper-plan-path> [--review] [--sections <section-numbers>]`
+
+
+> 从 /paper-plan 生成的 PAPER_PLAN.md 起草完整 LaTeX 论文。
+> 逐 section 撰写：每个 section 从 wiki 读取 ideas/methods/experiments/papers/concepts 取材，
+> 生成 LaTeX + figures + tables。BibTeX 从 DBLP/CrossRef 获取（遵循 citation-verification），
+> 完成后执行 de-AI polish（遵循 academic-writing）。
+> 可选逐 section Review LLM review。输出可编译的 paper/ 目录。
+
+## Inputs
+
+- `plan`：PAPER_PLAN.md 的路径（如 `wiki/outputs/paper-plan-sparse-lora-2026-04-08.md`）
+- `--review`（可选）：启用逐 section Review LLM review
+- `--sections`（可选）：只写指定 section（如 `--sections 3,4` 只写 Method + Experiments），用于增量撰写
+
+## Outputs
+
+- `paper/` 目录（在 wiki 项目根下）：
+  - `paper/main.tex` — 主文件（include 各 section）
+  - `paper/sections/introduction.tex`
+  - `paper/sections/related_work.tex`
+  - `paper/sections/method.tex`
+  - `paper/sections/experiments.tex`
+  - `paper/sections/conclusion.tex`
+  - `paper/sections/appendix.tex`（若有）
+  - `paper/figures/` — 生成的 figures（PDF/PNG）
+  - `paper/tables/` — 独立 table 文件（可选）
+  - `paper/math_commands.tex` — 共享数学符号定义
+  - `paper/references.bib` — 验证的 BibTeX 条目
+- `wiki/log.md` — 追加日志
+
+## Wiki Interaction
+
+### Reads
+- `wiki/outputs/paper-plan-*.md` — PAPER_PLAN（章节大纲、evidence map、figure plan、citation plan）
+- `wiki/ideas/*.md` — Hypothesis、Novelty argument、Approach sketch、Motivation、Risks、Lessons learned
+- `wiki/methods/*.md` — Mechanism、Procedure、Assumptions、Tradeoff profile（支持 Method 撰写）
+- `wiki/experiments/*.md` — Results、Analysis、key_result、metrics 数据
+- `wiki/papers/*.md` — Method、Results、Related（作为引用内容和 baseline 参考）
+- `wiki/concepts/*.md` — Definition、Intuition、Variants、Comparison（支持 Method 撰写）
+- `wiki/topics/*.md` — Overview、Timeline、SOTA tracker、Open problems（支持 Introduction 上下文）
+- `wiki/people/*.md` — 人名和机构（引用格式）
+- `wiki/graph/edges.jsonl` — 关系图（构建论证逻辑链）
+- `wiki/graph/open_questions.md` — 已知局限（写 Limitations 和 Future Work）
+- `.qoder/skills/shared-references/academic-writing.md` — 写作规范
+- `.qoder/skills/shared-references/citation-verification.md` — 引用纪律
+
+### Writes
+- `paper/` 目录（所有文件）
+- `wiki/log.md` — 追加操作日志
+
+### Graph edges created
+- 无（paper-plan 已创建 derived_from 边）
+
+## Workflow
+
+**前置**：确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）。
+
+### Step 1: 初始化 Paper 目录
+
+1. 读取 PAPER_PLAN.md，提取 venue、title、section 列表
+2. 若 `paper/` 目录已存在：
+   - 备份为 `paper.bak-{timestamp}/`
+   - 提示用户确认覆盖
+3. 创建目录结构：
+   ```
+   paper/
+   ├── main.tex
+   ├── math_commands.tex
+   ├── references.bib
+   ├── sections/
+   └── figures/
+   ```
+4. 从 `templates/` 复制 venue 模板（若存在）：
+   - `templates/{venue}.sty` 或 `templates/{venue}/`
+   - 若无模板：使用通用 article class，在 main.tex 中注明需要替换为正式模板
+5. 生成 `math_commands.tex`：
+   - 从 wiki/methods/（`## Mechanism`、`## Procedure`）和 wiki/concepts/（`## Definition`、`## Intuition`）收集 notation
+   - 统一符号定义（向量、矩阵、集合、常用运算符）
+6. 生成 `main.tex` 骨架：
+   ```latex
+   \documentclass{article} % 替换为 venue template
+   \input{math_commands}
+   % packages
+   \usepackage{booktabs,graphicx,amsmath,hyperref}
+
+   \title{<title>}
+   \author{} % 匿名提交时留空
+
+   \begin{document}
+   \maketitle
+   \begin{abstract}
+   % Step 3 生成
+   \end{abstract}
+   \input{sections/introduction}
+   \input{sections/related_work}
+   \input{sections/method}
+   \input{sections/experiments}
+   \input{sections/conclusion}
+   \bibliography{references}
+   \bibliographystyle{plain} % 替换为 venue 要求的 style
+   % \input{sections/appendix} % 取消注释如需要
+   \end{document}
+   ```
+
+### Step 2: 生成 Figures 和 Tables
+
+对 PAPER_PLAN 中 Figure Plan 的每个条目：
+
+1. **Diagram 类型**（架构图等）：
+   - 使用 TikZ 或 pgfplots 生成 LaTeX 原生图
+   - 若过于复杂：生成 matplotlib Python 脚本 → 输出 PDF
+   - 保存到 `paper/figures/{figure-name}.pdf`
+
+2. **Plot 类型**(实验结果图)：
+   - 从 `wiki/experiments/{slug}.md` 提取数据
+   - 生成 matplotlib 脚本（遵循 academic-writing 的 figure 设计规范）：
+     - Colorblind-safe palette
+     - Font size >= 8pt
+     - Error bars / confidence bands
+     - Clear legend
+   - 执行脚本生成 PDF：
+     ```bash
+     python3 paper/figures/plot_{name}.py
+     ```
+   - 保存到 `paper/figures/{figure-name}.pdf`
+
+3. **Table 类型**：
+   - 使用 booktabs 风格（toprule, midrule, bottomrule）
+   - Best result bold, second-best underline
+   - 直接嵌入 section .tex 文件（小表）或独立 `paper/tables/{name}.tex`（大表）
+
+### Step 3: 逐 Section 撰写
+
+对每个 section（按 PAPER_PLAN 的大纲顺序），若 `--sections` 指定则只写指定 section：
+
+**3a. 收集素材**
+
+从 PAPER_PLAN 的 section 定义中提取：
+- 该 section 支撑的 ideas
+- 对应的 wiki 页面列表
+- 计划的 figures/tables
+- 引用列表
+
+读取所有相关 wiki 页面的对应部分：
+- Introduction → wiki/ideas/{idea}.md（Hypothesis、Motivation、Novelty argument）+ wiki/topics/{topic}.md#Overview
+- Related Work → wiki/papers/*.md#Related + wiki/concepts/*.md#Comparison
+- Method → wiki/methods/{method}.md（## Mechanism + ## Procedure）+ wiki/concepts/{concept}.md（## Definition + ## Intuition）
+- Experiments → wiki/experiments/*.md#Results + wiki/experiments/*.md#Analysis
+- Conclusion → wiki/ideas/*.md#Lessons_learned + wiki/concepts/*.md#Open_problems + wiki/topics/*.md#Open_problems + wiki/graph/open_questions.md
+
+**3b. 撰写 LaTeX**
+
+遵循 `shared-references/academic-writing.md`：
+- 按该 section 的 paragraph plan 撰写
+- 插入 `\cite{key}` 引用（key 从 citation plan 映射）
+- 插入 `\ref{fig:name}` / `\ref{tab:name}` 引用 figures/tables
+- 使用 `math_commands.tex` 中定义的符号
+- 每段以 topic sentence 开头
+- Experiments section：idea-first 结构（"Our hypothesis is X. To verify, we..."）
+
+**3c. De-AI Polish**
+
+对每个撰写的 section 执行 de-AI polish（参照 academic-writing.md）：
+1. 扫描并替换 AI 特征词汇（delve, leverage, utilize, comprehensive...）
+2. 移除 excessive hedging
+3. 变化 sentence openings（避免连续相同句式）
+4. 移除 filler sentences（不增加信息的句子）
+5. 确保 active voice 为主
+6. 检查 notation consistency
+
+**3d. 可选 Review LLM Review（--review）**
+
+若启用 `--review`，对每个 section：
+
+```
+llm-review.chat:
+  system: "You are a senior ML researcher reviewing one section of a paper draft.
+           Focus on: clarity, logical flow, idea-experiment alignment, notation consistency.
+           Point out any remaining AI-sounding language patterns.
+           Suggest specific rewrites for unclear passages."
+  message: |
+    ## Section: {section name}
+    {LaTeX content}
+
+    ## Ideas this section should support
+    {ideas from the plan's idea list}
+
+    ## Review this section for:
+    1. Does it clearly support its target ideas?
+    2. Is the writing clear and precise?
+    3. Any AI-generated language patterns remaining?
+    4. Is the notation consistent with other sections?
+    5. Missing content that reviewers will expect?
+```
+
+根据 Review LLM 反馈修改 section（行内修改，不重写整个 section）。
+
+### Step 4: 构建 Bibliography
+
+遵循 `shared-references/citation-verification.md`：
+
+1. 收集所有 section 中使用的 `\cite{key}` 引用
+2. 对每个引用，从 PAPER_PLAN 的 citation plan 获取 BibTeX：
+   - 已验证的：直接写入 `references.bib`
+   - [UNCONFIRMED] 的：写入 `references.bib` 底部，带 `% [UNCONFIRMED]` 注释
+3. 排除未引用的条目（不使用 `\nocite{*}`）
+4. 验证 BibTeX 格式正确性（每条有 title, author, year）
+5. 输出 bibliography 统计：
+   ```
+   references.bib: {N} entries, {M} verified, {K} [UNCONFIRMED]
+   ```
+
+### Step 5: 全文 Cross-Review
+
+完成所有 section 后：
+
+```
+llm-review.chat:
+  system: "You are a senior ML researcher performing a final review of a complete paper draft.
+           Focus on: cross-section coherence, idea-experiment thread (do the experiments back the central ideas?),
+           narrative flow, notation consistency across sections, figure/table referencing.
+           This is NOT a line-by-line review — focus on structural and argumentative issues."
+  message: |
+    ## Full Paper Draft
+    {concatenated LaTeX of all sections}
+
+    ## Evidence Map
+    {from PAPER_PLAN}
+
+    ## Review Focus
+    1. Does the paper tell a coherent story from Introduction to Conclusion?
+    2. Are all ideas from the plan adequately supported in the text?
+    3. Is there notation inconsistency between sections?
+    4. Are all figures/tables referenced and discussed?
+    5. Any redundancy between sections?
+    6. Overall readiness for submission (1-10)?
+```
+
+根据 Review LLM 反馈做最终调整。
+
+### Step 6: 完成输出
+
+1. 确认所有文件已写入 `paper/` 目录
+2. 验证基本完整性：
+   - 所有 `\input{sections/X}` 的文件存在
+   - 所有 `\includegraphics{figures/X}` 的文件存在
+   - 所有 `\cite{key}` 在 references.bib 中有对应条目
+   - 所有 `\ref{label}` 有对应 `\label{label}`
+3. 追加日志：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ \
+     "paper-draft | drafted {venue} paper '{title}' | {N} sections, {M} figures, {K} citations ({V} verified)"
+   ```
+4. 输出到终端：
+   ```markdown
+   # Paper Write Complete
+
+   ## Files
+   - paper/main.tex (master file)
+   - paper/sections/ ({N} section files)
+   - paper/figures/ ({M} figure files)
+   - paper/references.bib ({K} entries, {V_count} [UNCONFIRMED])
+   - paper/math_commands.tex
+
+   ## Status
+   - Sections written: {list}
+   - De-AI polish: applied
+   - Review LLM review: {yes/no, if yes: overall score}
+   - [UNCONFIRMED] citations: {count} (resolve before /paper-compile)
+
+   ## Next Steps
+   - Run `/paper-compile paper/` to compile and verify
+   - Resolve [UNCONFIRMED] citations manually
+   - Run `/refine paper/main.tex --focus writing` for further polish
+   ```
+
+## Constraints
+
+- **每个 section 从 wiki 取材**：不凭空生成内容；每个技术陈述必须追溯到 wiki 页面
+- **BibTeX 遵循 citation-verification.md**：从 DBLP/CrossRef/S2 获取，不从 LLM 记忆生成
+- **de-AI polish 必选**：每个 section 写完后必须执行 polish pass，不可跳过
+- **figures 遵循 academic-writing.md**：colorblind-safe、font size >= 8pt、vector format preferred
+- **匿名提交**：不写作者名、机构、致谢（venue 匿名要求）
+- **\nocite{*} 禁止**：只引用实际使用的条目
+- **notation 一致性**：所有 section 使用 math_commands.tex 中的统一符号
+- **已有 paper/ 目录备份后覆盖**：不直接覆盖，先备份
+- **wikilink → \cite 转换**：PAPER_PLAN 中的 [[slug]] 在 LaTeX 中转换为 \cite{key}
+- **tables 使用 booktabs**：不使用竖线和全网格
+
+## Error Handling
+
+- **PAPER_PLAN 找不到**：报错，建议先运行 /paper-plan
+- **PAPER_PLAN 格式不完整**：列出缺失 section，建议重新运行 /paper-plan
+- **wiki 页面找不到**（plan 引用的 idea/experiment/method/paper 不存在）：警告并跳过该引用，标注缺失
+- **figure 生成失败**（matplotlib 错误）：输出占位符 `% TODO: generate figure {name}`，继续其他 section
+- **BibTeX 全部获取失败**：使用 [UNCONFIRMED] 占位，在终端报告需要手动处理的数量
+- **Review LLM 不可用**（--review 模式）：跳过 section review 和 cross-review，标注「unreviewed」
+- **venue template 不存在**：使用通用 article class，在 main.tex 中注明
+- **section 过长**（超过 plan 的 page budget）：警告，建议移至 appendix 或压缩
+
+## Dependencies
+
+### Tools（via Bash）
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+- `python3 tools/fetch_s2.py search "<title>"` — BibTeX fallback（S2 搜索）
+- `python3` — 执行 matplotlib figure 脚本
+
+### MCP Servers
+- `llm-review.chat` — 逐 section review（可选，--review）+ 全文 cross-review（Step 5）
+
+### Qoder Native
+- `Read` — 读取 wiki 页面和 PAPER_PLAN
+- `Glob` — 查找 wiki 页面
+- `Write` — 写入 paper/ 目录中的文件
+- `Bash` — 执行 figure 脚本、创建目录
+- `WebFetch` — DBLP / CrossRef BibTeX 获取
+
+### Shared References
+- `.qoder/skills/shared-references/academic-writing.md` — 写作规范 + de-AI polish 规则 + figure 设计
+- `.qoder/skills/shared-references/citation-verification.md` — BibTeX 获取流程 + [UNCONFIRMED] 协议
+
+### Called by
+- `/research` Stage 5（论文写作阶段）
+- 用户手动调用

--- a/.qoder/skills/paper-plan/SKILL.md
+++ b/.qoder/skills/paper-plan/SKILL.md
@@ -1,0 +1,402 @@
+---
+name: paper-plan
+description: 从 idea graph 编译论文大纲：编译 evidence map → 叙事结构 → 章节计划 + figure plan + citation plan，Review LLM review 必选
+---
+
+# /paper-plan
+
+> **用法**：`<idea-slugs...> --venue <ICLR|NeurIPS|ICML|ACL|CVPR|IEEE> [--title <working-title>]`
+
+
+> 从 wiki 的 idea graph 编译论文大纲。
+> 输入 target ideas（status: validated 或 in_progress 且具备 succeeded 实验），指定目标会议/期刊，
+> 从 wiki 编译 evidence map → 确定叙事结构 → 生成章节大纲 + figure plan + citation plan。
+> Review LLM review 是必选步骤（作为 area chair 审查大纲说服力）。
+> 输出 PAPER_PLAN.md 到 wiki/outputs/。
+>
+> 关键差异：大纲由 idea graph 驱动 — 每个 section 存在是因为它支撑某个 idea（或其证据/方法），
+> 而非因为论文惯例要求有该 section。
+
+## Inputs
+
+- `ideas`：目标 idea 的 slug 列表（空格分隔）
+  - 每个 idea 应为 `status: validated`，或为 `in_progress` 且至少有一个 `succeeded` 实验
+  - 若包含 `proposed` 或 `invalidated` 状态的 idea，发出警告但继续
+- `--venue`（必选）：目标会议/期刊，决定页数限制和格式要求
+  - 支持：`ICLR` / `NeurIPS` / `ICML` / `ACL` / `CVPR` / `IEEE`
+- `--title`（可选）：工作标题，若不提供则从 target ideas 生成
+
+## Outputs
+
+- `wiki/outputs/paper-plan-{slug}-{date}.md` — 完整论文计划（PAPER_PLAN.md）
+- `wiki/graph/edges.jsonl` — 新增 derived_from 边（plan → source ideas/papers）
+- `wiki/graph/context_brief.md` — 重建
+- `wiki/log.md` — 追加日志
+- **PAPER_PLAN_REPORT**（输出到终端）— 计划摘要
+
+## Wiki Interaction
+
+### Reads
+- `wiki/ideas/*.md` — Hypothesis、Motivation、Approach sketch、Novelty argument、status、novelty_score、target_venue、linked_experiments、origin_gaps
+- `wiki/experiments/*.md` — 支撑实验（通过 `linked_idea` 关联）、results、metrics、key_result
+- `wiki/methods/*.md` — idea 的 Approach sketch 中引用的方法（Mechanism、Procedure、source_papers）
+- `wiki/papers/*.md` — evidence 来源论文（Method、Results、Related）
+- `wiki/concepts/*.md` — idea 的 `origin_gaps` 指向的概念（Definition、Variants、Comparison）
+- `wiki/topics/*.md` — idea 的 `origin_gaps` 指向的研究方向（Overview、Open problems）
+- `wiki/graph/context_brief.md` — 全局上下文
+- `wiki/graph/open_questions.md` — 知识缺口（标注论文 limitation）
+- `wiki/graph/edges.jsonl` — 关系图谱（构建叙事逻辑链）
+- `.qoder/skills/shared-references/academic-writing.md` — 写作原则
+- `.qoder/skills/shared-references/citation-verification.md` — 引用纪律
+
+### Writes
+- `wiki/outputs/paper-plan-{slug}-{date}.md` — 论文计划文件
+- `wiki/graph/edges.jsonl` — derived_from 边
+- `wiki/graph/context_brief.md` — 重建
+- `wiki/log.md` — 追加操作日志
+
+### Graph edges created
+- `derived_from`：paper-plan → ideas（计划从哪些 ideas 派生）
+- `derived_from`：paper-plan → papers（计划引用哪些论文）
+
+## Workflow
+
+**前置**：确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）。
+
+### Step 1: 加载 Idea Graph
+
+1. 读取所有 target ideas 的 `wiki/ideas/{slug}.md`
+2. 对每个 idea，遍历：
+   - `linked_experiments` → 读取每个 `wiki/experiments/{slug}.md`（key_result、metrics、outcome）
+   - `origin_gaps` → 读取每个 `wiki/concepts/{slug}.md` 和 `wiki/topics/{slug}.md`（背景上下文）
+   - `## Approach sketch` 正文中的 wikilink → 读取每个 `wiki/methods/{slug}.md` 和 `wiki/papers/{slug}.md`
+3. 读取 `wiki/graph/context_brief.md` 获取全局上下文
+4. 读取 `wiki/graph/open_questions.md` 标注 known limitations
+5. 从 `wiki/graph/edges.jsonl` 加载相关边，构建 ideas 之间的关系
+
+**验证**：
+- 若任何 target idea 的 status 为 `proposed`：警告「idea 尚未验证，论文可能缺乏证据支撑」
+- 若任何 target idea 的 `novelty_score` 为空或 `novelty_score <= 2`：警告「idea 新颖性较弱，建议先运行 `/novelty`」
+- 若任何 target idea 的 `linked_experiments` 中没有任何一个 `succeeded` 结果：错误「至少需要一个支撑实验才能规划论文」
+
+### Step 2: 从 Wiki 编译 Evidence Map
+
+生成一个结构化矩阵，映射 ideas → evidence → sections：
+
+```markdown
+| Idea | Status | linked experiments | Methods/Concepts | Section |
+|------|--------|--------------------|------------------|---------|
+| [[primary-idea]] | validated | [[exp-main]] (succeeded), [[exp-ablation-1]] (succeeded) | [[method-core]], [[concept-foundation]] | Method + Exp 5.2 |
+| [[supporting-idea-1]] | validated | [[exp-ablation-2]] (succeeded) | [[method-component]] | Exp 5.3 (Ablation) |
+| [[supporting-idea-2]] | in_progress | [[exp-scaling]] (inconclusive) | [[concept-scaling]] | Exp 5.4 (Scaling) |
+```
+
+按维度映射 ideas 到论文结构：
+- **Primary idea** → 核心贡献，驱动 Abstract + Introduction + Method
+- **Decomposition ideas** → 各因素贡献，驱动 Ablation subsections
+- **Concepts/topics（来自 origin_gaps）** → 背景知识，驱动 Related Work + Introduction
+
+### Step 3: 确定叙事结构
+
+遵循 `shared-references/academic-writing.md` 的 hourglass 原则：
+
+1. **确定 paper 的核心故事线**：
+   - Gap（从 idea 的 `## Motivation` 和 `origin_gaps` 提取）
+   - Solution（从 idea 的 `## Approach sketch` 和关联的 methods 提取）
+   - Evidence（从 `linked_experiments` 的 results 提取）
+   - Impact（从 idea 的 `novelty_score` + 实验范围推断）
+
+2. **确定叙事角度**：
+   - 论文解决什么问题？（问题驱动 vs 方法驱动 vs 数据驱动）
+   - 主要读者是谁？（理论/系统/应用）
+   - 与最近最相关的 3 篇论文如何区分？
+
+3. **建立 section → idea 映射**：
+   每个 section 必须至少支撑一个 idea（或其支撑证据/方法）。无 idea 支撑的 section 是填充，应删除。
+
+### Step 4: 生成章节大纲
+
+按 venue 格式要求生成大纲，每个 section 包含：
+
+```markdown
+## 1. Introduction (1.5 pages)
+
+### Ideas addressed
+- Gap framing: {existing approaches lack X because Y}（来自 `origin_gaps`）
+- Primary contribution idea: [[primary-idea]]
+
+### Paragraph plan
+1. Broad context: {field importance, recent progress}
+2. Specific problem: {what's missing, why it matters}
+3. Our approach: "In this work, we propose..." + contributions list
+4. Results preview: {headline numbers}
+5. Paper structure: "The rest of this paper..."
+
+### Key citations
+- [[paper-A]] — establishes the problem
+- [[paper-B]] — closest prior work (we improve upon)
+- [[paper-C]] — our baseline
+
+---
+
+## 2. Related Work (1 page)
+
+### Groupings
+- Direction A: {papers, our position}
+- Direction B: {papers, our position}
+- Direction C: {papers, our position}
+
+### Ideas addressed
+- 用每个 idea 的 `origin_gaps` 中的背景 concepts/topics 区分本文与既往工作
+
+---
+
+## 3. Method (2-3 pages)
+
+### Ideas addressed
+- [[primary-idea]]: section 3.1-3.2（Approach sketch + 引用的 [[method-slug]]）
+- [[supporting-idea-1]]: section 3.3
+
+### Subsection plan
+- 3.1 Problem formulation: notation, objective
+- 3.2 Core approach: intuition → formalism
+- 3.3 Component X: design decision + justification
+- 3.4 Training/inference details
+
+### Figures
+- Figure 1: Overall architecture (mandatory)
+- Figure 2: Component X detail (if complex)
+
+---
+
+## 4. Experiments (2-3 pages)
+
+### Ideas addressed
+- [[primary-idea]]: section 4.2 (main results)
+- [[supporting-idea-1]]: section 4.3 (ablation)
+- [[supporting-idea-2]]: section 4.4 (scaling)
+
+### Subsection plan
+- 4.1 Setup: datasets, baselines, metrics, implementation details
+- 4.2 Main results: Table 1 (main comparison), [[exp-main]]
+- 4.3 Ablation study: Table 2 (component analysis), [[exp-ablation-*]]
+- 4.4 Analysis: scaling, robustness, qualitative examples
+
+### Figures/Tables
+- Table 1: Main comparison vs baselines
+- Table 2: Ablation results
+- Figure 3: Scaling curves / qualitative examples
+
+---
+
+## 5. Conclusion (0.5 page)
+
+### Key takeaway
+- {one sentence the reader should remember}
+
+### Limitations
+- {来自 gap_map 或各 idea 的 `## Risks`}
+
+### Future work
+- {来自 gap_map 的 open questions 与各 idea 的 `## Lessons learned`}
+```
+
+**Page budget**：根据 `--venue` 分配（参考 academic-writing.md 的 venue 表），总 section 页数 <= venue 主文限制。
+
+### Step 5: Figure Plan
+
+为每个计划中的 figure/table 设计：
+
+```markdown
+## Figure Plan
+
+### Figure 1: System Architecture
+- Type: diagram
+- Source: Method section description
+- Style: block diagram with labeled components
+- Size: full width (1 column = text width)
+
+### Table 1: Main Results
+- Type: comparison table
+- Source: [[exp-main]] key_result + baselines
+- Columns: Method | Metric-1 | Metric-2 | ...
+- Rows: baselines + ours (ours in bold)
+- Notes: best bold, second underline, ↑/↓ arrows for direction
+
+### Figure 3: Scaling Analysis
+- Type: line plot
+- Source: [[exp-scaling]] results
+- X-axis: scale dimension (model size / data size)
+- Y-axis: performance metric
+- Lines: ours vs baseline, with error bands
+```
+
+### Step 6: Citation Plan
+
+参照 `shared-references/citation-verification.md`：
+
+1. 列出大纲中所有 `[[slug]]` 引用的 wiki papers
+2. 对每篇论文，pre-fetch BibTeX：
+   - 先 DBLP，再 CrossRef，再 S2
+   - 成功：记录 BibTeX key + 来源
+   - 失败：标记 `[UNCONFIRMED]`
+3. 生成 citation coverage 报告：
+   ```
+   Citations: 15 total, 12 verified (DBLP: 8, CrossRef: 3, S2: 1), 3 [UNCONFIRMED]
+   ```
+4. 对 [UNCONFIRMED] 条目，提供建议的手动检查 URL
+
+### Step 7: Review LLM Review（必选）
+
+```
+llm-review.chat:
+  system: "You are an area chair at {venue} reviewing a paper outline.
+           Assess: Is the narrative convincing? Does every section serve a clear purpose?
+           Are the experiments sufficient to support the paper's central ideas?
+           Is the related work coverage adequate?
+           Are there obvious gaps that reviewers will attack?
+           Provide specific suggestions for strengthening the outline."
+  message: |
+    ## Paper Outline
+    {complete outline from Step 4}
+
+    ## Evidence Map
+    {evidence map from Step 2}
+
+    ## Figure/Table Plan
+    {plan from Step 5}
+
+    ## Citation Coverage
+    {report from Step 6}
+
+    ## Questions for Review
+    1. Is the narrative arc (gap → solution → evidence → impact) convincing?
+    2. Are any ideas under-supported? Which experiments are missing?
+    3. Is the related work grouping appropriate? Missing directions?
+    4. Will the page budget work? Any section too long/short?
+    5. Are the figures/tables sufficient to tell the story?
+```
+
+根据 Review LLM 反馈修改大纲（补充 section、调整 page budget、添加 figure/table、修正叙事结构）。
+
+### Step 8: 输出到 Wiki
+
+1. **生成 slug**：
+   ```bash
+   python3 tools/research_wiki.py slug "<working-title>"
+   ```
+
+2. **写入 PAPER_PLAN.md**：
+   创建 `wiki/outputs/paper-plan-{slug}-{date}.md`，包含：
+   - 元信息（venue、title、date、target ideas）
+   - Evidence Map（Step 2）
+   - 完整章节大纲（Step 4，含 Review LLM 修改）
+   - Figure/Table Plan（Step 5）
+   - Citation Plan + coverage report（Step 6）
+   - Review LLM Review Summary（Step 7 关键反馈和修改记录）
+
+3. **添加 graph edges**：
+   ```bash
+   # plan → target idea
+   python3 tools/research_wiki.py add-edge wiki/ \
+     --from "outputs/paper-plan-{slug}-{date}" --to "ideas/{primary-idea}" \
+     --type derived_from --evidence "Paper plan built from this idea"
+
+   # plan → key papers
+   python3 tools/research_wiki.py add-edge wiki/ \
+     --from "outputs/paper-plan-{slug}-{date}" --to "papers/{paper-slug}" \
+     --type derived_from --evidence "Paper plan cites this paper"
+   ```
+
+4. **重建派生数据**：
+   ```bash
+   python3 tools/research_wiki.py rebuild-context-brief wiki/
+   ```
+
+5. **追加日志**：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ \
+     "paper-plan | {venue} paper outline for [[{slug}]] | ideas: {idea-list} | citations: {verified}/{total}"
+   ```
+
+6. **输出 PAPER_PLAN_REPORT 到终端**：
+   ```markdown
+   # Paper Plan Report
+
+   ## Meta
+   - Title: {working title}
+   - Venue: {venue}
+   - Page limit: {N} pages
+   - Date: {date}
+
+   ## Ideas → Sections
+   | Idea | Status / Novelty | Section |
+   |------|------------------|---------|
+   | [[primary]] | validated / 4 | Method + Exp 5.2 |
+   | [[supporting-1]] | validated / 3 | Exp 5.3 |
+
+   ## Page Budget
+   | Section | Pages | Ideas |
+   |---------|-------|-------|
+   | Introduction | 1.5 | gap, contribution |
+   | Related Work | 1.0 | context |
+   | Method | 2.5 | primary, supporting |
+   | Experiments | 2.5 | all |
+   | Conclusion | 0.5 | — |
+
+   ## Figures/Tables: {N} planned
+   ## Citations: {verified}/{total} verified, {verify_count} [UNCONFIRMED]
+   ## Review LLM Review: score {X}/10, verdict: {verdict}
+
+   ## Next Steps
+   - Run `/paper-draft wiki/outputs/paper-plan-{slug}-{date}.md` to draft the paper
+   - Resolve {verify_count} [UNCONFIRMED] citations before /paper-compile
+   ```
+
+## Constraints
+
+- **--venue 必选**：不同会议的页数限制、格式要求差异大，不可省略
+- **至少一个 experiment evidence**：纯理论 idea 不足以支撑实验性论文，需至少一个支撑实验
+- **page budget 必须可行**：总 section 页数 <= venue 主文限制，否则调整（压缩或移至 appendix）
+- **Review LLM review 必选**：不可跳过。大纲阶段发现问题成本最低
+- **所有引用来自 wiki**：citation plan 中的每篇论文必须在 wiki/papers/ 中存在
+- **idea → section 映射完整**：每个 target idea 必须出现在至少一个 section 中
+- **每个 section 必须有 idea**：无 idea 支撑的 section 视为填充，应删除或合并
+- **graph edges 使用 tools/research_wiki.py**：不手动编辑 edges.jsonl
+- **引用使用 [[slug]]**：大纲中所有引用使用 wikilink 语法
+
+## Error Handling
+
+- **idea 状态不足**：若所有 ideas 均为 `proposed`，报错「ideas 尚未验证，建议先运行实验」
+- **无 experiment evidence**：报错「至少需要一个实验结果」，建议先运行 /exp-design + /exp-run
+- **wiki papers 不足**：若 citation plan 中 wiki 论文 < 5 篇，警告「相关工作覆盖不足，建议先 /ingest 更多论文」
+- **page budget 超限**：自动将低优先级 section 移至 appendix 计划，报告调整
+- **Review LLM 不可用**：降级为 Claude 自审，报告标注「single-model review — cross-model verification unavailable」
+- **BibTeX 获取失败**：标记 [UNCONFIRMED]，在 citation plan 报告中汇总
+- **slug 冲突**：追加日期后缀
+- **target idea 找不到**：报错，列出 wiki/ideas/ 中候选
+
+## Dependencies
+
+### Tools（via Bash）
+- `python3 tools/research_wiki.py slug "<title>"` — 生成 slug
+- `python3 tools/research_wiki.py add-edge wiki/ ...` — 添加 graph edge
+- `python3 tools/research_wiki.py rebuild-context-brief wiki/` — 重建 query_pack
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+- `python3 tools/fetch_s2.py search "<title>"` — Semantic Scholar 搜索（citation plan fallback）
+
+### MCP Servers
+- `llm-review.chat` — Step 7 大纲审查（必选）
+
+### Qoder Native
+- `Read` — 读取 wiki 页面
+- `Glob` — 查找 ideas、experiments、methods、papers
+- `WebFetch` — DBLP / CrossRef BibTeX 获取（Step 6）
+
+### Shared References
+- `.qoder/skills/shared-references/academic-writing.md` — 叙事结构和章节设计原则
+- `.qoder/skills/shared-references/citation-verification.md` — 引用获取和验证规则
+
+### Called by
+- `/research` Stage 5（论文写作阶段）
+- 用户手动调用

--- a/.qoder/skills/poster/SKILL.md
+++ b/.qoder/skills/poster/SKILL.md
@@ -1,0 +1,685 @@
+---
+name: poster
+description: 从已撰写的论文生成学术海报 —— 提炼章节为单页 HTML 海报,包含配图和段落间过渡
+---
+
+# /poster
+
+> **用法**：`[paper-dir] [--review] [--anonymous] [--no-figures] [--no-logos] [--no-refine]`
+
+
+> 从已撰写的论文生成学术 HTML 海报。读取 `paper/main.tex`、章节文件与图片;
+> 构建 PaperX 兼容的 `dag.json` 中间格式;将每个章节提炼为 2–5 句话摘要;
+> 选取代表性配图;渲染为自包含的 HTML 海报(三栏自适应布局)。
+
+## Inputs
+
+### 常用
+
+- `paper_dir`(可选,默认 `paper/`):LaTeX 项目目录,需包含 `main.tex` 和 `sections/`
+- `--review`(可选):调用 Review LLM 对生成的海报内容进行跨模型评审
+- `--anonymous`(可选):强制将作者写为 "Anonymous",忽略 `\author{}`、`paper/.author_display.txt` 缓存以及 `--authors` flag
+- `--no-figures`(可选):所有章节渲染为纯文本(适合文本密集型海报,或配图尚未准备好时)
+- `--no-logos`(可选):跳过 affiliation / conference logo 询问,header 只显示 venue 文本
+- `--no-refine`(可选):跳过 Step 5.5 critique-revise(默认会跑 1 轮)
+
+### 进阶(脚本化使用;交互场景一般用不到)
+
+- `--authors STR`:覆盖海报上的作者文本(例如 `--authors "Mingtian Yang, Co-Author"`)。一次性覆盖用;日常需求由 Step 0 Q1 的 `paper/.author_display.txt` 缓存自动处理。`--anonymous` 同时传入时仍以 `--anonymous` 为准。
+- `--venue STR`:header 右块的 venue 文本(例如 `"NeurIPS 2026"`)。跳过 Step 0 的 venue 询问。
+- `--affiliation-logo PATH` / `--conference-logo PATH`:logo 文件路径(PNG/JPG/PDF);各自跳过 Step 0 对应的询问。
+- `--layout corners|stacked`(默认 `corners`):header 布局。`corners` = 单位 logo 左上 + 会议 logo 右上;`stacked` = 两个 logo 都叠在右侧 `.conf` 区,venue 文本在最上。
+- `--auto-figures`:跳过 Step 2.5 的逐章节配图询问,直接为每章选择面积最大的候选图(旧的 "largest wins" 行为)。
+- `--refine-iterations N`(默认 1,硬上限 2):Step 5.5 的迭代次数。`0` 等同于 `--no-refine`。文字密集且首轮可能无法收敛时,调到 2。
+
+## Outputs
+
+- `poster/dag.json` —— PaperX 兼容的中间格式(未来可被 `/slides`、`/pr` 复用)
+- `poster/outline.html` —— 模板注入前的 `<section>` 块拼接结果
+- `poster/poster.html` —— 最终自包含的 HTML 海报(浏览器打开即可;若需 PDF:**Cmd/Ctrl+P → 另存为 PDF**,打印设置见 Step 7 报告)
+- `poster/poster.png` —— 2× CSS 尺寸的渲染截图(默认 2800×1800),见 Step 5b
+- `poster/images/` —— 从 `paper/figures/` 复制/转换(PDF→PNG @ 200 DPI)而来的图片
+- **POSTER_REPORT**(输出到终端)
+- `wiki/log.md` —— 追加日志条目
+
+## Wiki Interaction
+
+### Reads
+- `paper/main.tex` + `paper/sections/*.tex` + `paper/figures/` —— 论文源
+- `wiki/outputs/paper-plan-*.md`(可选)—— 叙事线、配图计划、证据图
+- `wiki/ideas/*.md`(可选)—— 假设、新颖性论证,用于海报开头
+- `wiki/experiments/*.md`(可选)—— 关键数值与结果,用于结果区 callout
+- `.qoder/skills/shared-references/academic-writing.md` —— 去 AI 风格化规则
+
+### Writes
+- `poster/` 目录(完整列于 Outputs)
+- `wiki/log.md` —— 追加
+
+### Graph edges created
+- 无(海报是展示产物,不是知识实体)
+
+## Workflow
+
+**前置**:确认 `paper/main.tex` 存在。否则报错:"先运行 /paper-draft"。
+
+### Step 0: 交互式 header 配置
+
+目标:收集 venue 文本与(可选的)两个 logo,用于海报 header 渲染。如果用户已通过 CLI flag 传入对应值,则静默跳过该项。
+
+整个交互流程用 `AskUserQuestion` 做是/否/布局选择,自由文本(路径与 venue)直接读取下一条用户消息。
+
+1. **作者** —— 论文级别的元数据,按下面的优先级解析:
+
+   1. 传入 `--authors STR` flag → 用它,不问也不持久化。
+   2. 传入 `--anonymous` flag → 强制 "Anonymous",不问也不持久化。
+   3. `paper/.author_display.txt` 存在 → 用文件内容,不问。这是"问一次,以后复用"的缓存。未来 `/paper-draft` 会在写作阶段填这个文件;在那之前,`/poster` Step 0 维护它(见下)。
+   4. dag.json 根节点 `content` (来自 `main.tex` 的 `\author{...}`) 非空且不是字面 "Anonymous" → 用它,不问。
+   5. **否则(匿名稿且没有缓存的 display name)**:问用户。
+
+   询问流程(只在第 5 条触发时进入):
+   - 用 `AskUserQuestion`,选项:
+     - `"Keep 'Anonymous' (double-blind submission)"`(Recommended)
+     - `"Provide author names (I'll ask for the string)"`
+   - 若选 "Provide author names":自由文本询问 *"海报上应显示什么作者字符串?例如 `Mingtian Yang, Co-Author Name`。回复字符串,或回复 `skip` 保留 'Anonymous'。"* 把下一条用户消息取作 authors 字符串。
+   - **把答案持久化** 到 `paper/.author_display.txt`(单行,不要末尾换行)。下一次 `/poster` 跑时文件已存在 → step 0 Q1 静默跳过。用户想改的话,自己编辑或删除这个文件。
+   - 两个分支("Keep Anonymous" 或 自定义字符串)都要持久化 —— 目标是 **除非用户主动删文件,否则不再被问**。
+
+2. **Venue 文本** —— 若未传入 `--venue`:
+   - 询问:*"海报 header 要显示什么 venue 文本?例如 `NeurIPS 2026`。回复文本,或回复 `skip` 留空。"*
+   - 把下一条用户消息原文取作 venue。`skip`(不区分大小写)视为空。
+
+3. **单位/实验室 logo** —— 若未传入 `--affiliation-logo` 且未传入 `--no-logos`:
+   - 用 `AskUserQuestion` 询问,选项:`"Yes, I have a logo file"` / `"No, skip the affiliation logo"`。
+   - 若选 yes:询问 *"单位 logo 文件路径?(PNG / JPG / PDF;相对路径或绝对路径都可以)"*。把下一条用户消息当作路径。校验文件存在;若不存在,提示错误后再询问一次,仍失败则按 skip 处理。
+
+4. **会议/期刊 logo** —— 若未传入 `--conference-logo` 且未传入 `--no-logos`:
+   - 流程同上(yes/no 用 `AskUserQuestion`,路径自由文本)。
+
+5. **布局** —— 若至少一个 logo 被提供,且未传入 `--layout`:
+   - 用 `AskUserQuestion` 询问,选项:
+     - `"corners —— 单位 logo 左上、会议 logo 右上"`(Recommended)
+     - `"stacked —— 两个 logo 叠在右侧 conf 区,venue 文本在上方"`
+   - 若只有 venue 没有 logo:跳过布局询问(默认 `corners` 即可,只用 venue 文本槽)。
+
+6. **配置摘要** —— 打印一行:
+   - `Header config: authors='{...}', venue='{...}', affiliation={path|none}, conference={path|none}, layout={...}`
+
+作者字符串通过 Step 5 的 `python3 tools/poster.py inject-title --authors "..."` 应用;venue 与 logo 通过 `python3 tools/poster.py inject-header` 应用。
+
+### Step 1: 构建 dag.json
+
+```bash
+python3 tools/wiki2dag.py build --paper-dir paper/ --output poster/dag.json
+```
+
+若用户传入 `--anonymous`,在命令上加 `--anonymous`。
+
+桥接工具生成三类节点:
+- **Root**(`level: 0`):`name` 为论文标题,`content` 为作者,`edge` 为按顺序排列的章节名
+- **Section**(`level: 1`):`name` 为章节标题,`content` 为完整正文,`visual_node` 为该章节引用的图片
+- **Visual**(`level: 2`):`name` 为 markdown 图片引用,`content` 为 caption,`resolution` 为 `WxH`
+
+`wiki2dag.py` 保留论文中的:
+- **数学公式**:`$…$`、`$$…$$`、`\(…\)`、`\[…\]` 原样进入章节内容,后续由海报 HTML 中的 KaTeX 渲染。`math_commands.tex` 里的宏会被展开,残留的 `\ensuremath{X}` 包装会被解包为 `$X$`,让 KaTeX 能识别。
+- **引用** —— *默认丢弃*:`\citep{key}` / `\citet{...}` 标记被剥成空。基于对 CCF-A 海报的调研,实际会场上的海报通常不在正文里渲染 `[N]` 内联标注(没地方放参考文献列表)。如果你的海报样式确实需要它们,在 `wiki2dag.py build` 上加 `--citations` flag 可以恢复为 `[N]` / `[N, M]`(按首次出现顺序的 `bibkey → ordinal`)。未来支持参考文献页脚的样式可以默认开启。
+- **表格**:`\begin{table}…\end{table}` envs(包括通过 `\input{tables/foo}` 内联的)被转为活的 HTML `<table class="poster-table">` 块,booktabs caption 渲染为 `<caption>`,`\multicolumn`、`\textbf`、`\emph`、`\textit`、`\texttt` 在 cell 层处理。Step 3 的 LLM 在 `SECTION_JSON.content` 中看到这段 HTML,必须**原样**插入到 summary 段落之后(见 Step 3)。fit() 算法会与正文文字一起缩放表格字号;若表格仍然溢出,Step 5.5 的 DOM 溢出探针会发现并要求修剪。
+- **TikZ 图**:`\begin{figure}` envs 中含 `\begin{tikzpicture}` 但**没有** `\includegraphics{}` 的,通过 `tools/rasterize_latex.py`(pdflatex + pdftoppm)自动光栅化到 `paper/figures/_tikz_<sec>_<label>.png`。生成的 PNG 在桥接层眼里就是普通 visual node,Step 3 完全一样处理。若同一个 figure env 里**同时**有 `\includegraphics{}`,现有流水线优先(TikZ 跳过)。光栅化失败时 stderr 告警 + 丢弃该图,其它流程继续。跨次运行缓存 —— 删除 PNG 即强制重建。
+
+### Step 2: 编译 WIKI_CONTEXT(可选)
+
+目标:可选地用论文自己的规划产物(假设陈述、新颖性论证、关联 ideas/experiments 的关键数值)为 Step 3 的蒸馏提示词提供锚点。**始终告知用户当前发生了什么 —— 不要静默采用。**
+
+**检测与透明度**:
+
+- **不存在 plan 文件**:打印一行 —— `Step 2: 在 wiki/outputs/ 未找到 paper-plan-*.md —— Step 3 将在没有 WIKI_CONTEXT 的情况下运行。` 跳到 Step 2.5。
+
+- **存在 plan 文件**:打印一行总结找到了什么,例如 `Step 2: 找到 wiki/outputs/paper-plan-2026-05-17.md(3 个 idea,2 个 experiment)。` 然后用 `AskUserQuestion`:
+  - `"Yes —— 作为 WIKI_CONTEXT 锚点采用"`(推荐)
+  - `"No —— 仅基于论文源蒸馏"`
+
+若用户选 **Yes**:读取 plan 获取 venue、叙事弧线、关联 idea slug。对每个 idea slug,读取 `wiki/ideas/<slug>.md` 的假设(hypothesis)与新颖性论证;对每个关联的 `wiki/experiments/*.md`,读取 `outcome` 与 `key_result` 字段。按章节聚合成一个 `WIKI_CONTEXT` 字符串:
+
+```
+[INTRODUCTION]
+hypothesis: <来自 idea 的一句话>
+novelty: <来自 idea 的一句话>
+
+[EXPERIMENTS]
+key_result: <来自 experiments 的关键数值>
+outcome: <一句话总结>
+```
+
+若用户选 **No**:`WIKI_CONTEXT` 保持为空。
+
+此字符串通过 Step 3 提示词中的 `{WIKI_CONTEXT}` 槽位传入。Step 3 提示词显式允许此槽位为空。
+
+### Step 2.5: 配图选择
+
+目标:决定每个被选中的章节应配哪张图(或无图)。在 `dag.json` 构建之后、LLM 提炼之前运行,使配图选择成为 Step 3 的*输入*,而不是让 LLM 猜。每张图都内联渲染在章节中;manifest 中的 ⚠ wide 标记仅作信息提示 —— 提醒比例极端的图在单列里可能被压扁,用户可以选其它图或跳过。
+
+**章节选择**(优先级表,硬上限 6 个章节,保持 1400×900 下可读):
+
+1. **Introduction**(摘要或第一节)
+2. **Method**(方法/方案章节)
+3. **主要结果**(Experiments / Replication / 主结果章节)
+4. **次要结果 / 消融**(空间允许时)
+5. **分析 / 讨论**(一个核心 insight)
+6. **Conclusion**(简短结论)
+
+**模式判定**:
+
+- 传入 `--no-figures` → 模式 = `none`;所有章节渲染为纯文本,跳过所有询问。
+- 传入 `--auto-figures` → 模式 = `auto`;为每章选面积最大的 visual(`resolution` 的 W×H),跳过所有询问。
+- 否则 → 模式 = `interactive`,执行下面的 manifest + 询问。
+
+**打印配图 manifest**(任何模式下都打印),示例:
+
+```
+Figure candidates per section:
+  Abstract        — text only
+  Introduction    — text only
+  Method          — text only
+  Experiments     — 2 candidates:
+                    [a] layer_curves.png   2378x618  aspect 3.85  ⚠ wide
+                    [b] bootstrap.png       974x612  aspect 1.59
+  Discussion     — text only
+  Conclusion     — text only
+```
+
+aspect 由 `resolution`(W×H)计算。⚠ wide 标记来自 dag.json 的 `wide` 字段(aspect ≥ 2.0 或 ≤ 0.5 时为 true)。
+
+**交互流程**(仅模式 = `interactive`):
+
+逐章节,按候选数与 wide 标记决定如何询问:
+
+| 候选数 | Wide? | 行为 |
+|---|---|---|
+| 0 | — | 无图(不询问,静默) |
+| 1 | any | 静默 inline 使用(manifest 已展示;若 `wide`,⚠ 标记即提示)。用户可重跑加 `--no-figures` 来移除。 |
+| ≥2 | any | **询问 Q-Pick**(多选):*"Which figure(s) for {Section}?"* —— `AskUserQuestion` 配 `multiSelect: true`,选项:每个候选(标签包含 ⚠ wide 标记如适用) / `Let Claude decide (pick largest one)` / `No figure`。用户可选一张、多张或全部。 |
+
+每次询问用 `AskUserQuestion`,选项数 ≤ 4。若某章节有 4 个以上候选,去掉 `Let Claude decide` 这一项以满足上限(用户已经在显式选了)。
+
+**跟进:同一章节选了 ≥2 张时询问布局。** 用 `AskUserQuestion`(单选):
+
+| 选项 | 行为 | 何时推荐 |
+|---|---|---|
+| `side-by-side` | 所有选中图都放进 **一个** `<div class="img-section">`;flex 布局自动水平平分宽度。 | 默认。3 列海报里最省空间。零 CSS 改动。 |
+| `vertical-stack` | 每张图一个独立 `<div class="img-section">`,自上而下堆叠。每张图占满列宽。 | 单图细节重要时;但章节会很高,fit() 会更激进地缩小文字。 |
+| `after-table` | 章节里**同时有** `<table class="poster-table">` 时使用,figures 横向并排,放在表格**之后**。 | 章节内容密;尊重论文阅读顺序。 |
+
+HTML 模板已原生支持 `side-by-side` 与 `vertical-stack`(flex 布局 + 多个 `.img-section`)。`after-table` 只是放置变体,不是新 CSS 类。
+
+所有决策做完后,打印一行汇总:
+
+```
+Figures chosen:
+  Experiments → fig2.png + fig3.png (side-by-side)
+  Method      → tikz_chain.png (inline)
+  (其他章节:仅文字)
+```
+
+**决策记录**:用按章节显示名作 key 的内存 dict 保留选择:
+
+```python
+{
+  "Experiments": {
+    "figures": ["images/fig2.png", "images/fig3.png"],   # 列表,即使只 1 张
+    "alts":    ["<caption fig2>",  "<caption fig3>"],    # 平行列表
+    "layout":  "inline-multi-side",                       # 见下
+  },
+  "Method": {
+    "figures": ["images/tikz_chain.png"],
+    "alts":    ["<caption>"],
+    "layout":  "inline",                                  # 单图场景
+  },
+  "Conclusion": {"figures": [], "alts": [], "layout": "none"},
+  ...
+}
+```
+
+`layout` 取值:
+- `"none"` —— 章节仅文字,无图
+- `"inline"` —— 一张图在一个 `.img-section` 中(向后兼容单图流程)
+- `"inline-multi-side"` —— ≥2 张图放进**同一个** `.img-section`(flex 水平)
+- `"inline-multi-stack"` —— ≥2 张图,每张一个 `.img-section`(垂直堆叠)
+- `"inline-multi-after-table"` —— ≥2 张图横向并排,放在章节内容的 `<table class="poster-table">` **之后**
+
+Step 3 会消费此 dict 填入每章节的提示词变量。
+
+### Step 3: 提炼海报章节
+
+加载 `poster/dag.json` 与 Step 2.5 的决策 dict。按顺序遍历被选中的章节节点。
+
+对每个章节,准备下面提示词所需的变量。配图相关变量从 Step 2.5 的决策 dict 取,**不要**在这里重新算。
+
+- `SECTION_JSON`:从 `poster/dag.json` 取该 section 节点,**去掉** `visual_node` 字段(visual 单独传入)。只保留 `name`, `content`, `level`。
+- `LAYOUT`:`"none"` / `"inline"` / `"inline-multi-side"` / `"inline-multi-stack"` / `"inline-multi-after-table"` 之一,从 `decisions[section_name]["layout"]` 取。决定 HTML 模板分支。
+- `IMAGE_SRCS`:图源列表,从 `decisions[section_name]["figures"]` 取(如 `["images/fig2.png", "images/fig3.png"]`)。`LAYOUT == "none"` 时为空列表。
+- `ALT_TEXTS`:与 `IMAGE_SRCS` 一一对应的 caption 列表(`decisions[section_name]["alts"]`)。
+- `WIKI_CONTEXT`(可选):Step 2 编译出的字符串(假设、新颖性、关键数值)。无 wiki 上下文时为空。
+
+对每个章节调用下面的提示词(从 PaperX `poster_outline_prompt` 移植,扩展了 `LAYOUT` 与 `WIKI_CONTEXT`):
+
+> You are given a section node JSON (SECTION_JSON) from a paper DAG. The section JSON you see has NO `visual_node` field and must be treated as authoritative.
+>
+> SECTION_JSON:
+> {SECTION_JSON}
+>
+> LAYOUT: {LAYOUT}    # one of "none" | "inline" | "inline-multi-side" | "inline-multi-stack" | "inline-multi-after-table"
+>
+> If LAYOUT is not "none", you are also given IMAGE_SRCS (a list of image paths) and ALT_TEXTS (parallel list of captions). The visual content MUST ONLY come from these provided sources (do not invent or substitute any other image). For single-figure layouts (`"inline"`), the lists each have length 1. For multi-figure layouts, length ≥ 2 and the order in the list is the order figures should appear in the rendered HTML (left-to-right for `*-side`, top-to-bottom for `*-stack`).
+>
+> IMAGE_SRCS: {IMAGE_SRCS}
+> ALT_TEXTS: {ALT_TEXTS}
+>
+> WIKI_CONTEXT (optional, may be empty — use it ONLY to ground concrete numbers/claims, never to invent content not in the section):
+> {WIKI_CONTEXT}
+>
+> **Task**:
+> 1. Write ONE concise paragraph summarizing ONLY the section's content for a scientific poster. Constraints: 2–5 sentences, factual, non-hallucinatory, no bullet lists, avoid starting with "This section". The summary must contain no more than 40 words and be written with strong logical coherence and smooth transitions to minimize perplexity.
+> 2. Output the HTML block for this section, choosing the template variant matching LAYOUT. Output ONLY the HTML and nothing else.
+>
+> **Strict output rules**:
+> - Output only the HTML for one section (one `<section>` block).
+> - Do NOT add markdown fences, explanations, or extra text.
+> - The `<div class="section-bar">` must be the section title (use `SECTION_JSON.name`).
+> - Replace the sample paragraph with your summary.
+> - LAYOUT == `"none"`: output the section block with NO `<div class="img-section">`.
+> - LAYOUT == `"inline"`: output the section block with exactly one `<div class="img-section">` containing one `<img>` whose `src` is `IMAGE_SRCS[0]` and `alt` is `ALT_TEXTS[0]`.
+> - LAYOUT == `"inline-multi-side"`: output ONE `<div class="img-section">` containing all `<img>` tags in `IMAGE_SRCS` order; the template's flex layout splits them horizontally.
+> - LAYOUT == `"inline-multi-stack"`: output MULTIPLE `<div class="img-section">` blocks, one per `<img>`, in `IMAGE_SRCS` order. Stacked top-to-bottom.
+> - LAYOUT == `"inline-multi-after-table"`: same as `"inline-multi-side"` (one `.img-section` with all `<img>` tags) but place that `.img-section` AFTER the `<table class="poster-table">` block(s) inside `<div class="section-body">`. Useful when the section's table is the primary artifact and figures serve as visual support.
+> - **TABLES**: if `SECTION_JSON.content` contains one or more `<table class="poster-table">…</table>` blocks, include EACH ONE verbatim (preserve the entire block byte-for-byte, including `<caption>`, `<thead>`, `<tbody>`, all `<tr>` / `<th>` / `<td>` tags and their attributes) inside `<div class="section-body">` AFTER your summary `<p>`. Do NOT paraphrase, restructure, or trim the table HTML. Exception — drop a table only if it is obviously too large for one column (> 5 columns AND > 6 rows) AND summarizing 2–3 key cells in prose would preserve the result; in that case, drop the table and call out the key numbers in your summary `<p>`.
+>
+> **Required HTML templates**(按 LAYOUT 选择对应变体):
+>
+> *LAYOUT = "none"*:
+> ```html
+> <section class="section">
+>   <div class="section-bar" contenteditable="true">SECTION_TITLE</div>
+>   <div class="section-body" contenteditable="true">
+>     <p>SUMMARY_TEXT</p>
+>   </div>
+> </section>
+> ```
+>
+> *LAYOUT = "inline"* (single figure):
+> ```html
+> <section class="section">
+>   <div class="section-bar" contenteditable="true">SECTION_TITLE</div>
+>   <div class="section-body" contenteditable="true">
+>     <p>SUMMARY_TEXT</p>
+>     <div class="img-section">
+>       <img src="IMAGE_SRCS[0]" alt="ALT_TEXTS[0]" class="figure" />
+>     </div>
+>   </div>
+> </section>
+> ```
+>
+> *LAYOUT = "inline-multi-side"* (≥2 figures, horizontal):
+> ```html
+> <section class="section">
+>   <div class="section-bar" contenteditable="true">SECTION_TITLE</div>
+>   <div class="section-body" contenteditable="true">
+>     <p>SUMMARY_TEXT</p>
+>     <div class="img-section">
+>       <img src="IMAGE_SRCS[0]" alt="ALT_TEXTS[0]" class="figure" />
+>       <img src="IMAGE_SRCS[1]" alt="ALT_TEXTS[1]" class="figure" />
+>       <!-- repeat for IMAGE_SRCS[2], etc. -->
+>     </div>
+>   </div>
+> </section>
+> ```
+>
+> *LAYOUT = "inline-multi-stack"* (≥2 figures, vertical):
+> ```html
+> <section class="section">
+>   <div class="section-bar" contenteditable="true">SECTION_TITLE</div>
+>   <div class="section-body" contenteditable="true">
+>     <p>SUMMARY_TEXT</p>
+>     <div class="img-section">
+>       <img src="IMAGE_SRCS[0]" alt="ALT_TEXTS[0]" class="figure" />
+>     </div>
+>     <div class="img-section">
+>       <img src="IMAGE_SRCS[1]" alt="ALT_TEXTS[1]" class="figure" />
+>     </div>
+>     <!-- one .img-section per figure -->
+>   </div>
+> </section>
+> ```
+>
+> *With a table* — when `SECTION_JSON.content` contains
+> `<table class="poster-table">`, insert the verbatim table block(s)
+> after the summary `<p>`. Default placement order inside
+> `<div class="section-body">`:
+>   1. summary `<p>`
+>   2. `<table class="poster-table">…</table>` (all tables, in source order)
+>   3. `<div class="img-section">…</div>` (if LAYOUT requires figures)
+>
+> If LAYOUT is `"inline-multi-after-table"` the order is the same — the
+> name is just a hint that the table is the primary artifact. Example:
+> ```html
+> <section class="section">
+>   <div class="section-bar" contenteditable="true">SECTION_TITLE</div>
+>   <div class="section-body" contenteditable="true">
+>     <p>SUMMARY_TEXT</p>
+>     <table class="poster-table">…verbatim from SECTION_JSON.content…</table>
+>     <div class="img-section">
+>       <img src="IMAGE_SRCS[0]" alt="ALT_TEXTS[0]" class="figure" />
+>       <img src="IMAGE_SRCS[1]" alt="ALT_TEXTS[1]" class="figure" />
+>     </div>
+>   </div>
+> </section>
+> ```
+
+按 `shared-references/academic-writing.md` 做去 AI 风格化(变换句首、避免 "leverage"/"comprehensive"/"delve" 等 AI 签名词)。从 `WIKI_CONTEXT` 拉取关键数值,让结果具体可信。
+
+按选择顺序将所有块写入 `poster/outline.html`。
+
+### Step 4: 添加章节间过渡句
+
+对拼接后的 outline 应用以下提示词(改写自 PaperX):
+
+> **Prompt**: You are given an HTML-like poster outline of multiple `<section class="section">` blocks. Each section has a title in `<div class="section-bar">` and main text in the first `<p>` inside `<div class="section-body">`.
+>
+> Generate one bridging sentence per section from the FIRST up to the SECOND-TO-LAST. Place each at the END of that section's first `<p>` to lead into the NEXT section's topic.
+>
+> **Output**: a JSON array of strings. Length = (number_of_sections − 1). The i-th string bridges section i to section i+1. Each is one sentence (12–25 words), fluent academic English, no newlines.
+>
+> **Patterns** to prefer:
+> - When the next section introduces/elaborates/substantiates a method or idea: "To introduce / elaborate on / substantiate \<next topic\>, we next present \<next title\>."
+> - When the next section is experimental: "Next, we evaluate \<subject\> to demonstrate ..." or "We then conduct experiments on \<task\> to empirically validate ..."
+> - Always reference the next section's topic without introducing new technical claims.
+
+解析返回的 JSON 数组。对每个字符串,追加到对应章节的第一个 `<p>` 末尾。最后一个章节不加过渡句。
+
+### Step 5: 构建海报
+
+```bash
+python3 tools/poster.py build \
+  --template templates/poster/poster_template.html \
+  --outline poster/outline.html \
+  --output poster/poster.html
+
+python3 tools/poster.py inject-title \
+  --dag poster/dag.json \
+  [--authors "{Step 0 收集到的 authors 覆盖串,或 --authors flag 的值}"] \
+  poster/poster.html
+```
+
+`--anonymous` 已在 Step 1(`wiki2dag.py`)生效 —— `dag.json` 中的标题/作者已是最终值,`inject-title` 默认从那里读。当论文的 `\author{}` 因双盲投稿而留空但海报需要显示真实作者时,传入 `--authors` 覆盖。同时传入 `--anonymous` 时仍以 `--anonymous` 为准。
+
+```bash
+# 应用 Step 0 收集到的 venue 与 logo。用户跳过的项就不要传对应 flag。
+python3 tools/poster.py inject-header \
+  --venue "{Step 0 的 venue}" \
+  [--affiliation-logo {path}] \
+  [--conference-logo {path}] \
+  --layout {corners|stacked} \
+  poster/poster.html
+
+python3 tools/poster.py inject-figures \
+  --dag poster/dag.json \
+  --paper-dir paper/ \
+  --poster-dir poster/
+
+python3 tools/poster.py validate poster/poster.html
+```
+
+`inject-figures` 直接拷贝 PNG/JPG,对 PDF 源使用 `pdftoppm` 以 200 DPI 转为 PNG。`validate` 检查每个 `<img src=...>` 能解析、标题非空、章节数 ≥ 3、不存在 `TODO`/`FIXME`/`[UNCONFIRMED]` 标记。
+
+### Step 5b: 渲染 PNG
+
+`validate` 通过后,把 HTML 海报渲染成 PNG,供用户预览,也作为后续 Step 5.5 critique-revise 的输入:
+
+```bash
+python3 tools/poster.py render poster/poster.html
+```
+
+产出 `poster/poster.png`,默认 2× CSS 像素(2800×1800)。用 `--scale {1,2,3}` 覆盖(1 = 快速预览,3 = 印刷质量)。
+
+**渲染引擎**:优先 Playwright(Chromium),其次是系统浏览器的子进程兜底。Playwright 之所以首选,是因为它在截图前**等到特定事件触发**——`document.fonts.ready`、所有 `<img>` `load` 事件、`flow.scrollWidth` 连续 10 帧不变(即 fit() 收敛)。子进程路径用 `--virtual-time-budget=5000` 这种 wall-clock 超时,在 CDN 慢响应时可能在 Google Fonts / KaTeX 加载前就截图。这正是 PaperX 用的等待语义。
+
+**安装 Playwright**(一次性,推荐):`pip install playwright && python -m playwright install chromium`。即使不装,`render` 也能走子进程路径;输出里会显示 `browser: chromium`(子进程)或 `browser: playwright-chromium`(首选)。
+
+**子进程兜底的浏览器探测**:Chrome → Edge → Chromium → Firefox(最后兜底)。Chrome/Edge/Chromium 三者等价(同引擎、同 CLI flag)。Firefox 也能用,但有两个限制 —— 不支持 HiDPI 缩放(无论 `--scale` 传什么,PNG 都是 1×);也没有 `--virtual-time-budget` 等价物。退化到 Firefox 时 `render` 会向 stderr 打印警告。
+
+**不支持 Safari** —— Safari 没有 headless CLI 截图 flag;接入需要 `safaridriver` + Selenium WebDriver。macOS 上只有 Safari 的用户可以 `brew install --cask google-chrome`(一行命令)解锁完整流程。
+
+若找不到任何支持的浏览器,`render` 以平台对应的安装提示退出。HTML 海报本身在任何浏览器里都能打开 —— 用户依然可以 `open poster/poster.html`。
+
+### Step 5.5: Critique-revise(截图 + DOM 溢出报告双驱动)
+
+目标:用**程序化的溢出报告**(从渲染后的 DOM 取的 ground truth)结合**截图**(视觉上下文)来修订 HTML。DOM 报告是 fit() 和 LLM 都可能漏看的东西 —— 它精确测量每个叶子元素的 bottom / right 与 flow 边缘的差,精确报出任何 clipping。LLM **不能**在报告显示 clipping 的情况下声明收敛,必须修剪文字直到报告 ok。
+
+自动应用,无用户交互。
+
+**跳过条件**:
+- 传入 `--no-refine` → 完全跳过。
+- `--refine-iterations 0` → 等同 `--no-refine`。
+- Step 5b 没产出 `poster/poster.png`(无可用 headless 浏览器)→ 警告后跳过。
+
+**迭代次数**:由 `--refine-iterations N` 决定(默认 1,硬上限 2)。注意:收敛不再只看文字稳定,而是依赖溢出报告 —— 见下面的终止条件。
+
+**单轮迭代流程**(i = 1..N):
+
+1. 确保 `poster/poster.png` 反映当前 `poster/poster.html`。若 HTML 自上次渲染后有改动,重跑 `python3 tools/poster.py render poster/poster.html`。
+2. 运行 `python3 tools/poster.py check-overflow poster/poster.html --output raw/tmp/poster.overflow.json`(scratch 路径 —— `poster/` 里只放最终产物)。读取该 JSON。
+3. **提前收敛(仅溢出报告路径)**:若 `i == 1` 且 `overflow.ok == true`,且认真比对截图后没看到任何明显的 LaTeX / 编码 / 编号问题(对自己应用下面 refinement 提示词里的强制 checklist),**可以**在这里就声明收敛:记录 `"converged after 0 iterations — DOM clean, no visible content issues"` 并退出。如果有**任何**疑虑就不要走这条捷径 —— 跑一轮 refinement 的成本远小于交付一张细节有问题的海报。
+4. 在内存里快照 `pre_html = <当前 poster.html>` —— 用于后面的文字稳定性判定。
+5. 读取 `poster/poster.png`(多模态)、`poster/poster.html`、以及 `raw/tmp/poster.overflow.json`(ground truth 的 clipping 报告)。
+6. 应用下面的 refinement 提示词。把 overflow JSON 作为 prompt 的一部分传入 —— LLM 凭它**精确**知道哪些章节要 trim,而不是从截图里猜。用 Claude(会话内,已多模态)。**不要**用 `llm-review.chat`,它按 `mcp-servers/llm-review/server.py` 只接受文本。
+7. 解析 LLM 输出:从第一个 ```` ```html ```` 围栏代码块里提取 HTML。
+8. 把修订后的 HTML 写回 `poster/poster.html`,并快照为 `post_html`。
+9. 重跑 `python3 tools/poster.py validate poster/poster.html`。若 validate 失败:停止,告诉用户具体问题,HTML 保留原样。
+10. 重新渲染 `poster/poster.png`。重跑 `check-overflow --output raw/tmp/poster.overflow.json` → 更新报告。
+11. **收敛检查(两个条件**都满足才算收敛**)**:
+    - (a) 新的 overflow 报告 `ok == true`,且
+    - (b) `pre_html` 与 `post_html` 在 `.flow` 区域字符差异 < 50。
+    
+    都满足:声明收敛(`"converged after {i} iteration(s) — DOM clean and prose stable"`)并退出。
+    
+    overflow.ok 仍为 false:下一轮**必须**继续 refine;即使 prose 稳定也不能停。LLM 没 trim 够。
+    
+    迭代预算用尽但 overflow.ok 还是 false:停止,清晰提示("Step 5.5 跑完 N 轮但仍有 DOM clipping —— 考虑 `--refine-iterations 2`,或在 `poster/outline.html` 里手动 trim 最长那节的文字"),HTML / PNG 留着给用户人工检查。
+
+**为什么这么设计**:上一版让 LLM 看降采样的 PNG 后凭感觉声明收敛。列边缘的细微 clipping 被漏掉。DOM 溢出报告把"clipping 的检测"从 LLM 判断里拿出来 —— 现在 clipping 是测量值,不是猜测。LLM 的活变成专门**修复**报告里标出的东西,不再兼职决定"有没有要修的"。
+
+**Refinement 提示词**(从 PaperX `poster_refinement_prompt` 移植;新增 overflow JSON 输入 + 强制 pre-flight checklist):
+
+> You are an expert Academic Poster Designer and Web Developer. Your task is to refine an existing HTML poster based on its visual rendering (screenshot), the current HTML code, and a structured DOM overflow report.
+>
+> **INPUTS**:
+> 1. **Current Poster Code (HTML)** — full poster.html
+> 2. **Visual Render (PNG screenshot)** — poster.png attached via Read
+> 3. **DOM Overflow Report (JSON)** — output of `tools/poster.py check-overflow`. This is **ground truth** about which elements are clipped. If `clipped` is non-empty, you MUST fix each entry.
+>
+> **MANDATORY PRE-FLIGHT CHECKLIST** — answer BEFORE generating any HTML. Write this as a fenced ```` ```json ```` block first; then below it, output the corrected HTML in a separate ```` ```html ```` block.
+>
+> ```json
+> {
+>   "overflow_report_ok": <true|false; copy from the report's "ok" field>,
+>   "clipped_count":     <integer; the length of the report's "clipped" array>,
+>   "col1_bottom_ok":    <true|false; from the screenshot, is the last text line in col 1 ≥ 10 px above the .poster bottom border AND fully readable?>,
+>   "col2_bottom_ok":    <true|false; same check for col 2 — pay specific attention to any figure's x-axis label>,
+>   "col3_bottom_ok":    <true|false; same check for col 3>,
+>   "latex_leaks":       <list of strings; raw LaTeX patterns you found, e.g. ["\\textbf{x}", "\\citep{key}"] — empty list if none>,
+>   "numbering_prefixes": <list of strings; section-bars with leading "1.", "A.", etc. — empty list if none>,
+>   "will_revise":       <true|false; if ANY of the above signal a problem, this MUST be true and the HTML block below MUST contain trimming/fixes>
+> }
+> ```
+>
+> If `will_revise: false`, your HTML block may be identical to the input.
+>
+> If `will_revise: true`, the HTML block MUST contain real edits addressing each flagged issue. **Do not output unchanged HTML claiming you fixed it** — that's the failure mode this checklist exists to prevent.
+>
+> **TASKS** (apply only where flagged by the checklist):
+>
+> **Task 1: Fix LaTeX / encoding leaks** (when `latex_leaks` non-empty)
+> - Replace raw LaTeX with HTML entities or Unicode (`\\textbf{x}` → `<strong>x</strong>`, `\\citep{key}` → `[N]`, `$d_S \\ge 10$` → `d_S ≥ 10`).
+>
+> **Task 2: Normalize section headers** (when `numbering_prefixes` non-empty)
+> - Strip leading `1.`, `2.1`, `A.`, `E.`, `- `, etc. from `<div class="section-bar">` contents.
+>
+> **Task 3: Fix DOM-reported clipping** (when `overflow_report_ok: false`)
+> - The JSON's `clipped` array names every offending element with its `section_title`, `tag`, `bottom_overflow_px`, and a content `preview`. For each clipped element, **trim the corresponding section's prose conservatively** (drop filler words, tighten sentences) until that element fits. Never delete claims, citations, or math expressions.
+>
+> **Task 4: Fix screenshot-only issues** (when any `colN_bottom_ok: false`)
+> - The DOM check has tolerance; visually cramped content (line right against the border) may still pass `overflow.ok: true`. If the screenshot shows this, trim the relevant column's prose by 5–15 words.
+>
+> **Output requirements**:
+> - First, the ```` ```json ```` checklist block (mandatory).
+> - Then, the ```` ```html ```` block: complete, runnable HTML.
+> - Preserve the CSS, the `<script>` fit algorithm, and font-related settings exactly. Only edit content inside `<section class="section">` and the title/authors slots.
+>
+> **HTML poster**:
+> ```html
+> {full content of poster/poster.html}
+> ```
+>
+> **DOM Overflow Report**:
+> ```json
+> {full content of raw/tmp/poster.overflow.json}
+> ```
+>
+> **Screenshot**:
+> *(the contents of poster/poster.png attached via the Read tool — Claude reads it as an image)*
+
+**终止条件**:
+- **收敛(首选)**:overflow.ok=true 且 prose diff < 50 字符。正常退出。
+- **达到迭代上限且 overflow.ok=true**:也算正常退出。
+- **达到迭代上限但 overflow.ok=false**:停止并向用户告警 —— 预算不够清除全部 clipping。建议 `--refine-iterations 2`,或在 `poster/outline.html` 里手动 trim 最长那节的文字。
+- **LLM 输出缺 JSON checklist 块** → 停止,告警("refinement LLM 未产出强制 pre-flight checklist"),HTML 保留原样。
+- **LLM 输出缺 HTML 围栏块** → 停止,告警,HTML 保留原样。
+- **修订后 validate 失败** → 停止,告诉用户具体问题,HTML 保留原样。
+- **LLM 在 overflow.ok=false 的情况下声明 `will_revise: false`** → 告警("refinement LLM 忽略了 DOM clipping 报告"),若预算还有就继续下一轮,否则告警用户。
+
+### Step 6: 可选 Review LLM 评审(`--review`)
+
+若传入 `--review`,把海报 HTML 发给 Review LLM:
+
+```
+llm-review.chat
+  system: "You are a senior researcher reviewing an academic poster.
+           Evaluate: (1) Is the content hierarchy clear? (2) Are key results prominently placed?
+           (3) Is each section self-contained and readable? (4) Is the visual balance good (text vs figures)?
+           (5) Are transitions between sections logical? (6) Would a passerby understand the contribution in 30 seconds?"
+  message: |
+    ## Poster HTML
+    {poster/poster.html 的完整内容}
+
+    ## DAG
+    {poster/dag.json 的完整内容}
+
+    Review for: content completeness, text density, figure selection, narrative flow.
+    Flag any section that is unclear, off-topic, or missing key context.
+```
+
+根据反馈编辑 `poster/outline.html` 并重新执行 Step 5。评审-修订循环最多 2 轮。
+
+### Step 7: 日志与报告
+
+```bash
+python3 tools/research_wiki.py log wiki/ \
+  "poster | generated poster for '{title}' | {N} sections, {M} figures | reviewed: {yes/no}"
+```
+
+打印 POSTER_REPORT:
+
+```markdown
+# 海报报告
+
+## 来源
+- 论文:{title}
+- 作者:{authors}
+- 论文目录:{paper_dir}
+
+## 生成情况
+- 包含章节:{N}/{可用总数}
+- 配图选择模式:{interactive | auto | none}
+- 嵌入配图:{M}
+- PDF→PNG 转换:{K}
+- Header:venue='{venue}', affiliation={path|none}, conference={path|none}, layout={corners|stacked}
+- Critique-revise(Step 5.5):{k/N 轮已应用 | 第 k/N 轮收敛(无实质修改) | 已跳过(--no-refine) | 已跳过(无可用 headless 浏览器)}
+- Review LLM(Step 6):{已调用 / 已跳过}
+
+## 输出
+- poster/poster.html ← 浏览器打开
+- poster/poster.png ← 平面截图,2× CSS(默认 2800×1800)
+- poster/dag.json(中间产物,可被 /slides /pr 复用)
+
+## 导出 PDF
+在 Chrome / Edge / Firefox 中打开 `poster/poster.html`,按 **Cmd+P**(macOS)
+或 **Ctrl+P**(Win/Linux) → **另存为 PDF**。推荐打印设置:
+- 方向:**横向**
+- 纸张尺寸:**自定义 1400×900 px**(若不支持自定义,退回 Letter / A3 横向)
+- 边距:**无**
+- 缩放:**100%**(若 100% 溢出,改为"适应页面")
+- 背景图形:**开启**(让蓝色 header 与 section bar 正常渲染)
+
+## 备注
+- {警告项,如缺失图片、选中章节等}
+```
+
+## Constraints
+
+- **不修改 `paper/` 源文件**:本 skill 对 LaTeX 源(`main.tex`、`sections/*.tex`、`figures/`、`references.bib`、`math_commands.tex`)只读。`paper/` 下允许写入的只有:(a) `paper/.author_display.txt`(Step 0 作者缓存);(b) `paper/figures/_tikz_<sec>_<label>.png`(Step 1 的 TikZ 光栅化缓存,见 Step 1 "TikZ 图")。`_tikz_` 前缀标识它们是从 `paper/sections/*.tex` 派生的产物;删除安全(下次运行重建)。其它输出全部写到 `poster/`。
+- **不创建 wiki 实体或图边**:海报是展示产物,不进知识图。
+- **复用已编译图**:不重新执行 `paper/figures/plot_*.py`,用户已运行过 `/paper-compile`。
+- **遵循 `--anonymous`**:开启时,作者在 `dag.json` 与海报 header 中都写为 "Anonymous"。
+- **章节数上限**:硬上限 6 个章节,保证 1400×900 下可读。章节按 Step 2.5 的优先级表选;论文章节数超过上限时,Related Work / Background / Appendix 优先被丢弃。
+- **40 词摘要**:按 poster_outline_prompt,每章正文段在加过渡句前不超过 40 词。
+- **强制去 AI 风格化**:按 `shared-references/academic-writing.md`。避开 "In this work" / "We propose" / "Our approach" 等签名开头,把 "leverage" 换成 "use","delve" 换成 "examine"。
+- **严格模板注入**:`tools/poster.py build` 仅注入到 `<div class="flow" id="flow">...</div>` 之间,不修改模板的 CSS 与 fit 算法。
+- **配图选择默认交互**:未传入 `--auto-figures` 也未传入 `--no-figures` 时,跑 Step 2.5 manifest + 询问流程。这些 flag 按 CLAUDE.md 规则 5 归用户所有 —— 不要替用户推断;不确定时,询问用户。
+- **wide 图无特殊布局**:任何图都在 `<section>` 内 inline 渲染。visual 节点上的 `wide` 字段仅作信息提示 —— 用来在 manifest 中显示 ⚠ 标记,让用户选别的图或跳过过宽/过高的图。未来的图像生成 skill 预期会在源头解决比例问题,产出适配海报的图。
+
+## Error Handling
+
+- **`paper/main.tex` 不存在**:报错并提示 "先运行 /paper-draft 生成论文"。
+- **`\input{sections/...}` 未找到章节**:列出搜索过的路径,提示检查 `main.tex` 是否使用了非标准的 section include。
+- **没有图片引用**:文本-only 章节继续渲染;在 POSTER_REPORT 中给出警告。
+- **`pdftoppm` 未安装**:PDF 图无法转 PNG;提示 `brew install poppler`(macOS)或 `apt install poppler-utils`(Linux)。海报仍能渲染但这些图会显示为 broken img。
+- **嵌套图路径**(如 `paper/figures/exp1/foo.pdf`):桥接工具会扁平化为 `images/foo.png`,且图片解析只在 `paper/figures/` 顶层查找。若多个图片跨子目录同名,后者会覆盖前者。当前仅支持扁平的 `paper/figures/` 布局。
+- **`PIL`/Pillow 未安装**:图片分辨率无法计算,`dag.json` 的 visuals `resolution` 为空;poster_outline_prompt 的 "最高分辨率优先" 规则失效,Claude 按章节顺序选图。提示 `pip install Pillow`。
+- **validate 失败**:把所有问题写入 stderr,不删除已有输出。用户改正 outline 后从 Step 5 继续。
+- **`render` 找不到可用浏览器**:打印对应平台的安装提示并继续(推荐 Chrome / Edge / Chromium;Firefox 作为兜底也可)。HTML 海报仍可用,只是少了 PNG。Step 5.5 critique-revise 也会跳过(无截图可参考)。Safari 不支持(没有 headless CLI)。
+- **退化到 Firefox**:`render` 会向 stderr 打印警告(不支持 HiDPI 缩放,layout 可能尚未收敛)。输出仍能用,但比 Chrome/Edge 质量低。建议用户装一个 Chromium 系浏览器以获得最佳效果。
+- **Refinement 输出格式异常(Step 5.5)**:若 LLM 没返回包含合法 `<section>` 与 `<h1 class="title">` 的 ```` ```html ```` 围栏,停止迭代,HTML 保留不变,告警提示。**不要**用残缺输出覆盖 HTML。
+- **Review LLM 不可用**:跳过 Step 6,在报告中标注,继续。
+
+## Dependencies
+
+### Tools(via Bash)
+- `python3 tools/wiki2dag.py build --paper-dir <dir> --output <path> [--anonymous] [--citations]` —— 构建 dag.json;`--citations` 选择性恢复内联 `[N]` 标记(默认丢弃,海报上不渲染参考文献列表)
+- `python3 tools/poster.py build --template <path> --outline <path> --output <path>` —— 注入 outline
+- `python3 tools/poster.py inject-title --dag <path> <poster.html> [--anonymous] [--authors STR]` —— 写入标题/作者;`--authors` 覆盖 dag.json 中的作者字段,适用于源论文已匿名的情况
+- `python3 tools/poster.py inject-header <poster.html> [--venue STR] [--affiliation-logo PATH] [--conference-logo PATH] [--layout corners|stacked]` —— venue 文本 + 可选 logo
+- `python3 tools/poster.py inject-figures --dag <path> --paper-dir <path> --poster-dir <path>` —— 复制/转换图片
+- `python3 tools/poster.py validate <poster.html>` —— 健康检查
+- `python3 tools/poster.py render <poster.html> [--scale 1|2|3] [--output PATH]` —— HTML → PNG,走 headless 浏览器(优先 Chrome / Edge / Chromium,Firefox 兜底)
+- `python3 tools/poster.py check-overflow <poster.html> [--output PATH]` —— 用 Playwright 查询渲染后的 DOM,产出 poster.overflow.json。Step 5.5 用它做 ground truth。
+- `python3 tools/research_wiki.py log wiki/ "<message>"` —— 追加日志
+- `pdflatex`(TeX Live)—— Step 1 的 TikZ 光栅化必需;`brew install --cask mactex` / `apt install texlive-full` 安装。需要 `tikz`、`pgfplots`、`standalone`、`booktabs`、`multirow`、`array`、`xcolor`、`amsmath`、`amssymb` 等包。若未安装,figure env 中没有 `\includegraphics{}` 的 TikZ 图会被 stderr 告警 + 丢弃,其余构建继续。
+- `pdftoppm`(poppler)—— PDF → PNG @ 200 DPI(用于论文 PDF 图和 TikZ 光栅化产物)
+- `pdfinfo`(poppler)—— PDF 页面尺寸,用于 resolution
+- Playwright + Chromium(推荐,可选)—— `pip install playwright && python -m playwright install chromium`。启用事件驱动等待(字体/图片/fit 稳定)。若未安装会自动兜底。
+- 系统 headless 浏览器(兜底)—— 自动探测顺序:Google Chrome → Microsoft Edge → Chromium → Firefox。Chrome/Edge/Chromium 完全等价;Firefox 只能在 1× 尺度渲染且无 sync-wait。Safari 不支持(无 headless CLI)。
+
+### MCP Servers
+- `llm-review.chat` —— 可选的跨模型评审(`--review`)
+
+### Qoder Native
+- `Read` —— 读 .tex / dag.json / outline.html / poster.png(多模态)
+- `Write` —— 写 outline.html
+- `Edit` —— 给 outline.html 注入过渡句,或在 Step 5.5 写回修订后的 HTML
+- `Bash` —— 调用 wiki2dag / poster / research_wiki
+
+### Shared References
+- `.qoder/skills/shared-references/academic-writing.md` —— 去 AI 风格化规则
+- `.qoder/skills/shared-references/cross-model-review.md` —— Review LLM 协议(`--review` 时)
+
+### Called by
+- 用户手动调用
+- 未来:`/research` Stage 5b(`/paper-compile` 之后)

--- a/.qoder/skills/prefill/SKILL.md
+++ b/.qoder/skills/prefill/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: prefill
+description: 用领域基础知识填充 wiki/foundations/，避免后续 /ingest 为教科书材料创建重复的 concept 页面
+---
+
+# /prefill
+
+> **用法**：`[domain] [--add '概念名']`
+
+
+> 将领域基础知识（奠基性方法、common practice、标准架构）作为**终端**页面沉淀到 `wiki/foundations/`。
+> Foundations 设计上**单向**：其他页面可以链接到 foundation，foundation 不写反向链接。
+
+## Trigger
+
+手动：`/prefill [domain]` 或 `/prefill --add "概念名"`。
+
+## Inputs
+
+- `domain`（位置参数，可选）：研究领域 — `general` / `NLP` / `CV` / `ML Systems` / `Robotics` 之一。未指定时从 `wiki/topics/` 标签推断；若 topics 为空则提示用户。
+- `--add "<概念>"`：跳过 catalog，直接为单个概念建立 foundation。
+
+## Outputs
+
+- `wiki/foundations/{slug}.md` — 每个种子一页
+- 更新的 `wiki/index.md`（由 `rebuild-index` 重生成 foundations 段落）
+- `wiki/log.md` 一条记录
+
+## Wiki Interaction
+
+### 读取
+- `wiki/topics/*.md` — 用于推断 domain（未指定时）
+- `wiki/foundations/*.md` — 跳过已存在的 foundation（幂等）
+- `.qoder/skills/prefill/foundations-catalog.yaml` — 种子列表
+
+### 写入
+- `wiki/foundations/{slug}.md`（仅新建，从不覆盖）
+- `wiki/index.md`（通过 `tools/research_wiki.py rebuild-index`）
+- `wiki/log.md`（通过 `tools/research_wiki.py log`）
+
+## Workflow
+
+**前置条件**：当前目录包含 `wiki/`、`tools/`、`.qoder/`。`WIKI_ROOT=wiki/`。
+
+### Step 1: 确定 domain
+
+1. 用户传入 `domain` → 直接使用。
+2. 否则若处于 `--add` 模式 → 默认 `general`，除非用户额外指定。
+3. 否则：读取 `wiki/topics/*.md` 的 frontmatter `tags`；若能识别出主导 domain 则用之，否则提示用户。
+
+### Step 2: 加载种子
+
+- **Catalog 模式**：读取 `.qoder/skills/prefill/foundations-catalog.yaml`，取 `domains.{domain}` 下所有条目，并叠加 `domains.general` 的全部条目（general foundations 适用所有领域）。
+- **`--add` 模式**：构造单一种子 `{slug: <slugified concept>, title: <concept>, summary: ""}`。Slug 用 `python3 tools/research_wiki.py slug "<concept>"` 生成。
+
+对每个种子，若 `wiki/foundations/{slug}.md` 已存在则**跳过**（不覆盖、不警告）。
+
+### Step 3: 从 Wikipedia 拉取背景
+
+对每个剩余种子调用 `tools/fetch_wikipedia.py`：
+
+```bash
+python3 tools/fetch_wikipedia.py summary "<title>"
+python3 tools/fetch_wikipedia.py sections "<title>"
+python3 tools/fetch_wikipedia.py section "<title>" --index <N>   # 拉取相关章节
+```
+
+- summary 调用返回 `{title, extract, url}`。
+- sections 调用返回 `[{index, line, level}, ...]` — 选取 `line` 包含 `Variants` / `Types` / `Architecture` / `History` / `Limitations` / `Applications` 的章节（大小写不敏感子串匹配）。
+- 任意调用退出码为 `2` 表示**页面不存在** — 该种子回退到 LLM 知识，生成的 frontmatter 中 `source_url: ""`。
+
+### Step 4: 组装 foundation 页面
+
+按下方模板渲染。Wikipedia 来源的内容与 LLM 生成的内容需视觉上区分：纯 LLM 段落以 `(LLM analysis)` 标注。
+
+```yaml
+---
+title: "{title}"
+slug: "{slug}"
+domain: "{domain}"
+status: mainstream         # 已被取代的方法填 historical
+aliases: []                # 列出 LLM 有把握的常见别名
+first_introduced: "{Wikipedia summary 中能提取的年份，否则留空}"
+date_updated: "{今天}"
+source_url: "{Wikipedia URL，404 时留空}"
+---
+
+## Definition
+{Wikipedia summary 首段，或 LLM 提供的定义。}
+
+## Intuition
+{基于定义的通俗解释。}
+
+## Formal notation
+{从 Wikipedia 提取的公式/记号；若无则由 LLM 补充并标注 `(LLM analysis)`。}
+
+## Key variants
+{从 Wikipedia "Variants" / "Types" / "Architecture" 章节提炼的列表。}
+
+## Known limitations
+{Wikipedia + LLM 综合判断。}
+
+## Open problems
+{LLM analysis (LLM analysis)}
+
+## Relevance to active research
+{LLM analysis (LLM analysis)}
+```
+
+每页写入 `wiki/foundations/{slug}.md`。
+
+### Step 5: 刷新导航和日志
+
+```bash
+python3 tools/research_wiki.py rebuild-index wiki/
+python3 tools/research_wiki.py log wiki/ "prefill | {N} foundations created for {domain}"
+```
+
+### Step 6: 报告
+
+打印分组摘要：
+
+```
+## Prefill Report — {date}
+
+**Domain**: {domain}
+**Created**: {N}  **Skipped (already present)**: {M}
+
+### mainstream
+- foundations/gradient-descent — Gradient Descent
+- ...
+
+### historical
+- foundations/recurrent-neural-networks — Recurrent Neural Networks
+```
+
+提醒用户：后续 `/ingest` 会与这些 foundation 去重，遇到匹配概念时创建 `[[foundation-slug]]` 链接而非新建 concept 页面。
+
+## Constraints
+
+- **foundations 是终端节点**：foundation 页面禁止写 `key_papers`、`related_concepts` 或任何外向引用字段。其他页面可链入。
+- **从不覆盖**已存在的 `wiki/foundations/{slug}.md`（幂等）。
+- **来源区分**：Wikipedia 内容与 LLM 内容必须在页面正文中视觉上区分。
+- **catalog 是建议性的**：seed YAML 由人工维护、不完整，用户可无需改代码自行扩展。
+- **仅写入 `wiki/foundations/`**：不会创建 `papers/`、`concepts/`、`topics/` 等目录下的页面。
+
+## Error Handling
+
+- **`wiki/foundations/` 不存在**：先运行 `python3 tools/research_wiki.py init wiki/`。
+- **Wikipedia 404**：记录缺失页面，该种子回退 LLM 知识（`source_url: ""`）。
+- **网络失败**：打印失败的种子，继续处理其余种子，不中断整个批次。
+- **catalog 文件缺失**：报错并指向 `.qoder/skills/prefill/foundations-catalog.yaml`。
+
+## Dependencies
+
+### 工具（通过 Bash）
+- `python3 tools/fetch_wikipedia.py summary|sections|section|wikitext "<title>" [--index N]`
+- `python3 tools/research_wiki.py slug "<title>"`
+- `python3 tools/research_wiki.py rebuild-index wiki/`
+- `python3 tools/research_wiki.py log wiki/ "<message>"`
+
+### Catalog
+- `.qoder/skills/prefill/foundations-catalog.yaml`

--- a/.qoder/skills/prefill/foundations-catalog.yaml
+++ b/.qoder/skills/prefill/foundations-catalog.yaml
@@ -1,0 +1,74 @@
+domains:
+  general:
+    - slug: gradient-descent
+      title: "Gradient Descent"
+      summary: "一阶优化算法家族，通过沿损失函数梯度的反方向迭代更新参数"
+    - slug: backpropagation
+      title: "Backpropagation"
+      summary: "利用链式法则高效计算神经网络中各参数梯度的算法"
+    - slug: regularization
+      title: "Regularization"
+      summary: "防止过拟合的技术家族，包括 L1/L2 正则化、dropout、早停等"
+    - slug: cross-validation
+      title: "Cross-Validation"
+      summary: "将数据划分为训练集和验证集以评估模型泛化能力的方法"
+    - slug: optimization
+      title: "Optimization"
+      summary: "机器学习中最小化损失函数的方法论，包括 SGD、Adam 等优化器"
+  NLP:
+    - slug: transformer
+      title: "Transformer"
+      summary: "基于自注意力机制的序列建模架构，取代 RNN 成为 NLP 主流"
+    - slug: attention-mechanism
+      title: "Attention Mechanism"
+      summary: "允许模型动态关注输入不同部分的机制"
+    - slug: recurrent-neural-networks
+      title: "Recurrent Neural Networks"
+      summary: "通过隐藏状态处理序列数据的神经网络架构，已被 Transformer 大幅取代"
+    - slug: word-embeddings
+      title: "Word Embeddings"
+      summary: "将离散词语映射到连续向量空间的表示学习方法"
+    - slug: sequence-to-sequence
+      title: "Sequence-to-Sequence Models"
+      summary: "编码器-解码器架构，用于变长输入到变长输出的映射"
+    - slug: language-model
+      title: "Language Model"
+      summary: "学习文本概率分布的模型，是 GPT/BERT 等预训练模型的基础"
+    - slug: tokenization
+      title: "Tokenization"
+      summary: "将文本切分为模型可处理的基本单元的方法"
+    - slug: pre-training
+      title: "Pre-training"
+      summary: "在大规模无标注数据上学习通用表示的训练范式"
+  CV:
+    - slug: convolutional-neural-networks
+      title: "Convolutional Neural Networks"
+      summary: "利用卷积操作提取空间特征的神经网络架构"
+    - slug: residual-connections
+      title: "Residual Connections"
+      summary: "通过跳跃连接缓解深层网络梯度消失的技术"
+    - slug: batch-normalization
+      title: "Batch Normalization"
+      summary: "通过规范化中间层激活值加速训练的技术"
+    - slug: generative-adversarial-networks
+      title: "Generative Adversarial Networks"
+      summary: "生成器和判别器对抗训练的生成模型框架"
+    - slug: data-augmentation
+      title: "Data Augmentation"
+      summary: "通过对训练数据施加变换来增加数据多样性的技术"
+    - slug: image-classification
+      title: "Image Classification"
+      summary: "将图像分配到预定义类别的视觉任务"
+  RL:
+    - slug: markov-decision-process
+      title: "Markov Decision Process"
+      summary: "强化学习的数学框架，定义状态、动作、转移和奖励"
+    - slug: policy-gradient
+      title: "Policy Gradient Methods"
+      summary: "直接优化策略函数的强化学习方法族"
+    - slug: q-learning
+      title: "Q-Learning"
+      summary: "学习状态-动作价值函数的无模型强化学习算法"
+    - slug: reward-shaping
+      title: "Reward Shaping"
+      summary: "通过设计辅助奖励信号引导强化学习agent学习的技术"

--- a/.qoder/skills/rebuttal/SKILL.md
+++ b/.qoder/skills/rebuttal/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: rebuttal
+description: 解析审稿意见 → 原子化 concerns (Rvx-Cy) → 映射到 wiki ideas/methods → 检查 evidence → Review LLM stress-test → 生成 rebuttal
+---
+
+# /rebuttal
+
+> **用法**：`<review-file-or-path> [--paper-slug <slug>] [--venue <venue>] [--stress-test] [--format formal|rich]`
+
+
+> 解析审稿意见，将每条 concern 原子化（Rvx-Cy 编号）并映射到 wiki idea 或 method，
+> 检查 evidence 是否充分（追溯到 wiki experiments），
+> 用 Review LLM 模拟审稿人追问（stress-test，评分 1-5），生成正式版（纯文本）和富文本版 rebuttal。
+> 安全检查确保 no fabrication, no overpromise, full coverage。
+
+## Inputs
+
+- `review`：审稿意见来源，以下之一：
+  - 文件路径（如 `raw/reviews/reviewer1.txt`、`raw/reviews/meta-review.md`）
+  - 多个文件路径（逗号分隔：`raw/reviews/R1.txt,raw/reviews/R2.txt,raw/reviews/R3.txt`）
+  - 直接粘贴的审稿文本
+- `--paper-slug`（可选）：关联论文在 wiki/outputs/ 中的 slug，用于定位 PAPER_PLAN
+- `--venue`（可选）：目标会议/期刊（ICLR / NeurIPS / ICML / ACL / CVPR），影响 rebuttal 格式和字数限制
+- `--stress-test`（可选，默认开启）：Review LLM 模拟审稿人追问，关闭用 `--no-stress-test`
+- `--format`（可选，默认 `formal`）：输出格式
+  - `formal`：正式 rebuttal 纯文本版（适合直接粘贴到 submission system）
+  - `rich`：富文本版（含 wiki [[links]]、详细分析、改进计划）
+
+## Outputs
+
+- **wiki/outputs/rebuttal-{slug}.md** — 富文本版 rebuttal（含 [[wikilinks]]、evidence 追溯、分析表格）
+- **wiki/outputs/rebuttal-{slug}.txt** — 正式版 rebuttal（plain text，适合 submission system 粘贴）
+- **wiki/ideas/*.md** / **wiki/methods/*.md** — 若 concern 暴露 evidence gap，在对应章节追加建议（idea 写入 `## Risks` / `## Lessons learned`；method 写入 `## Limitations`）
+- **wiki/log.md** — 追加日志
+
+## Wiki Interaction
+
+### Reads
+- `wiki/ideas/*.md` — 把 concern 映射到 idea，检查 linked experiments 与 novelty 论证
+- `wiki/methods/*.md` — 把 concern 映射到 method，检查 Mechanism / Procedure / Limitations
+- `wiki/experiments/*.md` — 通过 `linked_idea` 找到支持 idea 的实验 result
+- `wiki/papers/*.md` — 查找引用的论文上下文
+- `wiki/concepts/*.md` — 理解 method 相关 concerns 的概念背景
+- `wiki/outputs/PAPER_PLAN.md` — 了解论文结构（来自 /paper-plan，若有 --paper-slug）
+- `wiki/graph/context_brief.md` — 全局上下文
+- `wiki/graph/edges.jsonl` — idea-experiment-paper-method 关系
+- `.qoder/skills/shared-references/cross-model-review.md` — Review LLM stress-test 独立性
+
+### Writes
+- `wiki/outputs/rebuttal-{slug}.md` — 富文本版
+- `wiki/outputs/rebuttal-{slug}.txt` — formal 纯文本版
+- `wiki/ideas/*.md` / `wiki/methods/*.md` — 在 idea 的 `## Risks` / `## Lessons learned` 或 method 的 `## Limitations` 追加 reviewer 发现的 gap；不得静默翻转 idea 的 status，只能标注 concern
+- `wiki/log.md` — 追加日志
+
+### Graph edges created
+- 无新 edges（rebuttal 是查询操作，不修改知识图谱）
+
+## Workflow
+
+**前置**：
+1. 确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）
+2. 读取 `cross-model-review.md` 确认 stress-test 独立性原则
+3. 生成 slug：`python3 tools/research_wiki.py slug "{paper-slug}-rebuttal"`
+
+### Step 1: 解析审稿意见
+
+1. **读取审稿文本**：
+   - 若为文件路径：读取所有指定文件
+   - 若为直接文本：直接使用
+   - 合并多个 reviewer 的意见，标注来源（Reviewer 1/2/3/Meta）
+
+2. **识别结构**：
+   - 提取每个 reviewer 的：overall score（Accept/Reject/Borderline）、confidence、summary、Strengths、Weaknesses、questions
+   - 若格式不标准（纯文本），用 LLM 解析为结构化格式
+
+3. **输出**：每个 reviewer 的结构化意见
+
+### Step 2: 原子化 Concerns
+
+将每条 weakness 和 question 拆分为独立的 atomic concern：
+
+1. **拆分规则**：
+   - 一个 weakness 可能是复合句，包含多个独立 concern（"方法缺少消融实验，且没有与 X 比较" → 拆分为 2 个 concerns）
+   - 每个 atomic concern 分配 ID：`Rvx-Cy` 格式（Rv1-C1 = Reviewer 1, Concern 1；Rv1-C2 = Reviewer 1, Concern 2）
+   - 保留 reviewer 编号，确保追溯到原始意见
+
+2. **分类每个 concern**：
+   - **evidence**：关于实验数据、result 解读的事实性质疑
+   - **method**：关于方法设计、算法正确性的方法论问题
+   - **missing**：缺少某些实验/分析/比较/引用
+   - **clarity**：表达不清、符号混乱、图表问题
+   - **scope**：贡献不够显著、适用范围质疑
+   - **novelty**：与已有工作重叠、创新性不足
+   - **minor**：格式、typo 等小问题
+
+3. **评估严重性**：critical / major / minor
+
+4. **输出**：原子化 concern 列表，每个包含 {id (Rvx-Cy), reviewer, type, severity, text}
+
+### Step 3: 映射 Concerns 到 Wiki Ideas / Methods
+
+对每个 concern：
+
+1. **查找关联 idea 或 method**：
+   - 从 concern 文本提取关键词
+   - 在 `wiki/ideas/*.md` 与 `wiki/methods/*.md` 中搜索匹配项（假设/结果类质疑映射到 idea；设计/算法类质疑映射到 method）
+   - 读取 `wiki/graph/edges.jsonl` 查找 idea↔experiment 与 method↔paper 关系
+   - 若找不到直接匹配：标注 "unmapped"（无直接实体对应）
+
+2. **检查 Evidence Status**：
+   - 对 idea：读取 `linked_experiments`，统计 succeeded/inconclusive/failed 结果数量；读取 `novelty_score` 与 `status`
+   - 对 method：读取 `source_papers` 与 `## Limitations`
+   - **判断**：
+     - 充分（sufficient）：linked idea 至少有 1 个 succeeded experiment，或 method 有 source paper 支持
+     - 部分充分（partial）：有 experiments 但结果好坏混合
+     - 不足（insufficient）：无支持实验或 source 覆盖薄弱
+     - 矛盾（contradicted）：以 failed/inconclusive 为主
+
+3. **输出**：
+
+| Concern ID | Reviewer | Type | Severity | Entity mapped | Evidence Status | Strategy |
+|------------|----------|------|----------|---------------|-----------------|----------|
+| Rv1-C1 | R1 | method | critical | [[method-slug]] | sufficient | A |
+| Rv1-C2 | R1 | missing | major | [[idea-slug]] | insufficient | B |
+| Rv2-C1 | R2 | novelty | major | unmapped | — | D |
+
+### Step 4: 起草 Rebuttal 回应
+
+对每个 concern 按 strategy 起草回应：
+
+**Strategy A — Evidence 充分（直接回应）：**
+- 引用具体实验 result 和数据（标注来源，确保追溯到 wiki/experiments/）
+- 指向 wiki 中的 evidence（转化为论文引用）
+- 若 concern 基于误解：礼貌澄清，指出论文中相关 Section
+
+**Strategy B — Evidence 不足（承认 + 具体计划）：**
+- 诚实承认当前 evidence 不够充分
+- 提出具体的补充实验计划（可链接到 /exp-design）
+- 说明具体时间线和资源需求
+- 不使用模糊承诺，只承诺具体可执行的补充实验
+
+**Strategy C — Clarity 问题（修改承诺）：**
+- 承认表达不清
+- 提供改进后的描述（直接在 rebuttal 中展示修改后的文本）
+- 列出具体的 Paper Edit 计划
+
+**Strategy D — Scope/Novelty 质疑（论证）：**
+- 强调与现有工作的本质区别
+- 引用 novelty-check 结果（若有）
+- 指出 reviewer 可能遗漏的差异点
+
+**每条回应的格式**：
+```markdown
+**[Rvx-Cy]** {concern summary}
+
+{response text, 2-5 sentences，标注来源确保可追溯}
+```
+
+**安全检查（每条回应）**：
+- [ ] No fabrication：不伪造数据或实验结果
+- [ ] No overpromise：只承诺具体可执行的补充实验
+- [ ] 引用的数据在 wiki/experiments/ 中有记录
+- [ ] 若 linked idea 的 `status: invalidated` 或其 experiments 不确定，不得假装它已被支持
+
+### Step 5: Review LLM Stress-Test
+
+**遵循 cross-model-review.md**：不向 Review LLM 发送 Claude 的 rebuttal 策略分析。
+
+若 `--stress-test` 开启（默认）：
+
+```
+llm-review.chat:
+  system: "You are a critical reviewer who has just read a rebuttal to your review
+           comments. You are skeptical and will push back on weak responses.
+           For each rebuttal response, assess on a scale of 1-5:
+           1 = unconvincing (deflection or fabrication suspected)
+           2 = weak (vague, no concrete evidence)
+           3 = acceptable (addresses concern but could be stronger)
+           4 = strong (concrete evidence, clear reasoning)
+           5 = fully convincing (compelling evidence, thorough response)
+           Also check for overpromise: are commitments specific and feasible?
+           Provide a follow-up question for any response scoring <= 3."
+  message: |
+    ## Original Review Concerns
+    {atomic concerns list with Rvx-Cy IDs}
+
+    ## Author Rebuttal
+    {drafted rebuttal responses}
+
+    ## Please assess each response (score 1-5) and provide follow-up questions.
+```
+
+**处理 Review LLM 反馈**：
+- **score 4-5（convincing）**：保持原回应
+- **score 3（acceptable）**：加强回应，补充 Review LLM 建议的细节
+- **score 1-2（unconvincing/weak）**：重写回应，考虑是否需要更换 strategy（A→B，承认不足）
+
+**第二轮（若有 score <= 2 的回应）**：
+
+```
+llm-review.chat-reply:
+  threadId: {previous thread}
+  message: |
+    We've revised the following responses:
+    {revised responses}
+    Please re-assess (score 1-5).
+```
+
+最多 2 轮 stress-test。处理 follow-up 追问并更新回应。
+
+### Step 6: 格式化输出 + 安全检查
+
+**6a. 格式化正式版 rebuttal-{slug}.txt**（plain text，适合 submission system）：
+
+```
+We thank the reviewers for their constructive feedback. We address each concern below.
+
+Reviewer 1:
+
+[Rv1-C1] {concern summary}
+{response}
+
+[Rv1-C2] {concern summary}
+{response}
+
+Reviewer 2:
+...
+
+Summary of Revisions:
+- {bulleted list of planned changes}
+
+Additional Experiments (if applicable):
+- {new experiments committed to, with timeline}
+```
+
+**6b. 格式化富文本版 rebuttal-{slug}.md**：
+
+```markdown
+# Rebuttal Analysis: {paper title}
+
+## Coverage Summary
+| Concern ID | Type | Severity | Entity | Evidence Status | Review LLM Score | Strategy |
+|------------|------|----------|--------|-----------------|------------------|----------|
+| Rv1-C1 | method | critical | [[method-slug]] | sufficient | 4/5 | A |
+| Rv1-C2 | missing | major | [[idea-slug]] | insufficient | 3/5 | B |
+
+## Responses
+### Reviewer 1
+**[Rv1-C1]** ...
+**[Rv1-C2]** ...
+
+## Evidence Gap Analysis
+| Entity | Status / Novelty | Gap | Needed |
+|--------|------------------|-----|--------|
+| [[idea-slug]] | proposed / novelty 2 | No ablation on dataset X | Run ablation experiment |
+
+## Action Items
+
+### Paper Edits
+| Section | Change | Reason |
+|---------|--------|--------|
+| Section 3.2 | Clarify notation | Rv1-C3 clarity concern |
+
+### Wiki Updates
+| Page | Update | Reason |
+|------|--------|--------|
+| ideas/{slug} | Append concern to `## Risks` | Rv2-C1 evidence gap |
+
+### Suggested Experiments
+| Experiment | Linked Idea | Suggested by |
+|-----------|-------------|--------------|
+| ablation-dataset-x | [[idea-slug]] | Rv1-C2 |
+
+→ Run `/exp-design ablation-dataset-x` to design follow-up
+
+## Review LLM Stress-Test Summary
+- Average score: {N}/5
+- Scores 4-5: {N}/{total}
+- Scores 1-3: {N}/{total} (all revised)
+
+## Safety Checklist
+- [x] No fabrication: all cited data exists in wiki/experiments
+- [x] No overpromise: all committed experiments are specific and feasible
+- [x] Full coverage: {N}/{N} concerns addressed (no omissions)
+- [x] Invalidated/inconclusive ideas not presented as supported
+```
+
+**6c. 最终安全检查**：
+- **Full coverage**：确认每个 concern 都有回应（无遗漏）
+- **No fabrication**：每个引用的数据点在 wiki/experiments/ 中有记录（可追溯）
+- **No overpromise**：补充实验的承诺是具体可行的
+- **Honesty on weak ideas**：若 linked idea 的 `novelty_score <= 2` 或其 linked experiments 结果不确定，不得假装 evidence 充分
+
+**6d. 更新 wiki**：
+- 对存在 evidence gap 的 idea：在 `wiki/ideas/{slug}.md` 的 `## Risks`（或 `## Lessons learned`）追加 reviewer 指出的 gap
+- 对覆盖薄弱的 method：在 `wiki/methods/{slug}.md` 的 `## Limitations` 追加 concern
+- 追加日志：
+  ```bash
+  python3 tools/research_wiki.py log wiki/ \
+    "rebuttal | {N} concerns addressed | {M} evidence gaps | stress-test avg: {score}/5"
+  ```
+
+## Constraints
+
+- **No fabrication**：绝不编造实验数据或 result。每个引用的数字必须可追溯到 wiki/experiments/，标注来源
+- **No overpromise**：只承诺具体可执行的补充实验。用 "we will run ablation on X with setup Y" 而非 "we will investigate"
+- **Full coverage**：每个 reviewer concern (Rvx-Cy) 必须有回应，不得遗漏。coverage 不足时阻止输出
+- **Evidence 追溯**：每条回应引用的 evidence 必须可追溯到 wiki 页面，标注来源 slug
+- **不静默翻转 linked idea 的 status**：rebuttal 只在 idea 的 `## Risks` / `## Lessons learned` 或 method 的 `## Limitations` 追加 concern；status 转换由 `/exp-eval` 负责
+- **Review LLM 独立性**：stress-test 时遵循 cross-model-review.md，不向 Review LLM 透露回应策略
+- **Concern ID 格式**：严格使用 Rvx-Cy 格式（Rv1-C1, Rv1-C2, Rv2-C1），确保可追溯
+- **具体承诺**：所有修改承诺和实验计划必须具体（specific Section、具体 dataset、明确 metric）
+- **输出到 wiki/outputs/**：rebuttal 文件统一存放在 wiki/outputs/ 目录
+
+## Error Handling
+
+- **审稿文件找不到**：报错，列出 raw/reviews/ 下可用文件
+- **审稿格式无法解析**：降级为纯文本处理，由 LLM 提取 concerns，在报告中标注
+- **concern 映射不到 idea 或 method（unmapped）**：标注 "unmapped"，仍然回应（基于论文内容而非 wiki 实体）
+- **Review LLM stress-test 不可用**：跳过 Step 5，在报告中标注 "stress-test skipped: Review LLM unavailable"
+- **evidence 严重不足**：若 >50% concerns 的 evidence 为 insufficient，警告用户并建议先补充实验
+- **wiki 为空**：警告 wiki 知识库为空，建议先运行 /ingest 填充 ideas、methods 与 experiments
+- **所有回应被 Review LLM 评为 1-2 分**：终止输出，报告需要重新分析，建议先补充实验
+
+## Dependencies
+
+### Tools（via Bash）
+- `python3 tools/research_wiki.py slug "{title}"` — 生成 rebuttal slug
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+
+### MCP Servers
+- `llm-review.chat` — Step 5 stress-test 首轮
+- `llm-review.chat-reply` — Step 5 stress-test 后续轮
+
+### Qoder Native
+- `Read` — 读取审稿意见、wiki 页面、shared references
+- `Write` — 写入 rebuttal-{slug}.md、rebuttal-{slug}.txt
+- `Glob` — 查找 ideas、methods、experiments
+- `Grep` — 在 wiki 中搜索 concern 关键词
+
+### Shared References
+- `.qoder/skills/shared-references/cross-model-review.md` — Review LLM stress-test 独立性原则
+
+### Suggested follow-up skills
+- `/exp-design` — 为 evidence 不足的 concerns 设计补充实验
+- `/paper-draft` — 准备修订版论文（基于 Paper Edits 清单）

--- a/.qoder/skills/refine/SKILL.md
+++ b/.qoder/skills/refine/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: refine
+description: 通用多轮迭代改进：对任意研究制品反复调用 /review → 解析反馈 → 修复 → 更新 wiki，直到达标
+---
+
+# /refine
+
+> **用法**：`<artifact-slug-or-path> [--max-rounds N] [--target-score N] [--difficulty standard|hard|adversarial] [--focus method|evidence|writing|completeness]`
+
+
+> 通用多轮迭代改进循环，适用于任何研究制品（idea、proposal、experiment plan、paper draft）。
+> 每轮调用 /review 获取结构化反馈 → 解析 actionable items → Claude 修复制品 → 更新 wiki 实体 →
+> 重新 /review，直到评分达到目标分数或达到最大轮次。
+> 输出改进历史和最终 review 评分。
+
+## Inputs
+
+- `artifact`：要改进的制品，以下之一：
+  - wiki 页面的 slug（从 ideas/experiments/methods/outputs/ 中查找）
+  - 文件路径（如 `wiki/outputs/paper-draft-v1.md`）
+- `--max-rounds N`（可选，默认 4）：最大迭代轮次
+- `--target-score N`（可选，默认 8）：目标 review 评分（1-10），达到后停止
+- `--difficulty`（可选，默认 `hard`）：传递给 /review 的难度级别
+- `--focus`（可选）：传递给 /review 的审查焦点
+
+## Outputs
+
+- **改进后的 artifact**（wiki 页面或文件，原地更新）
+- **wiki 实体更新**（若 review 发现 idea/method 需加强或 gap 被识别）
+- **REFINE_REPORT**（输出到终端）：
+  - 每轮的评分变化轨迹
+  - 累计修复的 issues 列表
+  - 最终 review 评分和 verdict
+  - 未解决的 issues（若有）
+
+## Wiki Interaction
+
+### Reads
+- `wiki/ideas/*.md` — 若 artifact 是 idea
+- `wiki/experiments/*.md` — 若 artifact 是 experiment plan
+- `wiki/methods/*.md` — review 引用的 methods
+- `wiki/papers/*.md` — review 引用的 papers
+- `wiki/outputs/*.md` — 若 artifact 是 paper draft 或 output
+- `wiki/graph/context_brief.md` — 传递给 /review 的全局上下文
+- `wiki/graph/open_questions.md` — 检查是否有新 gap 需要记录
+
+### Writes
+- `wiki/ideas/{slug}.md` — 若 artifact 是 idea，修复 review 发现的问题
+- `wiki/experiments/{slug}.md` — 若 artifact 是 experiment plan
+- `wiki/methods/{slug}.md` — 若 review 指出 method 缺口（如 source_papers 缺失、Procedure 偏弱）
+- `wiki/outputs/*.md` — 若 artifact 是 paper draft 或 output
+- `wiki/graph/edges.jsonl` — 若修复过程中发现新关系
+- `wiki/graph/context_brief.md` — 每轮结束后重建（若 wiki 有变更）
+- `wiki/graph/open_questions.md` — 每轮结束后重建（若 wiki 有变更）
+- `wiki/log.md` — 追加操作日志
+
+### Graph edges created
+- 视修复内容而定，可能添加：`supports`、`addresses_gap`、`inspired_by` 等
+
+## Workflow
+
+**前置**：确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）。
+
+### Step 1: 初始化
+
+1. **定位 artifact**：
+   - 若为 slug：按顺序在 `wiki/ideas/`、`wiki/experiments/`、`wiki/methods/`、`wiki/outputs/`、`wiki/papers/` 中查找 `{slug}.md`
+   - 若为文件路径：直接读取
+   - 记录 artifact 类型和路径
+2. **读取当前内容**：加载 artifact 完整文本
+3. **初始化追踪变量**：
+   - `round = 0`
+   - `score_history = []`
+   - `fixed_issues = []`
+   - `unresolved_issues = []`
+   - `wiki_changes = []`
+
+### Step 2: 迭代循环
+
+重复以下步骤，直到满足终止条件：
+
+**Round N（N = 1, 2, ..., max-rounds）：**
+
+#### 2a. 调用 /review
+
+```
+Skill: review
+Args: "<artifact-path-or-content>" --difficulty {difficulty} --focus {focus}
+```
+
+解析 review 输出，提取：
+- `score`（1-10）
+- `verdict`（ready / needs-work / major-revision / rethink）
+- `weaknesses`（按 severity: critical / major / minor）
+- `actionable_items`（排序列表）
+- `wiki_entity_mapping`（ideas/methods needing strengthening, gaps identified）
+
+#### 2b. 检查终止条件
+
+- **达到目标分数**：`score >= target-score` → 终止，输出最终报告
+- **连续两轮评分无提升**：`score_history[-1] == score_history[-2]` → 终止（已收敛）
+- **达到最大轮次**：`round >= max-rounds` → 终止
+- **verdict == ready**：→ 终止
+- **verdict == rethink 且 round == 1**：→ 终止并建议重新设计（不在 rethink 级别的制品上反复迭代）
+
+#### 2c. 分类 actionable items 并修复
+
+对每个 actionable item 进行分类和处理：
+
+**Category A — 方法/内容问题（Claude 直接修复）：**
+- 方法描述不够具体 → 补充细节
+- 缺少对比分析 → 添加与 baseline 的对比
+- 论证逻辑不完整 → 补充推理步骤
+- 表达不清晰 → 重写相关段落
+- → 直接编辑 artifact 文件
+
+**Category B — wiki 知识缺口（建议外部操作）：**
+- idea 的 novelty 论证薄弱 → 建议重新运行 `/novelty`
+- method 缺少 source_papers → 标记给 `/ingest` 复查
+- 缺少相关工作引用 → 建议运行 `/ingest` 补充论文
+- 需要实验验证 → 建议运行 `/exp-run`
+- → 记录到 `unresolved_issues`，在报告中列出建议操作
+
+**Category C — idea / method 更新（Claude 修复 wiki）：**
+- review 指出 idea 的 `origin_gaps` 缺少某个 concept 链接 → 补上链接并写入反向 `linked_ideas`
+- review 发现 method 缺少 parent/child 关系 → 修补 method 页面
+- review 发现新的 gap → 记录到 gap_map（通过 rebuild）
+- review 发现新的关系 → 添加 graph edge
+- → 更新相关 wiki 页面，记录到 `wiki_changes`
+
+**Category D — 超出范围（跳过）：**
+- 需要新实验数据 → 无法在 refine 中解决
+- 需要领域专家判断 → 标记为 unresolved
+- → 记录到 `unresolved_issues`
+
+#### 2d. 更新追踪
+
+- `score_history.append(score)`
+- `fixed_issues.extend(category_A_items + category_C_items)`
+- `unresolved_issues.extend(category_B_items + category_D_items)`
+- `wiki_changes.extend(category_C_changes)`
+- `round += 1`
+
+#### 2e. 重建派生数据（若 wiki 有变更）
+
+若本轮有 wiki 变更（Category C）：
+```bash
+python3 tools/research_wiki.py rebuild-context-brief wiki/
+python3 tools/research_wiki.py rebuild-open-questions wiki/
+```
+
+### Step 3: 最终报告
+
+迭代结束后，生成 REFINE_REPORT：
+
+```markdown
+# Refine Loop Report: {artifact title}
+
+## Summary
+- **Artifact**: {slug or path}
+- **Rounds**: {N} / {max-rounds}
+- **Score trajectory**: {score_history, e.g., 5 → 6 → 7 → 8}
+- **Final score**: {final_score}/10
+- **Final verdict**: {verdict}
+- **Termination reason**: {target reached / converged / max rounds / rethink}
+
+## Issues Fixed ({count})
+
+| Round | Issue | Severity | Fix applied |
+|-------|-------|----------|-------------|
+| 1 | 方法描述不够具体 | major | 补充了具体算法步骤 |
+| 1 | idea novelty 论证薄弱 | major | 已标记 [[idea-slug]] 重跑 `/novelty` |
+| 2 | 缺少 ablation 设计 | minor | 添加了 ablation 计划 |
+
+## Wiki Changes Made
+
+| Page | Change | Round |
+|------|--------|-------|
+| `wiki/methods/{slug}.md` | 补全缺失的 source_papers 链接 | 1 |
+| `wiki/graph/edges.jsonl` | +1 edge (addresses_gap) | 2 |
+
+## Unresolved Issues ({count})
+
+| Issue | Severity | Suggested action |
+|-------|----------|------------------|
+| 缺少实验验证 | critical | Run `/exp-design {slug}` |
+| 缺少对比论文 | major | Run `/ingest` for {paper-title} |
+
+## Next Steps
+- {based on verdict and unresolved issues}
+```
+
+追加日志：
+```bash
+python3 tools/research_wiki.py log wiki/ \
+  "refine | {artifact-slug} | {N} rounds | score {initial}→{final} | verdict: {verdict}"
+```
+
+## Constraints
+
+- **每轮必须有实质进展**：若连续两轮 score 无变化，必须终止（防止无限循环）
+- **rethink 不反复迭代**：若首轮 verdict == rethink，直接终止并建议重新设计
+- **wiki 修改限于 review 建议**：refine 只修改 review 明确建议修改的 wiki 实体，不主动扩大修改范围
+- **unresolved issues 必须列出**：不能静默跳过无法在 loop 中解决的问题
+- **保留改进历史**：score_history 和 fixed_issues 完整记录，不丢弃中间状态
+- **review 参数透传**：--difficulty 和 --focus 透传给 /review，保持审查标准一致
+- **artifact 原地更新**：修复直接修改原始文件，不创建副本
+
+## Error Handling
+
+- **artifact 找不到**：提示用户检查 slug 或路径，列出可能的候选页面
+- **/review 调用失败**：重试一次，若仍失败则终止 loop，输出已完成的改进历史
+- **wiki 写入失败**：记录错误，继续下一轮（wiki 变更降级为 unresolved）
+- **首轮 score 已 >= target-score**：直接终止，输出报告（无需改进）
+- **所有 issues 都是 Category B/D**：无法在 loop 中修复，终止并输出 unresolved issues 列表
+
+## Dependencies
+
+### Tools（via Bash）
+- `python3 tools/research_wiki.py rebuild-context-brief wiki/` — 重建 query_pack
+- `python3 tools/research_wiki.py rebuild-open-questions wiki/` — 重建 gap_map
+- `python3 tools/research_wiki.py add-edge wiki/ ...` — 添加 graph edge（若需要）
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+
+### Skills（via Skill tool）
+- `/review` — 每轮审查（核心依赖）
+
+### Qoder Native
+- `Read` — 读取 artifact 和 wiki 页面
+- `Edit` — 修复 artifact 内容
+- `Glob` — 查找 artifact 和相关 wiki 页面
+
+### Shared References
+- `.qoder/skills/shared-references/cross-model-review.md` — 通过 /review 间接依赖

--- a/.qoder/skills/research/SKILL.md
+++ b/.qoder/skills/research/SKILL.md
@@ -1,0 +1,543 @@
+---
+name: research
+description: 端到端研究编排器：idea 发现 → 实验设计 → 执行 → 判决 → 论文撰写，带人工门控和状态恢复
+---
+
+# /research
+
+> **用法**：`<research-direction-or-brief> [--auto] [--start-from stage1|stage2|stage3|stage3-collect|stage3-check|stage4|stage5] [--skip-paper] [--venue ICLR|NeurIPS|ICML|ACL|CVPR]`
+
+
+> 端到端研究编排器，将所有 skill 组合为完整的研究流程。
+> Stage 0 (Bootstrap) + 5 个 Stage + 2 个 Human Gate，覆盖从空 wiki 到论文提交的全流程。
+> **零摩擦入口**：wiki 处于冷启动时，`/research` 在 Stage 0 暂停，需显式运行 `/init` / `$init` 进行 Bootstrap 后再继续。
+> 每个 Gate 和 Stage 保存进度到 `wiki/outputs/pipeline-progress.md`，支持跨 session 恢复。
+>
+> **Stage 3 为非阻塞设计**：实验部署后立即返回（`--auto` 模式自动设置 CronCreate 每 30 分钟监控），
+> 实验全部完成后自动进入 Stage 4。可随时用 `/exp-status` 查看进度。
+>
+> `--auto` 模式跳过人工确认（自动选 top-1 idea），`--skip-paper` 只做研究不写论文。
+
+## Inputs
+
+- `direction`：研究方向描述或 `RESEARCH_BRIEF.md` 文件路径
+  - 文本形式：一句话描述研究方向（如 "sparse LoRA for edge devices"）
+  - 文件形式：结构化的 RESEARCH_BRIEF.md（含 domain、constraints、target venues）
+- `--auto`（可选）：全自动模式，Gate 1 自动选 top-1 idea，Gate 2 自动继续，Stage 3b 自动 CronCreate
+- `--start-from <stage>`（可选）：从指定 stage 恢复执行
+  - 有效值：`stage1`、`stage2`、`stage3`、`stage3-collect`、`stage3-check`、`stage4`、`stage5`
+  - `stage3-collect`：跳过 deploy，直接进入 Stage 3c（收集已部署实验的结果）
+  - `stage3-check`：只检查实验状态（等同于 `/exp-status --pipeline {slug}`），不继续执行
+  - 需要 `wiki/outputs/pipeline-progress.md` 存在
+- `--skip-paper`（可选）：只做研究（Stage 1-4），不写论文（跳过 Stage 5），但仍执行 /exp-eval（Stage 4）
+- `--venue`（可选）：目标会议（ICLR / NeurIPS / ICML / ACL / CVPR），传递给 /paper-plan
+
+## Outputs
+
+- **wiki 更新**（通过子 skill 委托）：ideas/、experiments/、methods/、outputs/、graph/
+- **wiki/outputs/pipeline-progress.md** — 流水线进度快照（用于恢复）
+- **wiki/outputs/PIPELINE_REPORT.md** — 完整流水线报告
+- **paper/ 目录**（若未 --skip-paper）— 可提交的论文
+- **wiki/log.md** — 每个 stage 追加日志
+
+## Wiki Interaction
+
+### Reads
+- `wiki/graph/context_brief.md` — 全局上下文（传递给子 skills）
+- `wiki/graph/open_questions.md` — 知识缺口（传递给 /ideate）
+- `wiki/ideas/*.md` — Gate 1 选择、Stage 4 判决、Stage 5 论文规划
+- `wiki/experiments/*.md` — Stage 3-4 状态检查
+- `wiki/methods/*.md` — Stage 5 论文写作上下文
+- `wiki/outputs/pipeline-progress.md` — --start-from 恢复状态
+- `wiki/papers/*.md` — Stage 5 论文写作上下文
+
+### Writes
+- `wiki/outputs/pipeline-progress.md` — 每个 Gate 保存进度（委托写入 wiki 实体的操作由子 skill 完成）
+- `wiki/outputs/PIPELINE_REPORT.md` — 最终报告
+- `wiki/log.md` — 追加日志
+- 其他 wiki 实体写入均通过子 skill 委托（不直接写入 ideas/experiments/methods/）
+
+### Graph edges created
+- 无直接创建 — 所有 graph edges 通过子 skill 代理（/ideate、/exp-design、/exp-eval 各自创建 edges）
+
+## Workflow
+
+**前置**：
+1. 确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）
+2. 若 `--start-from` 指定，读取 `wiki/outputs/pipeline-progress.md` 恢复状态
+
+### Step 0: 初始化
+
+1. **解析输入**：
+   - 若为文件路径：读取 RESEARCH_BRIEF.md，提取 direction、domain、constraints、target_venue
+   - 若为文本：作为 direction，domain/constraints 留空
+   - 生成 slug：`python3 tools/research_wiki.py slug "{direction}"`
+
+2. **自动恢复检测**（无 `--start-from` 时）：
+   - 若 `wiki/outputs/pipeline-progress.md` 存在 且 `status == running`：
+     - 读取 direction、current_stage、started、slug
+     - 使用 AskUserQuestion 提示用户选择：
+       ```
+       检测到未完成的 pipeline:
+       方向: {direction}
+       当前阶段: {current_stage}
+       开始时间: {started}
+
+       [1] 从 {current_stage} 继续（推荐）
+       [2] 开始新的 pipeline（将覆盖旧进度）
+       [3] 先查看实验状态（/exp-status --pipeline {slug}）
+       ```
+     - 若 --auto 或用户选 [1]：自动设 `--start-from {current_stage}`，继续执行
+     - 若用户选 [2]：继续创建新 pipeline（覆盖旧进度文件）
+     - 若用户选 [3]：调用 `/exp-status --pipeline {slug}` 后退出，不继续执行
+
+3. **检查恢复**（有 `--start-from` 时）：
+   - 若 `wiki/outputs/pipeline-progress.md` 存在：
+     - 读取进度文件，恢复 idea_slug、experiment_slugs、stage3a_deployed、linked_idea_slugs、monitoring_cron_id
+     - 跳转到指定 stage
+   - 若进度文件不存在：报错退出，提示先运行完整流水线
+   - **`--start-from stage3-check`**：等同于调用 `/exp-status --pipeline {slug}`，展示状态后退出
+   - **`--start-from stage3-collect`**：跳过 Stage 3a+3b，直接进入 Stage 3c（收集已部署实验）
+
+3. **创建进度文件** `wiki/outputs/pipeline-progress.md`：
+   ```yaml
+   ---
+   slug: "{pipeline-slug}"
+   direction: "{research direction}"
+   status: running
+   current_stage: stage1
+   started: YYYY-MM-DD
+   mode: auto|interactive
+   skip_paper: true|false
+   venue: "{venue}"
+   idea_slug: ""
+   experiment_slugs: []
+   stage3a_deployed: []
+   linked_idea_slugs: []
+   iteration_count: 0
+   ---
+   ## Stage Log
+   - Stage 0 (Bootstrap): skipped
+   - Stage 1: pending
+   - Gate 1: pending
+   - Stage 2: pending
+   - Stage 3a (Deploy): pending
+   - Stage 3b (Await): pending
+   - Stage 3c (Collect): pending
+   - Stage 4: pending
+   - Gate 2: pending
+   - Stage 5: pending
+   ```
+
+4. **追加日志**：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ \
+     "research | started | direction: {direction} | mode: {auto|interactive}"
+   ```
+
+5. **Snapshot wiki 状态**（用于 Step Final 的 Growth Report）：
+   ```bash
+   python3 tools/research_wiki.py maturity wiki/ --json
+   ```
+   保存返回的 JSON 到内存变量 `maturity_before`。
+
+### Stage 0: Bootstrap（冷启动 handoff 路径）
+
+**触发条件**：运行 `python3 tools/research_wiki.py maturity wiki/ --json`，若 `level == "cold"` 且 `papers < 3`：触发 `/init` / `$init` handoff 流程；否则跳过，直接进入 Stage 1。
+
+1. **初始化 wiki 结构**（若未初始化）：
+   ```bash
+   python3 tools/research_wiki.py init wiki/
+   ```
+
+2. **交给 `/init` / `$init`**：
+   ```
+   Skill: init
+   Args: "{direction}"
+   ```
+   `/research` 不应重复实现 bootstrap 的搜索 / 排名 / auto-ingest 逻辑。
+
+3. **等待 `/init` 完成**（或在交互流程中征得用户确认）后进入 Stage 1。
+
+5. **重建派生数据**：
+   ```bash
+   python3 tools/research_wiki.py rebuild-context-brief wiki/
+   python3 tools/research_wiki.py rebuild-open-questions wiki/
+   ```
+
+6. **Bootstrap 报告**（`/init` 完成后）：
+   ```bash
+   python3 tools/research_wiki.py maturity wiki/ --json
+   ```
+   输出到终端：
+   ```
+   Bootstrap 完成：
+   Papers: {N} | Concepts: {K} | Methods: {Mt} | Edges: {E}
+   Maturity: cold → {new_level}
+   继续进入 Stage 1: Idea Discovery...
+   ```
+
+7. **日志 + 进度更新**：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ \
+     "research | stage0-bootstrap | init-handoff-complete | maturity: {level}"
+   python3 tools/research_wiki.py set-meta \
+     wiki/outputs/pipeline-progress.md current_stage stage1
+   ```
+
+### Stage 1: Idea Discovery
+
+调用 `/ideate`：
+
+```
+Skill: ideate
+Args: "{direction}" --auto
+```
+
+**完成后**：
+1. 读取生成的 ideas，按 pilot预实验结果和priority 排序
+2. 更新 pipeline-progress：Stage 1 → completed，记录生成的 idea slugs
+3. 追加日志
+
+### Gate 1: 选择 Idea
+
+**若 `--auto` 模式**：
+- 自动选择 priority 最高（排名 top-1）的 idea
+- 在终端输出选择结果，不等待确认
+
+**若交互模式**：
+- 列出所有生成的 ideas（slug、title、priority、novelty score\pilot result）
+- 使用 AskUserQuestion 提示用户选择一个 idea（或输入 stop 停止）
+- 若用户选择 stop：保存进度，终止流水线
+
+**保存进度**：
+- 更新 pipeline-progress：Gate 1 → passed，记录 idea_slug
+- 更新选中 idea 的 status: proposed → in_progress
+
+### Stage 2: Experiment Design
+
+调用 `/exp-design`：
+
+```
+Skill: exp-design
+Args: "{idea_slug}"
+```
+
+**完成后**：
+1. 读取生成的 experiment slugs（从 wiki/experiments/ 中 linked_idea == idea_slug 的页面,以及根据exp-slug在experiments/designs/{slug}-master.md获取实验块详细spec）
+2. 更新 pipeline-progress：Stage 2 → completed，记录 experiment_slugs
+
+### Stage 3: Experiment Execution（非阻塞）
+
+Stage 3 分为三个子阶段，允许实验在后台异步运行，不阻塞 session。
+
+#### Stage 3a: Deploy All
+
+按 run order（design中"ablation""sensitivity""main""generalization""analysis"）依次调用 `/exp-run {experiment_slug}`（默认 deploy 模式，Phase 1+2）：
+
+```
+Skill: exp-run
+Args: "{experiment_slug}"
+```
+
+（**默认 deploy 模式**，Phase 1+2，部署后立即返回，不等待实验完成）
+
+**每次部署后**：
+- 记录部署结果（成功/失败）到内存
+- 若 deploy 失败：记录到 pipeline-progress 中，在报告中标注警告（基线 deploy 失败时加强警告），但**继续部署其余实验**（不中止）
+
+**全部部署完成后**，更新 pipeline-progress.md：
+```bash
+python3 tools/research_wiki.py set-meta \
+  wiki/outputs/pipeline-progress.md current_stage stage3-await
+python3 tools/research_wiki.py set-meta \
+  wiki/outputs/pipeline-progress.md stage3a_deployed \
+  "[{experiment_slug_1}, {experiment_slug_2}, ...]"
+```
+追加日志：
+```bash
+python3 tools/research_wiki.py log wiki/ \
+  "research | stage3a | deployed {N} experiments | pipeline: {slug}"
+```
+
+#### Stage 3b: Await（非阻塞）
+
+实验部署完毕后，计算 ETA、保存进度并结束当前 session。
+
+1. 更新 pipeline-progress：
+   ```bash
+   python3 tools/research_wiki.py set-meta \
+     wiki/outputs/pipeline-progress.md current_stage stage3-await
+   ```
+2. **计算各实验预计完成时间**：
+   对每个已部署实验，读取 frontmatter 的 `started` 和 `estimated_hours` 字段：
+   - `eta = started + estimated_hours`
+   - `recommended_return = max(所有 eta) + 30 分钟缓冲，向上取整到最近整点或半点`
+3. 追加日志：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ \
+     "research | stage3b | awaiting {N} experiments | latest eta: {YYYY-MM-DD HH:MM} | pipeline: {slug}"
+   ```
+4. 输出操作指引后**结束当前 session**：
+   ```
+   ✅ Stage 3a 完成：{N} 个实验已全部部署：
+
+   实验                          环境            预计时长   预计完成
+   ────────────────────────────  ────────────    ────────   ──────────────
+   exp-foo-baseline              local           ~8h        明天 09:30
+   exp-foo-validation            remote (gpu1)   ~6h        今天 23:00
+   exp-foo-ablation              local           ~4h        今天 21:00
+
+   ⏳ 最晚完成：明天 09:30（exp-foo-baseline）
+   建议 明天 10:00 之后运行：
+
+     /exp-status                              ← 确认所有实验完成
+     /research --start-from stage3-collect    ← 收集结果并继续
+
+   进度已保存至 wiki/outputs/pipeline-progress.md，当前 session 可以关闭。
+   ```
+
+#### Stage 3c: Collect（实验完成后触发）
+
+**触发条件**：用户手动运行 `/research --start-from stage3-collect`
+
+对每个已部署的 experiment（从 `stage3a_deployed` 列表读取）：
+```
+Skill: exp-run
+Args: "{experiment_slug} --collect"
+```
+
+（collect 模式，Phase 3+4：检查完成状态并收集结果）
+
+**每次 collect 后的决策**：
+- 若 outcome == failed 且为 baseline experiment → **终止流水线**，报告基线无法复现
+- 若 outcome == failed 且为 validation experiment → 记录失败，继续收集其余实验，进入 Stage 4 评估
+- 若 outcome == inconclusive → 记录，继续
+
+**全部 collect 完成后**：
+- 更新 pipeline-progress：Stage 3 → completed
+  ```bash
+  python3 tools/research_wiki.py set-meta \
+    wiki/outputs/pipeline-progress.md current_stage stage4
+  ```
+- 追加日志：
+  ```bash
+  python3 tools/research_wiki.py log wiki/ \
+    "research | stage3c | collected {N} experiments | pipeline: {slug}"
+  ```
+
+- 更新linked idea 的 status: in_progress-> tested
+
+- 继续进入 Stage 4
+
+### Stage 4: Verdict & Iteration
+
+对每个 completed experiment 调用 `/exp-eval`：
+
+```
+Skill: exp-eval
+Args: "{experiment_slug}" --auto
+```
+
+**评估关联 idea 是否充分**：
+1. 读取主要 linked idea（及任何辅助 idea）的最新状态
+2. 判断是否需要迭代：
+   - **充分**（主要 linked idea 已切换为 `validated`，或 ≥1 个支持性实验 `outcome=succeeded`）→ 进入 Gate 2
+   - **不足**（idea 仍为 `proposed`或`in_progress`或`tested` 且所有关联实验都是 `failed`/`inconclusive`，或 idea 为 `failed`）→ 进入迭代
+
+**迭代路径**（不足时，最多 1 次重试）：
+1. 分析失败原因
+2. 对相应的需要改进的实验块调用 `/refine` 改进 experiment plan：
+   ```
+   Skill: refine
+   Args: "{experiment_plan_slug}" --max-rounds 2 --focus evidence
+   ```
+3. 对新增/修改的 experiments 重新执行 Stage 3 → Stage 4
+4. 最多迭代 2 轮（防止无限循环），每个 stage 最多 1 次 auto retry
+
+**完成后**：
+- 更新 pipeline-progress：Stage 4 → completed，记录 linked_idea_slugs
+
+### Gate 2: 确认 Paper Ready
+
+**若 `--skip-paper`**：跳过 Gate 2 和 Stage 5，直接生成最终报告
+
+**若 `--auto` 模式**：自动继续，进入 Stage 5
+
+**若交互模式**：
+- 展示 idea 状态摘要：
+  ```
+  Idea: {slug} | Status: {status} | Novelty: {novelty_score}
+  Linked experiments: {count} ({succeeded}/{inconclusive}/{failed})
+  ```
+- 使用 AskUserQuestion 提示用户确认：ready for paper / need more experiments / stop here
+- 若 "need more experiments"：返回 Stage 2 重新规划
+- 若 "stop here"：保存进度，生成最终报告（不含论文）
+
+**保存进度**：
+- 更新 pipeline-progress：Gate 2 → passed
+
+### Stage 5: Paper Writing
+
+依次调用子 skills：/paper-plan → /paper-draft → /refine → /paper-compile
+
+**5a. 调用 /paper-plan**：
+```
+Skill: paper-plan
+Args: "{linked_idea_slugs}" --venue {venue}
+```
+（将 Stage 4 收集到的 validated idea slug(s) 传递给 /paper-plan）
+
+**5b. 调用 /paper-draft**：
+```
+Skill: paper-draft
+Args: "wiki/outputs/PAPER_PLAN.md" --review
+```
+
+**5c. 调用 /refine on Paper**：
+```
+Skill: refine
+Args: "paper/main.tex" --max-rounds 3 --target-score 8 --focus writing
+```
+
+**5d. 调用 /paper-compile**：
+```
+Skill: paper-compile
+Args: "paper/"
+```
+
+**完成后**：
+- 更新 pipeline-progress：Stage 5 → completed, status: completed
+
+### Step Final: Pipeline Report
+
+生成 `wiki/outputs/PIPELINE_REPORT.md`：
+
+```markdown
+# Research Pipeline Report
+
+## Stage Summary
+| Stage | Status | Duration |
+|-------|--------|----------|
+| Stage 0: Bootstrap | completed/skipped | ... |
+| Stage 1: Idea Discovery | completed | ... |
+| Gate 1: Idea Selection | passed | ... |
+| Stage 2: Experiment Design | completed | ... |
+| Stage 3a: Deploy Experiments | completed | ... |
+| Stage 3b: Await (async) | completed | ... |
+| Stage 3c: Collect Results | completed | ... |
+| Stage 4: Verdict | completed | ... |
+| Gate 2: Paper Ready | passed | ... |
+| Stage 5: Paper Writing | completed | ... |
+
+## Selected Idea
+- **Idea**: [[{idea_slug}]] — {idea title}
+- **Priority**: {N}
+- **Novelty score**: {score}
+
+## Idea Trail
+| Idea | Initial Status | Final Status | Novelty (start → end) |
+|------|----------------|--------------|------------------------|
+| [[{slug}]] | proposed | validated | 3 → 4 |
+
+## Experiment Results
+| Experiment | Outcome | Key Result |
+|-----------|---------|------------|
+| [[{slug}]] | succeeded | {result} |
+
+## Iteration History
+- Total iterations: {N}
+- Reason for iteration: {idea evidence insufficient / ...}
+
+## Deliverables
+- Ideas: +{N} created, {N} validated
+- Experiments: +{N} created, {N} completed
+- Methods: +{N} created/updated
+- Graph edges: +{N}
+- Paper: paper/main.pdf (if applicable)
+
+## Wiki Growth (pipeline total)
+| Metric | Before | After | Delta |
+|--------|--------|-------|-------|
+| Papers | {N} | {N} | +{N} |
+| Methods | {N} | {N} | +{N} |
+| Ideas | {N} | {N} | +{N} |
+| Experiments | {N} | {N} | +{N} |
+| Edges | {N} | {N} | +{N} |
+| Maturity | {level} | {level} | {status} |
+| Coverage | {%} | {%} | +{%} |
+（数据来自 Step 0 step 5 的 `maturity_before` 与此处重新调用 `maturity --json` 的对比。仅展示 delta != 0 的行。）
+
+## Next Steps
+- {recommendations based on remaining gaps or unresolved issues}
+```
+
+追加日志：
+```bash
+python3 tools/research_wiki.py log wiki/ \
+  "research | completed | idea: {slug} | linked ideas: {N} updated | paper: {yes/no}"
+```
+
+更新 pipeline-progress：status: completed
+
+## Constraints
+
+- **编排器不直接修改 wiki 实体，不嵌入子 skill 逻辑**：所有 wiki 修改通过子 skill 委托完成，pipeline 只负责协调，通过 Skill tool 调用
+- **Gate 和 Stage 必须保存进度**：每个 Gate 和 Stage 完成/进入等待时必须保存 pipeline-progress.md
+- **Stage 3a 部署失败不中止**：deploy 失败时记录警告继续部署，不提前终止（baseline collect 失败时才终止）
+- **baseline collect 失败终止**：Stage 3c collect 结果，baseline outcome == failed 时终止流水线
+- **Stage 3b 结束 session**：Stage 3b 完成后当前 session 结束，不继续等待实验
+- **最多 2 轮迭代**：Stage 4 迭代最多 2 轮，防止无限循环
+- **--auto 不跳过计算**：auto 模式跳过人工确认，但不跳过任何计算步骤
+- **--skip-paper 仍执行 Stage 4 /exp-eval**：即使不写论文，也要完成 idea/experiment 更新
+- **子 skill 参数透传**：将 domain、--venue 等参数正确传递给子 skill
+- **日志记录每个 Stage**：每个 Stage 完成后追加 log.md 审计日志
+- **不重复执行已完成 stage**：--start-from 跳过已完成的 stages
+- **进度文件在 wiki/outputs/pipeline-progress.md**：统一位置，便于发现和恢复
+- **自动恢复优先**：无 --start-from 且有未完成 pipeline 时，默认提示用户恢复而不是重新开始
+
+## Error Handling
+
+- **pipeline-progress 不存在但指定 --start-from**：报错，提示先运行完整流水线
+- **pipeline-progress 损坏或格式异常**：尝试从 wiki 当前状态推断进度（读取 ideas/experiments 状态），恢复到最近的 Gate
+- **子 skill 调用失败**：记录错误到 pipeline-progress，报告失败的 stage，建议 --start-from 恢复
+- **所有 ideas 生成失败**：终止流水线，建议用户调整 research direction
+- **所有实验 deploy 失败**：终止流水线（Stage 3a），生成失败报告，建议检查 GPU/SSH 配置
+- **Stage 3c baseline collect 失败**：终止流水线，报告基线无法复现，建议重新 /exp-design
+- **所有实验 collect 失败（其他非 baseline）**：进入 Stage 4 评估（以失败为证据）
+- **Gate 用户选择 stop**：保存进度到 pipeline-progress，生成部分报告
+- **RESEARCH_BRIEF.md 格式错误**：降级为纯文本 direction，忽略结构化字段
+- **wiki 为空（无 papers/concepts）**：先触发 Stage 0 handoff，要求执行 `/init` / `$init` 再进入 Stage 1
+- **迭代后 idea 证据仍不足**：在报告中标注 "idea evidence insufficient after max iterations"，由用户决定是否继续
+- **用户选择查看状态（自动恢复检测 [3]）**：调用 `/exp-status --pipeline {slug}` 后退出，不继续执行新流水线
+
+## Dependencies
+
+### Skills（via Skill tool）
+- `/init` — Stage 0 Bootstrap handoff
+- `/ideate` — Stage 1 idea 发现
+- `/exp-design` — Stage 2 实验设计
+- `/exp-run` — Stage 3a（deploy 模式）和 Stage 3c（--collect 模式）
+- `/exp-status` — 用户手动查看实验进度，`--auto-advance` 可在所有完成时自动触发 Stage 4
+- `/exp-eval` — Stage 4 判决
+- `/refine` — Stage 4 迭代 + Stage 5 论文改进
+- `/paper-plan` — Stage 5 论文规划
+- `/paper-draft` — Stage 5 论文撰写
+- `/paper-compile` — Stage 5 论文编译
+
+### Tools（via Bash）
+- `python3 tools/research_wiki.py slug "{title}"` — 生成 pipeline slug
+- `python3 tools/research_wiki.py set-meta <path> <field> <value>` — 更新 pipeline-progress 字段
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+- `python3 tools/research_wiki.py maturity wiki/ --json` — 检查 wiki 成熟度（Stage 0 触发条件 + Growth Report）
+- `python3 tools/research_wiki.py init wiki/` — 初始化 wiki 结构（Stage 0）
+
+### MCP Servers
+- 无直接 MCP 调用 — 所有 Review LLM 交互通过子 skill 间接使用
+
+### Qoder Native
+- `Read` — 读取 pipeline-progress、wiki 页面、RESEARCH_BRIEF
+- `Write` — 写入 pipeline-progress、PIPELINE_REPORT
+- `Glob` — 查找 experiments、ideas、methods
+- `Skill` — 调用子 skills（核心能力）
+- `AskUserQuestion` — Gate 和自动恢复检测的用户交互

--- a/.qoder/skills/reset/SKILL.md
+++ b/.qoder/skills/reset/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: reset
+description: 按 scope 重置 wiki 到干净 scaffold（wiki / raw / log / checkpoints / all）。适用于开发迭代或 setup 失败后的无痛重启。
+---
+
+# /reset
+
+> **用法**：`--scope wiki|raw|log|checkpoints|all`
+
+
+> 按 scope 重置 wiki 到干净 scaffold。设计目的是开发迭代和 setup 失败恢复 — 不是日常操作。
+
+## Trigger
+
+手动：`/reset --scope wiki` / `--scope raw` / `--scope log` / `--scope checkpoints` / `--scope all`。可用逗号组合多个 scope：`--scope wiki,log`。
+
+## Inputs
+
+- `--scope`（必填）：取值
+  - `wiki` — 删除 `wiki/<entity>/` 与 `wiki/outputs/` 下所有 `*.md`，同时删除 `wiki/index.md`、`wiki/log.md` 和 `wiki/graph/` 下的文件。保留 `.gitkeep` 和 `wiki/CLAUDE.md`。
+  - `raw` — 删除 `raw/papers/`、`raw/discovered/`、`raw/tmp/`、`raw/notes/`、`raw/web/` 下所有条目（保留 `.gitkeep`）。
+  - `log` — 重置 `wiki/log.md` 为空模板。
+  - `checkpoints` — 通过 `research_wiki.py checkpoint-clear` 清除批处理状态。
+  - `all` — 以上全部。
+
+## Outputs
+
+- 磁盘上清空 / 重置后的文件。
+- 控制台摘要：已删除文件数、已重置文件数。
+
+## Wiki Interaction
+
+### 读取
+- 所有 `wiki/<entity>/*.md`（用于枚举删除清单）。
+- `raw/<sub>/*`（用于枚举 raw 删除清单）。
+
+### 写入
+- 删除 `wiki/<entity>/*.md`（保留 `.gitkeep`）。
+- 重写 `wiki/index.md`、`wiki/graph/*`，可选地重写 `wiki/log.md`。
+- 删除 `raw/<sub>/*`（保留 `.gitkeep`）。
+
+## Workflow
+
+**前置条件**：当前目录包含 `wiki/`、`tools/`。`WIKI_ROOT=wiki/`。
+
+### Step 1: 构造删除计划（dry-run）
+
+```bash
+python3 tools/reset_wiki.py --scope <scope>
+```
+
+该命令打印 JSON 计划，列出将要删除或重置的全部文件，**不修改任何东西**。按 scope 分组展示给用户（wiki entity 目录、raw 子目录、log、checkpoints）。
+
+### Step 2: 与用户确认
+
+打印计划摘要并请求显式确认：
+
+```
+About to delete N files and reset M files. Continue? [y/N]
+```
+
+用户拒绝则退出。**未经明确许可不得执行** — `/reset` 是破坏性操作，`raw/` 的删除不可恢复。
+
+### Step 3: 执行
+
+```bash
+python3 tools/reset_wiki.py --scope <scope> --yes
+```
+
+工具打印 JSON 状态报告（`{deleted_files, reset_files}`）。
+
+### Step 4: 记录日志（除非已重置 log）
+
+若执行的 scope 不包含 `log`，追加一条日志：
+
+```bash
+python3 tools/research_wiki.py log wiki/ "reset | scope: <scope>"
+```
+
+### Step 5: 报告
+
+打印结果并建议下一步：
+
+```
+## Reset complete — scope: <scope>
+
+Deleted: N files
+Reset:   M files
+
+Next steps:
+- /init       — 从 raw/ 引导 wiki
+- /prefill    — 沉淀基础背景知识
+- /ingest     — 手动添加单个来源
+```
+
+## Constraints
+
+- **破坏性操作前必须确认**：禁止在未展示计划并征得用户同意前调用 `--yes`。
+- **保留**：`.gitkeep` 占位、`wiki/CLAUDE.md`、`.qoder/`（skill 永不被触碰）。
+- **`raw/` 删除不可逆**：PDF 不在 git 中。执行 `raw` 或 `all` scope 前必须警告用户。
+- **`/reset` 不触碰** `tools/`、`mcp-servers/`、`i18n/`、`.env` 或 git 状态。
+- **scope 必填**：无默认行为（`/reset` 不带参数时提示用户选择 scope，而非猜测）。
+
+## Error Handling
+
+- **未知 scope**：列出有效 scope 并以非零退出码退出。
+- **wiki 目录缺失**：报错并建议运行 `/init`。
+- **`checkpoint-clear` 失败**：记录警告但不影响其他 scope。
+
+## Dependencies
+
+### 工具（通过 Bash）
+- `python3 tools/reset_wiki.py --scope <scope> [--yes] [--project-root .]` — 确定性破坏性辅助工具
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+- `reset_wiki.py` 在 `checkpoints` scope 下直接删除 `wiki/.checkpoints/*.json`(不走 CLI — `checkpoint-clear` 子命令需指定具体的 `task_id`,而 `/reset --scope checkpoints` 的语义是"全部清除")

--- a/.qoder/skills/review/SKILL.md
+++ b/.qoder/skills/review/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: review
+description: 通用跨模型审查：Review LLM 对任意研究制品进行独立评审，输出结构化评分、wiki 实体映射与改进建议
+---
+
+# /review
+
+> **用法**：`<artifact-path-or-slug> [--difficulty standard|hard|adversarial] [--focus method|evidence|writing|completeness]`
+
+
+> 对任意研究制品（idea、proposal、experiment plan、paper draft、method）进行跨模型审查。
+> 使用 Review LLM 作为独立审稿人，输出结构化评分、可操作的改进建议，以及与 wiki 实体的映射
+> （哪些 ideas/methods 需要加强，哪些 gaps 被发现）。
+> 支持三种难度级别（standard / hard / adversarial）和四种审查焦点。
+> 可独立使用，也被 /ideate、/refine、/exp-design 调用。
+
+## Inputs
+
+- `artifact`：要审查的制品，以下之一：
+  - wiki 页面的 slug（如 `sparse-lora-for-edge-devices`，从 ideas/experiments/methods/ 中查找）
+  - 文件路径（如 `wiki/outputs/paper-draft-v1.md`）
+  - 自由文本（直接粘贴的 proposal 或 idea 描述）
+- `--difficulty`（可选，默认 `standard`）：
+  - `standard`：单轮审查，给出结构化反馈
+  - `hard`：多轮对话（最多 3 轮），Claude 对每个 weakness 进行 rebuttal
+  - `adversarial`：多轮对话（最多 3 轮），Review LLM 额外尝试找致命缺陷，模拟最严苛的审稿人
+- `--focus`（可选，默认全面审查）：
+  - `method`：聚焦方法设计的正确性、创新性、可行性
+  - `evidence`：聚焦证据是否充分、实验是否严谨、idea/method 是否得到充分支撑
+  - `writing`：聚焦表达清晰度、结构组织、论证逻辑
+  - `completeness`：聚焦是否遗漏关键内容（相关工作、ablation、baseline）
+
+## Outputs
+
+- **Review Report**（输出到终端）：
+  - Overall Score（1-10）
+  - Strengths（优点列表）
+  - Weaknesses（缺点列表，按严重程度排序）
+  - Questions（审稿人的疑问）
+  - Actionable Suggestions（可操作的改进建议，按优先级排序）
+  - Wiki Entity Mapping（哪些 ideas/methods 需要加强，哪些 gaps 被发现）
+  - Verdict：`ready` / `needs-work` / `major-revision` / `rethink`
+- 若 `--difficulty >= hard`：额外包含多轮对话记录和最终修正后的评分
+- 该 skill **不直接修改 wiki**，但会输出建议的 wiki 更新列表
+
+## Wiki Interaction
+
+### Reads
+- `wiki/papers/*.md` — 查找制品引用的论文，验证引用正确性
+- `wiki/concepts/*.md` — 理解制品涉及的技术概念
+- `wiki/methods/*.md` — 检查制品依赖的 methods 当前状态
+- `wiki/experiments/*.md` — 查找相关实验结果
+- `wiki/ideas/*.md` — 如果审查的是 idea，检查其上下文
+- `wiki/graph/context_brief.md` — 获取全局上下文
+- `wiki/graph/open_questions.md` — 对照 gap map 检查完整性
+- `.qoder/skills/shared-references/cross-model-review.md` — 审稿独立性原则
+
+### Writes
+- **无**。Review 是只读查询操作。
+  - 审查结果输出到终端，由用户或调用方（如 /refine）决定是否应用。
+
+### Graph edges created
+- **无**。
+
+## Workflow
+
+**前置**：确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）。
+
+### Step 1: 加载上下文
+
+1. **解析 artifact**：
+   - 若为 slug：按顺序在 `wiki/ideas/`、`wiki/experiments/`、`wiki/methods/`、`wiki/papers/`、`wiki/outputs/` 中查找 `{slug}.md`
+   - 若为文件路径：直接读取
+   - 若为自由文本：直接使用
+2. **确定 artifact 类型**：idea / experiment / method / paper-draft / proposal / other
+3. **加载相关 wiki 上下文**：
+   - 读取 `wiki/graph/context_brief.md` 获取全局视角
+   - 读取 `wiki/graph/open_questions.md` 获取知识缺口列表
+   - 根据 artifact 类型，加载相关 wiki 页面：
+     - idea → 其 origin_gaps（concepts/topics）、相关 papers
+     - experiment → 其 linked_idea、相关 experiments
+     - method → 其 source_papers 和 parent_methods
+     - paper-draft → 其引用的所有 wiki 页面
+4. **读取 cross-model-review.md**：确认 Review LLM 独立性原则
+5. **构建 reviewer system prompt**（根据 --focus）：
+
+   **Base prompt（所有 focus）：**
+   ```
+   You are a senior ML researcher reviewing a research artifact.
+   Be thorough, specific, and constructive. For every weakness, suggest a concrete fix.
+   Score on a 1-10 scale where:
+   - 1-3: Fundamental flaws, not salvageable in current form
+   - 4-5: Significant issues but core idea may have merit
+   - 6-7: Solid work with clear areas for improvement
+   - 8-9: Strong work, minor issues only
+   - 10: Exceptional, publication-ready
+   ```
+
+   **Focus-specific additions：**
+   - `method`：额外要求评估 technical correctness, novelty of approach, feasibility, comparison to alternatives
+   - `evidence`：额外要求评估 experimental rigor, statistical significance, idea-evidence alignment, missing controls
+   - `writing`：额外要求评估 clarity, logical flow, notation consistency, figure quality, related work coverage
+   - `completeness`：额外要求评估 missing baselines, missing ablations, missing datasets, missing related work, reproducibility
+
+   **Adversarial addition（仅 adversarial 模式）：**
+   ```
+   Additionally: actively search for fatal flaws. A fatal flaw is anything that,
+   if true, would make the entire contribution invalid (incorrect proof, data leakage,
+   unfair comparison, published prior work). If you find one, flag it clearly.
+   ```
+
+### Step 2: Review LLM 首轮审查
+
+**遵循 cross-model-review.md**：不向 Review LLM 发送任何 Claude 的预判。
+
+```
+llm-review.chat:
+  system: {reviewer system prompt from Step 1}
+  message: |
+    ## Artifact to Review
+    {artifact full text}
+
+    ## Context from Knowledge Base
+    {relevant wiki context: related ideas/methods with status, related experiments, gap map entries}
+
+    ## Review Instructions
+    Please provide:
+    1. **Strengths** (3-5 bullet points)
+    2. **Weaknesses** (ranked by severity, each with a concrete suggestion to fix)
+    3. **Questions** (things that are unclear or need clarification)
+    4. **Score** (1-10 with one-sentence justification)
+    5. **Verdict**: ready / needs-work / major-revision / rethink
+    6. **Idea-/method-level feedback**: For each idea or method referenced in the artifact, assess whether the evidence/justification is sufficient. List any ideas or methods that need stronger support.
+    7. **Knowledge gaps identified**: Any open questions or missing knowledge that would strengthen this work.
+```
+
+记录 Review LLM 返回的 `threadId`（用于 Step 3 多轮对话）。
+
+### Step 3: 多轮对话（hard / adversarial 模式）
+
+若 `--difficulty` 为 `standard`，跳过此步。
+
+**对 Review LLM 的每个 weakness 进行回应**（最多 3 轮）：
+
+**Round N（N = 1, 2, 3）：**
+
+1. Claude 分析 Review LLM 的 weaknesses，对每个 weakness 分类：
+   - **可反驳（rebuttal）**：Claude 有充分理由或 wiki 证据反驳 → 写出 rebuttal
+   - **承认（acknowledge）**：weakness 确实存在 → 承认并提出修复方案
+   - **需要更多信息（clarify）**：weakness 基于误解 → 提供澄清
+
+2. 将 Claude 的回应发送给 Review LLM：
+   ```
+   llm-review.chat-reply:
+     threadId: {from Step 2}
+     message: |
+       Thank you for the review. Here are my responses:
+
+       {for each weakness: rebuttal / acknowledgment / clarification}
+
+       Please re-evaluate considering these responses. Update your score if warranted.
+       If --difficulty == adversarial: Also, please try harder to find any remaining
+       fatal flaws I may have missed.
+   ```
+
+3. Review LLM 回应新的评估和修正后的评分
+
+4. 若 Review LLM 的评分变化 < 0.5 且无新 weakness → 停止对话（收敛）
+5. 若已达 3 轮 → 停止对话
+
+### Step 4: 结构化输出
+
+综合 Step 2 + Step 3 结果，生成结构化 Review Report：
+
+```markdown
+# Review Report: {artifact title}
+
+## Meta
+- **Artifact type**: {idea / experiment / method / paper-draft / proposal}
+- **Difficulty**: {standard / hard / adversarial}
+- **Focus**: {method / evidence / writing / completeness / 全面}
+- **Reviewer**: Review LLM（在 `.env` 中配置）
+- **Rounds**: {1 for standard, N for hard/adversarial}
+
+## Score: {final score}/10 — {verdict}
+
+| Verdict | 含义 |
+|---------|------|
+| ready | 可直接使用或提交 |
+| needs-work | 有明确的改进点，修复后可用 |
+| major-revision | 核心部分需要重大修改 |
+| rethink | 基本方向可能有问题，需重新考虑 |
+
+## Strengths
+1. {strength 1}
+2. {strength 2}
+...
+
+## Weaknesses (by severity)
+
+### Critical
+- {weakness}: {具体描述} → **Fix**: {具体修复建议}
+
+### Major
+- {weakness}: {具体描述} → **Fix**: {具体修复建议}
+
+### Minor
+- {weakness}: {具体描述} → **Fix**: {具体修复建议}
+
+## Questions
+1. {question}
+...
+
+## Wiki Entity Mapping
+
+### Ideas / methods needing stronger support
+| Entity | Signal | Issue | Suggested action |
+|--------|--------|-------|------------------|
+| [[idea-slug]] | novelty_score 2/5 | Novelty argument is thin | Run /novelty rerun |
+| [[method-slug]] | source_papers sparse | Missing source paper backing | Ingest the missing paper, then rerun /check |
+
+### Knowledge gaps identified
+| Gap | Related to | Suggested action |
+|-----|-----------|------------------|
+| {描述} | [[slug]] | /ingest, /exp-run, or /query |
+
+### Suggested wiki updates
+- `wiki/ideas/{slug}.md`: add risk factor from review
+- `wiki/methods/{slug}.md`: tighten Tradeoff profile / Limitations
+- `wiki/graph/open_questions.md`: will be updated on next rebuild
+
+## Dialogue History (hard/adversarial only)
+
+### Round 1
+**Review LLM**: {summary of initial review}
+**Claude**: {summary of rebuttals/acknowledgments}
+
+### Round 2
+**Review LLM**: {updated assessment}
+...
+
+## Actionable Items (ranked)
+1. [CRITICAL] {action item}
+2. [MAJOR] {action item}
+3. [MINOR] {action item}
+```
+
+## Constraints
+
+- **审稿独立性**：严格遵循 `shared-references/cross-model-review.md`，不向 Review LLM 泄露 Claude 的预判
+- **不修改 wiki**：review 只输出建议，不直接修改任何 wiki 页面。wiki 修改由调用方（如 /refine）执行
+- **score 必须有 justification**：不接受没有理由的分数
+- **weakness 必须有 fix**：每个 weakness 必须附带具体的、可操作的修复建议，不接受空洞批评
+- **entity-level mapping 必须**：输出必须包含 Wiki Entity Mapping 部分，将 review 发现映射到具体 wiki 实体（ideas、methods 等）
+- **adversarial 模式必须搜索致命缺陷**：如已发表的完全相同工作、证明错误、数据泄露等
+- **多轮对话最多 3 轮**：防止无限循环，若 3 轮后仍未收敛则以当前状态输出
+- **引用 wiki 页面时使用 [[slug]]**：所有对 wiki 页面的引用使用 wikilink 语法
+
+## Error Handling
+
+- **artifact 找不到**：提示用户检查 slug 或路径，列出可能的候选页面
+- **Review LLM 不可用**：降级为 Claude 自我审查模式，报告标注「single-model review, cross-model verification unavailable」，建议用户稍后用 Review LLM 重新审查
+- **wiki 为空**：正常执行审查，但 Wiki Entity Mapping 部分标注「wiki empty, no entity mapping available」
+- **artifact 太长**：若超过 Review LLM 上下文窗口，按 section 分段审查，最后合并
+- **Review LLM 返回无效响应**：重试一次，若仍无效则使用 Claude 自审降级方案
+- **多轮对话中 Review LLM 不收敛**：3 轮后强制结束，输出最后一轮的评分和总结
+
+## Dependencies
+
+### Tools（via Bash）
+- 无直接工具调用（review 不需要确定性工具）
+
+### MCP Servers
+- `llm-review.chat` — Review LLM 首轮审查（Step 2）
+- `llm-review.chat-reply` — Review LLM 多轮对话（Step 3）
+
+### Qoder Native
+- `Read` — 读取 artifact 和 wiki 页面
+- `Glob` — 查找 artifact 对应的 wiki 页面
+
+### Shared References
+- `.qoder/skills/shared-references/cross-model-review.md` — 审稿独立性原则（必读）
+
+### Called by
+- `/ideate` Phase 4（审查 top ideas）
+- `/refine` 每轮迭代（审查当前版本）
+- `/exp-design --review`（审查实验计划）

--- a/.qoder/skills/setup/SKILL.md
+++ b/.qoder/skills/setup/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: setup
+description: 交互式 API key 配置引导 — 检测当前 .env 状态，逐步引导配置 Semantic Scholar、DeepXiv 和 Review LLM
+---
+
+# /setup
+
+> 引导你完成 ΩmegaWiki 的可选 API key 配置。
+> 读取当前 `.env`，展示已配置和未配置的内容，并帮助你逐步设置每个 key，
+> 包括清晰解释每个 key 的作用和获取方式。
+> 可随时重新运行，只更新你选择配置的 key。
+
+## Inputs
+
+- 不需要任何参数
+- 读取：`.env`（当前配置状态）
+- 读取：`config/setup-guide.md`（每个 key 的参考说明）
+
+## Outputs
+
+- 更新后的 `.env`（包含新配置的 key）
+- 当前配置状态总结
+
+## Wiki Interaction
+
+### Reads
+- 无（setup 在 wiki 创建之前运行）
+
+### Writes
+- 无（不修改 wiki）
+
+## Workflow
+
+### Step 1：读取配置参考文档
+
+读取 `config/setup-guide.md`，加载所有可配置 key 的完整参考信息，
+包括每个 key 的作用、使用它的 skill、获取方式以及未配置时的降级行为。
+
+### Step 2：检测当前环境
+
+运行以下命令检查已配置的内容：
+
+```bash
+python3 -c "
+import sys, os
+sys.path.insert(0, 'tools')
+try:
+    import _env
+except Exception:
+    pass
+keys = {
+    'SEMANTIC_SCHOLAR_API_KEY': 'Semantic Scholar',
+    'DEEPXIV_TOKEN':            'DeepXiv',
+    'LLM_API_KEY':              'Review LLM（API key）',
+    'LLM_BASE_URL':             'Review LLM（base URL）',
+    'LLM_MODEL':                'Review LLM（模型名）',
+}
+for k, label in keys.items():
+    v = os.environ.get(k, '').strip()
+    print(f'SET:{k}' if v else f'UNSET:{k}')
+"
+```
+
+同时检测 Python 环境和 `.venv` 状态：
+```bash
+ls .venv/ 2>/dev/null && echo "venv:present" || echo "venv:absent"
+python3 --version
+```
+
+### Step 3：展示配置状态
+
+向用户展示清晰的状态总结，按状态分组：
+
+```
+ΩmegaWiki 配置状态
+================================
+✓  ANTHROPIC_API_KEY      — 由 Qoder 管理（Qoder 登录）
+
+推荐配置：
+✗  Semantic Scholar        — 未配置（引用链扩展速度慢 3 倍，建议配置免费 key）
+
+可选：
+✗  DeepXiv                 — 未配置（语义搜索不可用）
+✗  Review LLM              — 未配置（跨模型 review 不可用）
+```
+
+询问用户："您想配置哪些？（可以跳过任意一个或全部）"
+
+### Step 4：配置各 Key（用户决定）
+
+对用户想要配置的每个 key，按以下子流程处理。
+写入 `.env` 前必须向用户确认。
+
+---
+
+#### 4a：Semantic Scholar API Key
+
+**解释**："Semantic Scholar 提供论文引用数据和检索功能。
+被 /ingest、/init、/novelty、/ideate 使用。免费获取。
+**推荐配置** — 不配置的话，/init 速度慢 3 倍，引用链扩展效率大幅下降。"
+
+**引导获取**："访问 https://www.semanticscholar.org/product/api，
+点击 'Get API Key'，免费申请。"
+
+**询问**："您是否有 Semantic Scholar API key？（粘贴，或输入 'skip' 跳过）"
+
+**如果提供了 key**，写入 `.env`：
+使用 Edit 工具更新 `.env`：
+- 若已有 `SEMANTIC_SCHOLAR_API_KEY=`（即使为空），替换该行
+- 否则追加 `SEMANTIC_SCHOLAR_API_KEY=<值>`
+
+---
+
+#### 4b：DeepXiv Token
+
+**解释**："DeepXiv 提供语义论文检索、AI 论文摘要（TLDR）和热门论文检测。
+被 /daily-arxiv、/novelty、/ideate、/ingest、/init 使用。
+不配置时，这些 skill 回退到 arXiv RSS + Semantic Scholar，功能全部可用，
+只是缺少语义搜索和 TLDR 功能。"
+
+**提供三种选项**：
+1. **自动注册**（推荐，免费，秒完成）：运行注册请求
+2. **粘贴已有 token**：用户提供自己的 token
+3. **跳过**：稍后配置
+
+**选项 1 — 自动注册**，运行：
+```bash
+python3 -c "
+import sys, json
+from uuid import uuid4
+try:
+    import requests
+except ImportError:
+    print('ERROR: requests 未安装', file=sys.stderr)
+    sys.exit(1)
+
+suffix = uuid4().hex[:10]
+payload = {
+    'sdk_secret': 'UuZp0i83svQU7_naUEexczc-X3NWv7lvNkD8e3sPyng',
+    'name': f'deepxiv_{suffix}',
+    'email': f'{suffix}@example.com',
+}
+try:
+    resp = requests.post('https://data.rag.ac.cn/api/register/sdk', json=payload, timeout=30)
+    resp.raise_for_status()
+    result = resp.json()
+except Exception as e:
+    print(f'ERROR: {e}', file=sys.stderr)
+    sys.exit(1)
+
+if not result.get('success'):
+    print(f'ERROR: {result.get(\"message\", \"unknown\")}', file=sys.stderr)
+    sys.exit(1)
+
+token = result.get('data', {}).get('token', '')
+daily_limit = result.get('data', {}).get('daily_limit', 1000)
+if not token:
+    print('ERROR: 响应中没有 token', file=sys.stderr)
+    sys.exit(1)
+
+print(token)
+print(f'daily_limit:{daily_limit}', file=sys.stderr)
+"
+```
+stdout → token 值；stderr → 人类可读状态（直接透传，不要抑制）。
+
+注册成功后写入 `.env`。失败时显示错误信息，并提供让用户手动粘贴 token 的选项。
+
+---
+
+#### 4c：Review LLM
+
+**解释**："Review LLM 将 ΩmegaWiki 连接到第二个 AI 模型，进行独立的对抗性评审。
+被 /review、/novelty、/ideate、/paper-plan、/paper-draft、/rebuttal、/refine、
+/exp-eval、/exp-design，以及 /daily-arxiv 的 inform 推荐使用。支持任何 OpenAI-compatible API。
+不配置时，这些 skill 跳过跨模型 review 步骤（功能全部保留）。"
+
+**展示 provider 对照表**（来自 `config/setup-guide.md` Key 3 部分）。
+
+**如果用户问 'OpenAI-compatible 是什么意思'**：解释为任何接受
+`POST /chat/completions`、请求体格式为 `{"model": "...", "messages": [...]}` 的 API。
+
+**依次询问**：
+1. `LLM_BASE_URL` — 例如 `https://api.deepseek.com/v1`
+2. `LLM_API_KEY` — 对应 provider 的 API key
+3. `LLM_MODEL` — 模型名称，例如 `deepseek-chat`
+
+**格式校验**：Base URL 应以 `http://` 或 `https://` 开头，通常以 `/v1` 结尾。
+格式看起来有问题时，写入前询问用户确认。
+
+**用户确认后写入** `.env` 中的三个变量。
+
+**写入后提醒**：Review LLM MCP server 在 Qoder 启动时读取 `.env`，
+变更在重启 Qoder 后生效。
+
+---
+
+#### 4d：arXiv Categories（仅用户主动询问时）
+
+此 key 有合理默认值（`cs.LG,cs.CV,cs.CL,cs.AI,stat.ML`）。
+仅当用户明确要求，或其研究领域明显不在 ML/AI 范围内时才配置。
+
+---
+
+### Step 5：验证配置
+
+用户完成配置后，运行验证检查：
+
+```bash
+python3 -c "
+import sys, os
+sys.path.insert(0, 'tools')
+try:
+    import _env
+except Exception:
+    pass
+keys = ['SEMANTIC_SCHOLAR_API_KEY', 'DEEPXIV_TOKEN', 'LLM_API_KEY', 'LLM_BASE_URL', 'LLM_MODEL']
+for k in keys:
+    v = os.environ.get(k, '').strip()
+    print(f'已配置  {k}' if v else f'未配置  {k}')
+"
+```
+
+展示最终总结。对仍未配置的 key，简要说明其解锁的功能，
+并告知用户可以随时重新运行 `/setup` 来补充配置。
+
+### Step 6：下一步
+
+如果是全新安装（`wiki/` 目录不存在）：
+```
+配置完成。接下来：
+  • 将你自己的论文放入 raw/papers/（.tex 或 .pdf）
+  • 可选：把意图笔记放入 raw/notes/，网页存档放入 raw/web/
+  • /init 与直接本地 /ingest 会自动管理 raw/discovered/ 与 raw/tmp/ 下的生成内容
+  • 运行：/init [你的研究主题]
+```
+
+如果 `wiki/` 已存在：
+```
+配置已更新。重启 Qoder 后 Review LLM 变更生效。
+```
+
+## Constraints
+
+- **不覆盖已有非空值**，除非先征得用户同意
+- **不在输出中展示完整 key 值**，只显示前 8 个字符 + `...`
+- **只写入 `.env`**，不写入 `~/.env` 或其他位置
+- **不读写 wiki**，此 skill 可在 wiki 创建之前运行
+- **优雅跳过**：若用户说"全部跳过"，展示状态总结后直接退出
+
+## Error Handling
+
+- **`.env` 不存在**：提示用户 `setup.sh` 可能未运行，提供创建命令：
+  ```bash
+  cp config/.env.example .env
+  ```
+  然后继续配置流程。
+
+- **`config/setup-guide.md` 不存在**：直接使用本 SKILL.md 中的信息继续。
+
+- **DeepXiv 注册失败**（网络错误、服务器错误）：清晰展示错误信息，
+  提供让用户手动粘贴 token 的选项，或跳过。
+
+- **Python 环境问题**（`tools/_env.py` 找不到）：提示 `.venv` 可能未激活，
+  但仍通过 shell 或 Python 文件读取检查 `.env` 当前状态。
+
+## Dependencies
+
+### Tools（via Bash）
+- `python3 -c "import _env; ..."` — 读取当前 `.env` 状态
+- `python3 -c "import requests; ..."` — DeepXiv 自动注册 HTTP 请求
+
+### Files Read
+- `config/setup-guide.md` — 所有可配置 key 的完整参考
+- `.env` — 当前配置（读 + 写）
+
+### Files Written
+- `.env` — 通过 Edit 工具写入新配置的 key
+
+### 不调用 MCP server、不访问 wiki、不调用其他 skill

--- a/.qoder/skills/shared-references/academic-writing.md
+++ b/.qoder/skills/shared-references/academic-writing.md
@@ -1,0 +1,156 @@
+# Academic Writing Principles
+
+> Shared reference for all skills that produce written output: /paper-draft, /paper-plan, /survey.
+> These principles ensure publication-quality writing that reads as expert-authored, not AI-generated.
+
+---
+
+## 1. Narrative Structure
+
+### The Hourglass Shape
+
+Every well-structured paper follows an hourglass:
+
+```
+BROAD:   Introduction — why this matters to the field
+NARROW:  Method — exactly what we did
+NARROW:  Experiments — exactly what happened
+BROAD:   Discussion — what this means for the field
+```
+
+### Section-Level Rules
+
+- **Introduction**: Start with the problem (not the solution). The reader must feel the gap before you fill it.
+  - Paragraph 1: broad context and importance
+  - Paragraph 2: specific problem and why existing approaches fall short
+  - Paragraph 3: "In this work, we..." — your contribution
+  - Paragraph 4: summary of results and paper structure
+
+- **Related Work**: Organize by theme, not by paper. Each paragraph covers a research direction, not a single citation.
+  - End each paragraph with how your work differs from that direction
+  - Never write a flat list of "X did Y. Z did W."
+
+- **Method**: Lead with intuition before formalism. A reader should understand *why* before *how*.
+  - One figure showing the overall architecture (mandatory)
+  - Notation introduced before first use
+  - Each subsection = one design decision
+
+- **Experiments**: Claim-first structure. Each subsection begins with the claim it validates.
+  - "We claim X. To verify, we..." (not "We ran experiment A. Results show...")
+  - Tables before discussion (readers scan tables first)
+  - Error bars or confidence intervals mandatory
+
+- **Conclusion**: New insight, not summary. What should the reader remember tomorrow?
+
+## 2. Clarity Rules
+
+### Sentence Level
+
+- **One idea per sentence.** If a sentence has "and" + "which" + "that", split it.
+- **Active voice by default.** "We train the model" not "The model is trained."
+- **Specific > vague.** "Reduces latency by 40%" not "significantly improves performance."
+- **Define before use.** Every acronym spelled out on first use. Every symbol defined before first equation.
+
+### Paragraph Level
+
+- **Topic sentence first.** Every paragraph starts with its main claim.
+- **One point per paragraph.** If you find yourself writing "Additionally" mid-paragraph, start a new one.
+- **Transitions between paragraphs.** The last sentence of paragraph N should connect to the first sentence of paragraph N+1.
+
+### Notation Consistency
+
+- Define a `math_commands.tex` file for shared notation
+- Same symbol = same meaning throughout the paper
+- Bold lowercase for vectors (**x**), bold uppercase for matrices (**W**), calligraphic for sets
+- Never redefine a symbol mid-paper
+
+## 3. Figure and Table Design
+
+### Figures
+
+- **Every figure must be referenced in text** and discussed (not just displayed)
+- **Colorblind-safe palettes**: use distinguishable patterns + colors (never rely on color alone)
+- **Font size >= 8pt** in all labels, legends, axis ticks
+- **Vector format preferred** (PDF/SVG for line plots, PNG only for photos/screenshots)
+- **Caption is self-contained**: a reader should understand the figure from its caption alone
+- **Consistent style**: all figures use the same font, line width, color scheme
+
+### Tables
+
+- **Horizontal rules only** (no vertical lines, no full grid): `\toprule`, `\midrule`, `\bottomrule`
+- **Best result in bold**, second-best underlined
+- **Units in column header**, not in every cell
+- **Align decimal points** in numeric columns
+- **Caption above table** (convention in most ML venues)
+
+## 4. De-AI Polish Rules
+
+AI-generated text has recognizable patterns. These must be eliminated before submission.
+
+### Words and Phrases to Remove or Replace
+
+| AI Pattern | Replace With |
+|------------|-------------|
+| "delve into" | "examine" / "analyze" / remove entirely |
+| "it is worth noting that" | remove (just state the thing) |
+| "it is important to note" | remove |
+| "in the realm of" | "in" |
+| "leverage" (as verb) | "use" / "exploit" / "apply" |
+| "utilize" | "use" |
+| "facilitate" | "enable" / "allow" / remove |
+| "comprehensive" (without evidence) | remove or quantify |
+| "crucial" / "pivotal" | "important" / "key" / remove |
+| "Furthermore" at paragraph start | vary: "Moreover" / "In addition" / restructure |
+| "In conclusion" (exact phrase) | "To summarize" / restructure without filler |
+| "a myriad of" | "many" / "various" / specific number |
+| "shed light on" | "reveal" / "clarify" / "show" |
+| "pave the way for" | "enable" / remove |
+| "cutting-edge" / "state-of-the-art" (as filler) | only use SOTA when citing specific benchmarks |
+| "robust" (without robustness experiments) | remove or qualify |
+| "novel" (overuse) | use once in abstract + once in intro, no more |
+
+### Structural Patterns to Fix
+
+- **Excessive hedging**: "It could potentially be argued that X might..." → "X is likely because..."
+- **Redundant topic shifts**: "Having discussed X, we now turn to Y" → just start Y
+- **Enumeration addiction**: "First... Second... Third..." in every paragraph → vary structure
+- **Superlative inflation**: "groundbreaking", "revolutionary" → let results speak
+- **Repetitive sentence openings**: vary subject-verb patterns across consecutive sentences
+
+### The Polish Pass
+
+After drafting, run this mental checklist on every paragraph:
+
+1. Could a reviewer guess this was AI-generated? If yes, rewrite.
+2. Does every adjective earn its place? Remove unearned superlatives.
+3. Is there a shorter way to say this? Use it.
+4. Does this paragraph add information, or just fill space? Cut filler.
+5. Read aloud: does it sound like a human expert wrote it?
+
+## 5. Venue-Specific Formatting
+
+### Page Limits (typical)
+
+| Venue | Main | References | Appendix |
+|-------|------|-----------|----------|
+| ICLR | 10 pages | unlimited | unlimited |
+| NeurIPS | 9 pages | unlimited | unlimited |
+| ICML | 8 pages | unlimited | unlimited |
+| ACL | 8 pages (long) | unlimited | unlimited |
+| CVPR | 8 pages | +2 pages | — |
+| IEEE TPAMI | ~20 pages | included | — |
+
+### Anonymity Rules
+
+- No author names, affiliations, or acknowledgments in submission
+- No "our previous work [1]" — use "Smith et al. [1]" (third person)
+- No GitHub links to identifiable repos
+- No institution-specific cluster names
+
+## What NOT To Do
+
+- **Never submit without de-AI polish** — reviewers increasingly check for AI patterns
+- **Never use filler paragraphs** — every paragraph must advance the argument
+- **Never present results without context** — "95% accuracy" means nothing without baseline comparison
+- **Never mix tenses** — Method in present tense, experiments in past tense, results in present
+- **Never cite without discussing** — every \cite must be accompanied by how it relates to your work

--- a/.qoder/skills/shared-references/citation-verification.md
+++ b/.qoder/skills/shared-references/citation-verification.md
@@ -1,0 +1,94 @@
+# Citation Discipline
+
+> Shared reference for all skills that generate citations: /paper-draft, /survey, /paper-plan.
+> Every citation in a OmegaWiki output must be **verifiable** — never LLM-generated.
+
+---
+
+## Core Rule
+
+**BibTeX entries must come from authoritative sources, not from LLM memory.**
+
+LLMs hallucinate citation details (wrong year, wrong venue, wrong authors, non-existent papers).
+The only acceptable sources for BibTeX are:
+
+1. **DBLP** (`https://dblp.org/`) — primary source for CS venues
+2. **CrossRef** (`https://api.crossref.org/`) — primary source for DOI-bearing publications
+3. **Semantic Scholar** (`https://api.semanticscholar.org/`) — fallback for preprints
+4. **The paper's own .bib file** — if available in `raw/papers/`
+
+## The [UNCONFIRMED] Protocol
+
+When a BibTeX entry **cannot** be fetched from any authoritative source:
+
+1. Generate a best-effort entry from available information (title, authors, year from wiki page)
+2. Prefix the BibTeX key with `UNCONFIRMED_`: `@article{UNCONFIRMED_smith2024attention, ...}`
+3. Add a comment: `% [UNCONFIRMED] BibTeX not confirmed from DBLP/CrossRef — manual check required`
+4. The `[UNCONFIRMED]` marker is a **hard blocker** for submission — /paper-compile must flag all remaining `[UNCONFIRMED]` entries
+
+## Fetching BibTeX
+
+### DBLP (preferred for CS)
+
+```bash
+# Search by title
+WebFetch: https://dblp.org/search/publ/api?q={url-encoded-title}&format=json&h=3
+
+# Parse response: .result.hits.hit[].info contains title, authors, venue, year, url
+# Get BibTeX: WebFetch the .url field + ".bib" suffix
+```
+
+### CrossRef (preferred for DOI)
+
+```bash
+# Search by title
+WebFetch: https://api.crossref.org/works?query.bibliographic={url-encoded-title}&rows=3
+
+# Parse response: .message.items[] contains title, author, container-title, DOI
+# Construct BibTeX from structured data
+```
+
+### Semantic Scholar (fallback for arXiv preprints)
+
+```bash
+# Use tools/fetch_s2.py which is already in the project
+python3 tools/fetch_s2.py search "<title>"
+# Returns paperId, title, authors, year, venue, externalIds
+```
+
+## Citation Key Convention
+
+```
+{first-author-lastname}{year}{first-keyword}
+```
+
+Examples:
+- `hu2022lora` (Hu et al., 2022, "LoRA: Low-Rank Adaptation...")
+- `vaswani2017attention` (Vaswani et al., 2017, "Attention Is All You Need")
+
+## Rules for Skills
+
+### /paper-draft
+1. After drafting each section, collect all `\cite{}` references
+2. For each citation: attempt DBLP → CrossRef → S2 in order
+3. Only include entries that are actually cited (`\nocite{*}` is forbidden)
+4. Write `references.bib` with fetched entries + [UNCONFIRMED] entries separated at bottom
+
+### /survey
+1. Use `[[slug]]` wikilinks during drafting (wiki-internal format)
+2. When converting to LaTeX, resolve each `[[slug]]` to a `\cite{key}`
+3. The citation key must match a verified BibTeX entry
+4. If a wiki paper has no verifiable BibTeX, output `\cite{UNCONFIRMED_slug}` and flag
+
+### /paper-plan
+1. In the citation plan, list all wiki papers that will be cited
+2. Pre-fetch BibTeX for each planned citation (fail-fast: identify [UNCONFIRMED] entries early)
+3. Report citation coverage: how many are verified vs. [UNCONFIRMED]
+
+## What NOT To Do
+
+- **Never** generate BibTeX from memory (wrong venue/year is worse than [UNCONFIRMED])
+- **Never** cite a paper not in the wiki (all citations trace back to wiki/papers/)
+- **Never** use `\nocite{*}` (every entry must be explicitly cited)
+- **Never** silently drop a [UNCONFIRMED] marker (it must survive until human verification or successful fetch)
+- **Never** fabricate DOIs or arXiv IDs

--- a/.qoder/skills/shared-references/cross-model-review.md
+++ b/.qoder/skills/shared-references/cross-model-review.md
@@ -1,0 +1,92 @@
+# 评审独立性原则
+
+> 引用方: `/review`, `/novelty`, `/ideate`, `/exp-eval`, `/exp-design`, `/paper-plan`, `/paper-draft`, `/rebuttal`, `/refine`
+
+---
+
+## Core Rule
+
+When using a Review LLM (any external model) as a reviewer or cross-verifier, **never share the primary model's own judgment, scores, or conclusions** with the reviewer before they form their independent assessment.
+
+The reviewer must receive:
+- The **artifact** being reviewed (idea, method, paper draft, experiment results)
+- The **relevant context** (wiki pages, prior work, constraints)
+- The **review criteria** (what to evaluate, at what difficulty level)
+
+The reviewer must **NOT** receive:
+- Claude's own score or rating of the artifact
+- Claude's assessment of strengths/weaknesses
+- Claude's recommendation (proceed/modify/abandon)
+- Any framing that anchors the reviewer toward a particular conclusion
+
+---
+
+## Why This Matters
+
+1. **Anchoring bias**: If the Review LLM sees "Claude rated this 7/10", its review will cluster around 7. Independent assessment catches blind spots that anchored assessment misses.
+2. **Confirmation bias**: If Claude says "the main weakness is X", the Review LLM will focus on X and miss weakness Y. Unprimed reviewers explore the full space.
+3. **Diversity of perspective**: The entire value of cross-model review is that different models have different biases. Sharing judgments before review collapses this diversity.
+
+---
+
+## How to Apply
+
+### In `/review` (adversarial critique)
+- Step 2: Send artifact + context + review prompt to the Review LLM. Do NOT include any pre-assessment.
+- Step 3 (multi-turn): Claude may respond to the Review LLM's critique with rebuttals, but these are responses to its points, not pre-formed judgments.
+
+### In `/novelty` (cross-verification)
+- Step 3: Send method signature + existing similar works to the Review LLM. Do NOT include Claude's novelty score from Step 2.
+
+### In `/ideate` (dual-model brainstorm)
+- Phase 2: The Review LLM generates ideas from the same landscape context as Claude, but does NOT see Claude's idea list. Merge happens after both complete independently.
+
+### In `/exp-eval` (impartial verdict)
+- Step 2: Send experiment results + the linked idea's hypothesis + context to the Review LLM. Do NOT include Claude's interpretation of the results.
+
+---
+
+## Composing Independent Assessments
+
+After both models have independently assessed:
+
+1. **If scores agree** (within 1 point): Use the average. High confidence.
+2. **If scores disagree** (2+ points apart): Flag the disagreement explicitly. Investigate which model missed what. Report both scores with reasoning.
+3. **Conservative default**: When combining novelty or quality scores, take the **lower** score. Better to underestimate than to overcommit to a flawed idea.
+4. **不得用平均值掩盖关键发现**：若其中一个模型发现致命缺陷（如该方法已被发表），该发现无论另一模型评分如何均成立。
+
+---
+
+## Review LLM 可用性检查
+
+调用 `llm-review.chat` 之前，每个 skill 必须检查可用性并优雅处理。
+
+### 检测
+
+`llm-review.chat` 调用会失败的情况：
+- MCP server 未配置（缺少 `.qoder/mcp.json` 或 `MCP server enablement in Qoder settings` 未启用）
+- `.env` 中未设置 `LLM_API_KEY` 或 `LLM_BASE_URL`
+- API 端点不可达
+
+### 降级协议
+
+当 review MCP server **不可用**时：
+
+1. **不要静默跳过**。告知用户：
+   > "跨模型 review 尚未配置。此 skill 在独立 review LLM 辅助下效果更好。你想现在配置，还是仅用 Claude 继续？"
+
+2. **若用户选择配置**，交互引导：
+   - 询问用户使用哪个 OpenAI 兼容 API（DeepSeek、OpenAI、Qwen、OpenRouter 等）
+   - 帮助用户编辑 `.env`，设置 `LLM_API_KEY`、`LLM_BASE_URL`、`LLM_MODEL`
+   - 提示用户重启 Qoder 以使 MCP server 加载新配置
+   - 引导参考 `.env.example` 中的 provider 列表
+
+3. **若用户选择继续（不配置 review）**，进入 Claude-only 模式：
+   - 跳过 `llm-review.chat` 调用
+   - 由 Claude 自身执行 review/critique 步骤（自评模式）
+   - 明确标注输出为 `[Claude 自评 — 无独立第二意见]`
+   - 其余 skill 流程正常执行
+
+### 当 Review LLM 可用时
+
+按上述标准跨模型 review 协议执行。`llm-review.chat` 工具由 `llm-review` MCP server 提供（在 `.qoder/mcp.json` 中配置），兼容任何 OpenAI-compatible API。

--- a/.qoder/skills/survey/SKILL.md
+++ b/.qoder/skills/survey/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: survey
+description: 从 wiki 知识生成论文 Related Work 章节：主题分组 → 叙事结构 → LaTeX 输出，遵循 citation-verification 和 academic-writing
+---
+
+# /survey
+
+> **用法**：`<research-question-or-idea-slugs> [--format latex|markdown] [--max-papers 30]`
+
+
+> 基于 wiki 已有知识，生成可直接用于论文的 Related Work 章节。
+> 从 wiki/papers/、concepts/、topics/ 取材，按研究方向分组（非逐篇罗列），
+> 每组以「与本文的区别」收尾。引用遵循 citation-verification.md，
+> 写作遵循 academic-writing.md 的 Related Work 规则。
+> 支持 LaTeX 和 Markdown 两种输出格式。
+
+## Inputs
+
+- `query`：以下之一：
+  - 研究问题描述（自由文本，如 "parameter-efficient fine-tuning for LLMs"）
+  - idea slugs 列表（从 wiki/ideas/ 中，用于围绕特定 ideas 组织相关工作）
+  - PAPER_PLAN.md 路径（从中提取 Related Work section 定义）
+- `--format`（可选，默认 `latex`）：输出格式
+  - `latex`：`\cite{key}` 引用，可直接嵌入论文
+  - `markdown`：`[[slug]]` wikilink 引用，用于 wiki 存档
+- `--max-papers`（可选，默认 30）：最多引用的论文数量
+
+## Outputs
+
+- `wiki/outputs/related-work-{slug}-{date}.md` — Related Work 文本（归档）
+- `wiki/graph/edges.jsonl` — derived_from 边（若新建 output）
+- `wiki/log.md` — 追加日志
+- **终端输出** — Related Work 正文（方便直接复制）
+
+## Wiki Interaction
+
+### Reads
+- `wiki/papers/*.md` — Problem & Context、Key idea、Experiment & Results、Related、My take
+- `wiki/concepts/*.md` — Definition、Variants、Comparison、Known limitations
+- `wiki/topics/*.md` — Overview、Timeline、Open problems、Seminal works
+- `wiki/ideas/*.md` — Hypothesis、Motivation、origin_gaps（若输入为 idea slugs）
+- `wiki/methods/*.md` — Mechanism、Procedure、source_papers（idea 引用的可复用方法）
+- `wiki/index.md` — 内容目录，按 importance 筛选
+- `wiki/graph/context_brief.md` — 全局上下文
+- `wiki/graph/edges.jsonl` — 论文间语义关系（same_problem_as、similar_method_to、builds_on、challenges）
+- `.qoder/skills/shared-references/academic-writing.md` — Related Work 写作规则
+- `.qoder/skills/shared-references/citation-verification.md` — 引用纪律
+
+### Writes
+- `wiki/outputs/related-work-{slug}-{date}.md` — 归档文件
+- `wiki/graph/edges.jsonl` — derived_from 边
+- `wiki/log.md` — 追加操作日志
+
+### Graph edges created
+- `derived_from`：related-work output → source papers
+
+## Workflow
+
+**前置**：确认工作目录为 wiki 项目根（包含 `wiki/`、`raw/`、`tools/` 的目录）。
+
+### Step 1: 定位相关知识
+
+1. **解析输入**：
+   - 若为自由文本：提取关键词，在 wiki/index.md 中匹配 tags 和 titles
+   - 若为 idea slugs：读取每个 idea 的 `origin_gaps`（concepts/topics）→ 走到 `concepts.key_papers` 与 topic 的 seminal works 收集相关论文；同时读取 idea 的 `## Approach sketch` 引用的 methods，再从 `methods.source_papers` 拉论文
+   - 若为 PAPER_PLAN 路径：读取 Related Work section 的 groupings 和 citations
+2. **读取 wiki/graph/context_brief.md** 获取全局上下文
+3. **读取 wiki/graph/edges.jsonl**：提取论文间语义关系（same_problem_as、similar_method_to、builds_on、challenges）
+4. **生成候选论文列表**：
+   - 从 index.md 按 importance 降序排列
+   - 按 tags 和 domain 匹配度排序
+   - 限制为 `--max-papers` 篇
+5. **若候选论文 < 5 篇**：警告「相关论文不足，建议先 /ingest 更多论文」
+
+### Step 2: 精读相关页面
+
+对候选论文列表中的每篇论文：
+
+1. 读取 `wiki/papers/{slug}.md`：重点读 Problem & Context、Key idea、Experiment & Results、My take
+2. 读取该论文关联的 `wiki/concepts/*.md`：重点读 Definition、Variants、Comparison
+3. 读取相关 `wiki/topics/*.md`：重点读 Timeline、Open problems
+
+记录每篇论文的：
+- 核心贡献（一句话）
+- 方法类别（属于哪个研究方向）
+- 与本文的关系（same problem / similar method / builds on / challenges）
+- 局限性（从 Limitations 或 My take 提取）
+
+### Step 3: 主题分组
+
+遵循 `shared-references/academic-writing.md` 的 Related Work 规则：
+
+1. **按研究方向分组**（非逐篇罗列）：
+   - 从 wiki/topics/ 和 concepts/ 的分类中提取自然分组
+   - 每组 3-8 篇论文
+   - 分组标题描述研究方向（如 "Parameter-Efficient Fine-Tuning"），非单篇论文
+2. **确定组间顺序**：
+   - 从宏观到具体（大方向 → 子方向 → 最相关方法）
+   - 或按时间线（早期奠基 → 发展 → 最新）
+3. **确定组内顺序**：
+   - 按年份升序（展现演进）
+   - 重要论文详写（2-3 句），次要论文简写（1 句）
+4. **标注每组与本文的关系**：
+   - 每组结尾一句：「Unlike these approaches, our method...」或「We build upon X by...」
+
+### Step 4: 生成段落
+
+遵循 `shared-references/academic-writing.md`：
+
+1. **每组一段或两段**：
+   - 开头：该方向的背景和重要性
+   - 中间：按组内顺序展开每篇论文的贡献
+   - 结尾：与本文的定位关系（必须有）
+
+2. **引用格式**：
+   - `--format latex`：`\cite{key}`，key 从 citation-verification.md 的命名规则生成
+   - `--format markdown`：`[[slug]]`
+
+3. **写作规范**：
+   - 不写平铺列表（"X did Y. Z did W."）
+   - 每段有 topic sentence
+   - 使用对比连接词（"While X focuses on..., Y addresses..."）
+   - 不使用 AI 特征词汇（参考 academic-writing.md de-AI 列表）
+
+4. **De-AI polish**：
+   - 扫描并替换 AI 特征词汇
+   - 变化 sentence openings
+   - 移除 filler sentences
+
+### Step 5: BibTeX 准备（仅 --format latex）
+
+若输出格式为 LaTeX，遵循 `shared-references/citation-verification.md`：
+
+1. 收集所有 `\cite{key}` 引用
+2. 对每个 key，尝试获取 BibTeX：DBLP → CrossRef → S2
+3. 已验证的：记录 BibTeX
+4. 未验证的：标记 `[UNCONFIRMED]`
+5. 输出 BibTeX 条目列表（可追加到 paper/references.bib）
+6. 报告 citation coverage
+
+### Step 6: 归档
+
+1. **生成 slug**：
+   ```bash
+   python3 tools/research_wiki.py slug "<query-keywords>"
+   ```
+
+2. **写入归档文件**：
+   创建 `wiki/outputs/related-work-{slug}-{date}.md`：
+   ```yaml
+   ---
+   title: "Related Work: {topic}"
+   type: related-work
+   format: {latex|markdown}
+   paper_count: {N}
+   date_generated: YYYY-MM-DD
+   ---
+   ```
+   正文为完整 Related Work 文本。
+   若 latex 格式：附录包含 BibTeX 条目。
+
+3. **添加 graph edges**：
+   ```bash
+   # output → 每篇引用的论文
+   python3 tools/research_wiki.py add-edge wiki/ \
+     --from "outputs/related-work-{slug}-{date}" --to "papers/{paper-slug}" \
+     --type derived_from --evidence "Cited in related work section"
+   ```
+
+4. **追加日志**：
+   ```bash
+   python3 tools/research_wiki.py log wiki/ \
+     "survey | {topic} | {N} papers, {G} groups, format: {format}"
+   ```
+
+5. **终端输出**：完整 Related Work 正文 + citation coverage 统计
+
+## Constraints
+
+- **只引用 wiki 中已有论文**：不凭空编造引用。每个 `\cite{}` 或 `[[slug]]` 必须对应 wiki/papers/ 中的页面
+- **按主题分组，非逐篇列表**：每段覆盖一个研究方向，非「Paper A did X. Paper B did Y.」
+- **每组必须有定位句**：与本文的关系（结尾处说明区别或继承）
+- **候选论文 < 5 篇时警告**：提示用户先 /ingest 更多论文
+- **BibTeX 遵循 citation-verification.md**：不从 LLM 记忆生成（仅 --format latex）
+- **de-AI polish 必选**：生成后必须执行 polish pass
+- **归档到 outputs/**：不直接修改 wiki 的 papers/concepts/topics 页面
+- **graph edges 使用 tools/research_wiki.py**：不手动编辑 edges.jsonl
+
+## Error Handling
+
+- **wiki 论文不足 3 篇**：报错，建议先 /ingest 足够数量的论文
+- **无匹配论文**：扩大搜索范围（放宽 tag 匹配），若仍无则报错
+- **BibTeX 获取全部失败**（latex 格式）：使用 [UNCONFIRMED] 占位，报告数量
+- **PAPER_PLAN 格式不匹配**：忽略 plan 的分组建议，使用自动分组
+- **slug 冲突**：追加日期后缀
+
+## Dependencies
+
+### Tools（via Bash）
+- `python3 tools/research_wiki.py slug "<title>"` — 生成 slug
+- `python3 tools/research_wiki.py add-edge wiki/ ...` — 添加 graph edge
+- `python3 tools/research_wiki.py log wiki/ "<message>"` — 追加日志
+- `python3 tools/fetch_s2.py search "<title>"` — BibTeX fallback（S2 搜索）
+
+### MCP Servers
+- 无（survey 不需要 Review LLM，可通过 /review --focus writing 单独审查）
+
+### Qoder Native
+- `Read` — 读取 wiki 页面
+- `Glob` — 查找 ideas、methods、concepts、topics、papers
+- `WebFetch` — DBLP / CrossRef BibTeX 获取（仅 --format latex）
+
+### Shared References
+- `.qoder/skills/shared-references/academic-writing.md` — Related Work 写作规则 + de-AI polish
+- `.qoder/skills/shared-references/citation-verification.md` — BibTeX 获取和 [UNCONFIRMED] 协议
+
+### Called by
+- `/paper-draft` Step 3（Related Work section 可委托此 skill）
+- 用户手动调用

--- a/.qoder/skills/visualize/SKILL.md
+++ b/.qoder/skills/visualize/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: visualize
+description: 生成并更新可视化产物 —— Obsidian 图谱配置与 Canvas 知识地图。交互式网页图谱视图位于 SPA 的 app/modules/graph.js（由 tools/serve.py 提供服务）。
+---
+
+# /visualize
+
+> **用法**：`[--obsidian] [--canvas] [--focus <node_id>] [--depth N] [--types <page-type,...>] [--edge-types <edge-type,...>] [--all]`
+
+
+> 为 OmegaWiki 知识图谱生成可视化产物。
+> 产出 Obsidian 图谱配置（按实体类型分色组）以及带类型标签边的精选 Canvas 视图。
+> 交互式网页探索请使用 SPA 的 Graph 视图（先跑 `tools/serve.py`，然后访问 `#/graph`）。
+
+## Inputs
+
+- `--obsidian`（可选）：生成或更新 `.obsidian/graph.json`，按实体类型分色组
+- `--canvas`（可选）：基于图谱数据生成 Obsidian Canvas（`.canvas`），边带类型标签
+- `--focus <node_id>`（可选）：把 Canvas 聚焦到某个具体节点（例如 `methods/my-method`）
+- `--depth N`（可选）：聚焦 Canvas 的 BFS 深度（默认：2）
+- `--types <list>`（可选）：把节点过滤到这些 page type，逗号分隔（例如 `papers,concepts`）
+- `--edge-types <list>`（可选）：把边过滤到这些语义类型，逗号分隔（例如 `builds_on,challenges`）
+- `--all`（可选，没传任何 flag 时即默认）：生成全部可视化产物
+
+## Outputs
+
+- `wiki/.obsidian/graph.json` —— Obsidian 图谱颜色配置（按实体类型分色组）
+- `wiki/.obsidian/app.json` —— Obsidian 应用设置（仅当不存在时才创建）
+- `wiki/canvases/knowledge-map.canvas` —— 完整知识地图 Canvas，边带标签
+- `wiki/canvases/idea-evidence.canvas` —— 以 idea 为中心的子图 Canvas
+- `wiki/canvases/focus-{node-id}.canvas` —— 聚焦 Canvas（使用 `--focus` 时）
+- 终端输出：Obsidian 插件推荐与设置说明
+
+独立 HTML 探索器（`wiki/graph-view.html`）已停产；同样的用法由 SPA Graph 视图（`app/modules/graph.js`，由 `tools/serve.py` 提供服务）覆盖，且与前端其余部分共用同一份代码库。
+
+## Wiki Interaction
+
+### Reads
+
+- `wiki/graph/edges.jsonl` —— 带类型的语义边
+- `wiki/graph/citations.jsonl` —— 论文引用
+- `wiki/*/` —— 全部 entity 目录的 frontmatter
+- `config/visualize.json` —— 颜色调色板与可视化偏好
+
+### Writes
+
+- `wiki/.obsidian/graph.json` —— CREATE/OVERWRITE（本地产物，已 gitignore；每次都从 `config/visualize.json` 重生成）
+- `wiki/.obsidian/app.json` —— 仅在不存在时 CREATE（不覆盖用户自定义；已 gitignore）
+- `wiki/canvases/*.canvas` —— CREATE/OVERWRITE（本地产物，已 gitignore）
+
+## Workflow
+
+**前置条件**：确认当前工作目录是 wiki 项目根（包含 `wiki/`、`raw/`、`tools/`）。
+设 `WIKI_ROOT=wiki/`。
+
+### Step 0: 确认图谱数据存在
+
+检查 `wiki/graph/edges.jsonl` 存在且非空。若为空，提示尚无图谱数据，建议先运行 `/ingest`。
+
+### Step 1: 生成 Obsidian 配置（`--obsidian` 或 `--all`）
+
+```bash
+python3 tools/visualize.py generate-obsidian-config wiki/
+```
+
+创建 `.obsidian/graph.json`，包含 9 类实体的色组，使用 `path:{entity_type}` 形式的查询。
+`.obsidian/app.json` 仅在不存在时才创建。
+
+### Step 2: 生成 Canvas 视图（`--canvas` 或 `--all`）
+
+#### Step 2a —— 完整知识地图
+
+```bash
+python3 tools/visualize.py generate-canvas wiki/
+```
+
+布局：力导（无固定中心）。节点先按 entity type 聚类初始化位置，然后用 spring–electron 模拟稳定下来。
+
+#### Step 2b —— 聚焦 Canvas
+
+**生成前先决定 focus 节点：**
+
+1. 若用户显式传了 `--focus <node_id>`，直接使用，跳过下面步骤。
+2. 否则枚举 foundation 页：`ls wiki/foundations/*.md`（排除 `.gitkeep`）。
+   - **0 个**：跳过 Step 2b，不生成聚焦 Canvas，只输出 Step 2a 的完整知识地图。
+   - **1 个**：自动用该 foundation 作为 `--focus`（即 `foundations/<slug>`），打印选择，**不弹问**。
+   - **2 个及以上**：用 `AskUserQuestion` 让用户挑一个。每个 foundation 列为一个选项（label = `foundations/<slug>`，description = 该页 frontmatter 的 `title`）。把用户选的 slug 作为 `--focus`。
+
+然后生成：
+
+```bash
+python3 tools/visualize.py generate-canvas wiki/ --focus <node_id> --depth <N>
+```
+
+布局：径向同心圆。focus 节点位于画布中心；距离 focus BFS 距离 `d` 的节点落在第 `d` 环。每环内按 entity type 排序，同类节点在圆上聚团。
+
+**`--focus` BFS 逻辑**：从目标节点开始，在 `edges.jsonl` + `citations.jsonl` 上做广度优先搜索，收集 `--depth` 跳之内的全部节点和边。只渲染该邻域子图。若 `node_id` 找不到，中止并列出 5 个最相近的 slug 候选。
+
+Canvas 节点 schema：
+
+```json
+{
+  "id": "<slug>",
+  "type": "file",
+  "file": "<relative-path-to-md>",
+  "label": "<frontmatter title>",
+  "x": <int>,
+  "y": <int>,
+  "width": <int，papers 按 importance 缩放>,
+  "height": <int，papers 按 importance 缩放>,
+  "color": "<obsidian-color-id>"
+}
+```
+
+`label` 字段覆盖显示名；旧版 Obsidian 不支持时会 fallback 到文件名（slug）。width/height 基础尺寸按 entity type 决定；papers 按 importance 缩放（1→0.7×、2→0.85×、3→1.0×、4→1.2×、5→1.5×，缺失时默认 3）。
+
+Canvas 边 schema：
+
+```json
+{
+  "id": "<source>-<target>-<edge-type>",
+  "fromNode": "<slug>",
+  "toNode": "<slug>",
+  "label": "<edge-type>"
+}
+```
+
+若设置了 `--types`，丢弃不在列表里的节点，并丢弃 source 或 target 已被丢弃的边。
+若设置了 `--edge-types`，丢弃不在列表里的边。
+
+### Step 3: SPA Graph 视图（后台自动启动）
+
+之前的独立 HTML 探索器已停产。如需交互式网页探索，本 skill **自动**在后台启动 SPA 后端（`tools/serve.py`）—— 用户**不需要**手动跑 `python tools/serve.py`。
+
+**自动启动逻辑：**
+
+1. 探测 8765 端口，看服务是否已经在跑：
+
+   ```bash
+   python3 -c "import socket,sys; s=socket.socket(); s.settimeout(0.3); sys.exit(0 if s.connect_ex(('127.0.0.1',8765))==0 else 1)"
+   ```
+
+   退出码 `0` = 端口被占（服务已起 —— 跳过启动）。退出码 `1` = 端口空闲（需要启动）。
+
+2. 若端口空闲，用 **`Bash` tool 的 `run_in_background: true`** 后台启动（不要前台，前台会无限阻塞 skill）：
+
+   ```bash
+   python3 tools/serve.py
+   ```
+
+   不要用 `Agent` subagent 包裹 —— agent 不适合长跑服务，且 agent 返回时服务可能跟着挂掉。后台 `Bash` 进程归 Qoder 会话所有，活到会话结束。
+
+3. 把 URL 打印给用户：
+
+   ```
+   SPA Graph view: http://127.0.0.1:8765/#/graph
+   ```
+
+SPA Graph 视图（`app/modules/graph.js`）是真正的 ES module，包含与原单文件生成器一样的 Cytoscape + 力导向布局 + 过滤器 + BFS 搜索，并集成了双击跳转到 SPA Reader 视图的能力。`/visualize` 不再重新生成 `wiki/graph-view.html`。
+
+### Step 4: 打印推荐
+
+```bash
+python3 tools/visualize.py list-recommendations
+```
+
+打印推荐的 Obsidian 插件（Graph Analysis、Dataview、Excalidraw）以及配置说明。
+
+### Step 5: 日志
+
+```bash
+python3 tools/research_wiki.py log wiki/ "visualize | generated: [产物列表]"
+```
+
+标准日志格式：
+
+```markdown
+## [YYYY-MM-DD] /visualize | <format> — <n> nodes, <m> edges<focus-note>
+```
+
+`<focus-note>` 在使用 `--focus` 时为 ` (focus: <node_id>, depth <N>)`，否则为空。
+
+## Color Palette
+
+### 节点颜色（按 page_type）
+
+| page_type     | HTML hex  | Obsidian color ID |
+| ------------- | --------- | ----------------- |
+| `papers`      | `#4C9BE8` | `"1"`             |
+| `concepts`    | `#F4A261` | `"2"`             |
+| `topics`      | `#2A9D8F` | `"3"`             |
+| `people`      | `#E76F51` | `"4"`             |
+| `ideas`       | `#A8DADC` | `"5"`             |
+| `experiments` | `#9B5DE5` | `"6"`             |
+| `methods`     | `#84CC16` | `"3"`             |
+| `Summary`     | `#90BE6D` | `"4"`             |
+| `foundations` | `#B5B5B5` | `"6"`             |
+
+### 边颜色（HTML 模式，按语义类别）
+
+| 类别        | 类型                                                                  | Hex       |
+| ----------- | --------------------------------------------------------------------- | --------- |
+| 相似        | `same_problem_as`、`similar_method_to`                                | `#ADB5BD` |
+| 谱系        | `builds_on`、`extends_concept`、`derived_from`、`inspired_by`         | `#4C9BE8` |
+| 比较        | `challenges`、`critiques_concept`                                     | `#E76F51` |
+| 概念使用    | `introduces_concept`、`uses_concept`                                  | `#F4A261` |
+| 证据        | `supports`、`contradicts`、`tested_by`、`invalidates`                 | `#9B5DE5` |
+| Gap         | `addresses_gap`                                                       | `#F9C74F` |
+| Citation    | `cites`                                                               | `#B5B5B5` |
+
+## Constraints
+
+- 不要手动改 `wiki/graph/` —— 只读
+- `config/visualize.json` 是用户拥有的 —— 不要覆盖
+- `.obsidian/app.json` 仅在缺失时创建（尊重用户自定义）
+- Canvas 文件每次运行重生成（幂等覆盖）
+- 不依赖外部 Python 包（仅用 stdlib）
+- `wiki/.obsidian/` 与 `wiki/canvases/` 都是已 gitignore 的本地产物；source of truth 是 `config/visualize.json` + `wiki/graph/`。`/init` Step 6 与直接调用 `/visualize` 都会幂等地重生成它们 —— 永远不要 commit 它们。
+
+## Error Handling
+
+- **没有图谱数据**：提醒用户先跑 `/ingest` 建立知识库
+- **`config/visualize.json` 缺失**：报错，文件应当存在于 `config/visualize.json`
+- **`--focus` 节点找不到**：中止并打印 `Error: node "<node_id>" not found`；列出 5 个最相近的 slug 候选
+- **过滤后没有节点**：中止并汇总当前过滤器与可用类型
+- **Canvas 节点超过 500 个**：警告大型 Canvas 可能很慢；建议用 `--focus` 或 `--types` 缩小范围
+- **entity 目录缺失**：静默跳过，只处理存在的目录
+- **JSONL 行格式不正确**：静默跳过，继续处理后续行
+- **`wiki/canvases/` 不存在**：写入前先创建目录
+
+## Dependencies
+
+### Tools（via Bash）
+
+- `python3 tools/visualize.py generate-obsidian-config wiki/` —— Obsidian 配置
+- `python3 tools/visualize.py generate-canvas wiki/ [--focus <node_id>] [--depth N]` —— Canvas 生成
+- `python3 tools/visualize.py list-recommendations` —— 插件推荐
+- `python3 tools/research_wiki.py log wiki/ "<message>"` —— 追加日志
+- `python3 tools/serve.py` —— 本地 SPA 服务器（Graph 视图位于 `#/graph`）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AutoSci — 运行时契约（Qoder 版）
+
+编辑 `i18n/zh/AGENTS.md`,不要改根目录下的副本。运行 `setup-qoder.sh --lang zh`(或 `setup-qoder.ps1`)同步。
+
+## 仓库布局
+
+- `wiki/` — 产物面。`index.md` 是目录;`log.md` 是 append-only;每类实体一个子目录;`wiki/graph/` 自动生成。
+- `runtime/` — 契约源(schema + policy + templates)。修改任何规则前先读 `runtime/CLAUDE.md`。
+- `raw/` — 用户自有 `{papers,notes,web}/`(只读)+ skill 可写的 `discovered/`、`tmp/`。
+- `tools/` — Python 助手(`research_wiki.py` 是 wiki 引擎,`lint.py` 是校验器)。
+- `.qoder/skills/` — 由 `tools/convert_to_qoder.py` 从 `i18n/zh/skills` 生成的 Qoder 原生 skills。不要手改;改 i18n 源后重跑 setup。
+
+完整目录树:`docs/runtime-directory-structure.zh.md`。
+
+## 链接语法
+
+Wikilink:`[[slug]]`。slug 全小写、连字符分隔、无空格。
+
+## Skill 调用约定（Qoder）
+
+- Skill 位于 `.qoder/skills/<name>/SKILL.md`。文档中的 `/init`、`/ingest` 等写法表示"调用 skill `init`"、"调用 skill `ingest`" —— 按该 skill 的 `SKILL.md` 工作流逐步执行。
+- 当一个 skill 把任务委托给另一个 skill(如 `/init` Step 5 扇出到 `/ingest`)时,为每个工作单元启动一个 Qoder 子代理(Agent 工具),把被委托 skill 的指令和输入交给它。
+- 并行扇出使用 Qoder 子代理;`.qoder/skills/init/references/parallel-ingest.md` 中的 git worktree 隔离契约保持不变。子代理 prompt 必须用相对路径,且子代理的工作目录必须是 worktree 路径。
+- `llm-review` MCP server 的工具写作 `llm-review.chat`、`llm-review.chat-reply`、`llm-review.web_search`。使用 `/review`、`/rebuttal` 等之前,先从 `.qoder/mcp.json`(或 Qoder 的 MCP 设置)注册该 server。
+- 长跑服务(如 `tools/serve.py`)以后台 Bash 进程运行,归 Qoder 会话所有;不要用子代理包裹。
+
+## 硬规则
+
+1. `raw/{papers,notes,web}` 归用户所有,只读。skill 只能向 `raw/discovered/` 或 `raw/tmp/` 追加。
+2. `wiki/graph/` 是派生态。仅通过 `tools/research_wiki.py`(`add-edge`、`add-citation`、`rebuild-*`)修改。
+3. `wiki/log.md` 是 append-only。绝不就地重写。
+4. 写正向链接 → 同步写反向链接。完整规则在 `runtime/schema/xref.yaml`。
+5. 用户面 skill 参数(记录在 skill 的 **Usage** 行中的 flag)归用户所有。不得仅根据仓库状态擅自补出、翻转或删除它们。用户未提供时,只有 skill 文档化了省略行为才用默认值;否则询问用户。
+
+## 查阅索引
+
+| 需要 | 去哪 |
+|---|---|
+| 页面 frontmatter 字段、enum、默认值、生命周期 | `runtime/schema/entities.yaml` |
+| 页面正文章节结构                                | `runtime/templates/{kind}.md.tmpl` |
+| 边类型、属性、方向、confidence                | `runtime/schema/edges.yaml` |
+| 正向 → 反向链接规则                            | `runtime/schema/xref.yaml` |
+| slug 规则、ownership、edge 存储位置            | `runtime/schema/conventions.yaml` |
+| 各 skill 对字段/边的写权限                     | `runtime/policy/writers.yaml` |
+| 改契约本身 / 重新 regen                        | `runtime/CLAUDE.md` |
+
+## Python 环境
+
+按优先级:`.venv/bin/python`(Windows 上 `.venv/Scripts/python.exe`)→ 当前激活的 conda 环境 → `python3`(Windows 上 `python`)。tools/ 通过 `tools/_env.py` 自动从 `~/.env` 和项目根 `.env` 加载 API key。

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Claude Code](https://img.shields.io/badge/main-Claude_Code_stable-d97706.svg)](https://docs.anthropic.com/en/docs/claude-code)
 [![Codex Preview](https://img.shields.io/badge/Codex-preview-111111.svg)](https://developers.openai.com/codex)
 [![OpenCode Preview](https://img.shields.io/badge/OpenCode-preview-6f42c1.svg)](https://opencode.ai/)
+[![Qoder Preview](https://img.shields.io/badge/Qoder-preview-00c4cc.svg)](https://qoder.com)
 [![arXiv](https://img.shields.io/badge/arXiv-2605.31468-b31b1b.svg)](https://arxiv.org/abs/2605.31468)
 [![Status](https://img.shields.io/badge/status-internal_beta-orange.svg)](#️⃣-status--update)
 
@@ -72,6 +73,30 @@ Current boundary:
 | Daily arXiv | CI is recommendation-only; no repository writeback or unattended ingest |
 
 See [docs/codex-preview.md](docs/codex-preview.md) for the preview notes and known boundaries.
+
+### Qoder Preview
+
+Try the Qoder adaptation on this branch:
+
+```bash
+git clone -b autosci-qoder https://github.com/skyllwt/AutoSci.git
+cd AutoSci
+./setup-qoder.sh --lang zh        # or: powershell -ExecutionPolicy Bypass -File .\setup-qoder.ps1 -Lang zh
+# Open the folder in Qoder, then ask Qoder to run the `init` skill for your research topic.
+```
+
+Current boundary:
+
+| Area | Status |
+|---|---|
+| Local Qoder skills | Preview supported via generated `.qoder/skills` (`tools/convert_to_qoder.py`) |
+| Runtime instructions | Root `AGENTS.md`, generated from the selected language (`i18n/<lang>/AGENTS.md`) |
+| Shared skill source | `i18n/<lang>/skills` remains the bilingual source of truth |
+| Review LLM | Local `llm-review` MCP configured through generated `.qoder/mcp.json` (example in `config/mcp.qoder.json.example`) |
+| Parallel ingest fan-out | Qoder subagents (Agent tool) with the same git-worktree isolation contract |
+| Daily arXiv | Recommendation-only; standalone OpenAI-compatible API with deterministic fallback and optional email |
+
+The Qoder preview does not replace the Claude Code stable release, the Codex Preview, or the OpenCode Preview.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,206 +2,34 @@
 
 <img src="assets/autosci-logo.png" width="160" alt="AutoSci Logo">
 
-# AutoSci
+# AutoSci-Qoder
 
-**Read, think, experiment, write, evolve — the AI research agent with memory that compounds across every project.**
+**读文献、想点子、跑实验、写论文、持续进化 —— 面向 Qoder 的 AI 科研智能体，记忆跨项目复利积累。**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/Python-3.9+-yellow.svg)](https://www.python.org/)
-[![Claude Code](https://img.shields.io/badge/main-Claude_Code_stable-d97706.svg)](https://docs.anthropic.com/en/docs/claude-code)
-[![Codex Preview](https://img.shields.io/badge/Codex-preview-111111.svg)](https://developers.openai.com/codex)
-[![OpenCode Preview](https://img.shields.io/badge/OpenCode-preview-6f42c1.svg)](https://opencode.ai/)
-[![Qoder Preview](https://img.shields.io/badge/Qoder-preview-00c4cc.svg)](https://qoder.com)
+[![Qoder](https://img.shields.io/badge/runtime-Qoder-00c4cc.svg)](https://qoder.com)
 [![arXiv](https://img.shields.io/badge/arXiv-2605.31468-b31b1b.svg)](https://arxiv.org/abs/2605.31468)
-[![Status](https://img.shields.io/badge/status-internal_beta-orange.svg)](#️⃣-status--update)
-
 
 </div>
 
 ---
 
-## ⚠️ Status & Update
+## 项目简介
 
-> **Thanks to everyone who's been trying AutoSci — the community response has been amazing!** AutoSci evolved from our earlier OmegaWiki prototype into what we're building toward: a next-generation research agent that can handle the full scientific lifecycle. We're actively testing and iterating on new features, and more capabilities are on the way. Jump in, break things, and tell us what you think — your feedback and ideas are what's shaping where this goes next. 🙏
+本仓库是 [AutoSci](https://github.com/skyllwt/AutoSci)（上游稳定版基于 Claude Code）的 **Qoder 适配版**。AutoSci 是一个以记忆为中心的科研智能体系统，覆盖从文献消化到 rebuttal 的完整科研生命周期，并在项目之间保持结构化持久记忆。
 
-> **🌿 Which branch?** [`main`](https://github.com/skyllwt/AutoSci/tree/main) remains the **stable Claude Code version**. [`autosci-codex`](https://github.com/skyllwt/AutoSci/tree/autosci-codex) is the **official Codex Preview**, and [`autosci-opencode`](https://github.com/skyllwt/AutoSci/tree/autosci-opencode) is the **official OpenCode Preview**. These are separate runtime adaptations; the existing Claude Code and Codex versions remain available. The **full system described in our [paper](https://arxiv.org/abs/2605.31468)** — SciMem · SciFlow · SciDAG · SciEvolve — lives on the [`paper`](https://github.com/skyllwt/AutoSci/tree/paper) branch (frozen as tag [`arxiv-v1`](https://github.com/skyllwt/AutoSci/tree/arxiv-v1)).
+适配原则：**不改动上游的科研逻辑**。全部 28 个 skill、Python 工具链（`tools/`）、wiki 契约（`runtime/`）保持原样，仅将运行时载体从 Claude Code 替换为 Qoder：
 
-### OpenCode Preview
-
-Try the OpenCode adaptation without changing your Claude Code or Codex checkout:
-
-```bash
-git clone -b autosci-opencode https://github.com/skyllwt/AutoSci.git
-cd AutoSci
-./setup.sh --lang en
-opencode
-# Then ask OpenCode to run the init skill for your research topic.
-```
-
-Current boundary:
-
-| Area | Status |
+| 上游（Claude Code） | 本仓库（Qoder） |
 |---|---|
-| Local OpenCode skills | Preview supported via generated `.opencode/skills` |
-| Runtime instructions | Root `AGENTS.md`, generated from the selected language |
-| Shared skill source | `i18n/<lang>/skills` remains the bilingual source of truth |
-| Review LLM | Local `llm-review` MCP configured through generated `opencode.json` |
-| Daily arXiv | Recommendation-only; standalone OpenAI-compatible API with deterministic fallback and optional email |
+| `.claude/skills/` | `.qoder/skills/`（由 `tools/convert_to_qoder.py` 自动生成） |
+| `CLAUDE.md` 运行时契约 | `AGENTS.md`（Qoder 自动读取） |
+| `.mcp.json` | `.qoder/mcp.json`（llm-review MCP server） |
+| `/setup`、`/init` 等斜杠命令 | 按 skill 名称调用（如让 Qoder 运行 `init` skill） |
+| Claude Code 子代理并行 ingest | Qoder 子代理（Agent 工具）+ 同一套 git worktree 隔离契约 |
 
-The OpenCode preview does not replace the Claude Code stable release or the Codex Preview.
-
-### Codex Preview
-
-Try the Codex preview without changing your `main` checkout:
-
-```bash
-git clone -b autosci-codex https://github.com/skyllwt/AutoSci.git
-cd AutoSci
-./setup.sh --lang en
-codex
-# Then invoke: $init [your-research-topic]
-```
-
-Current boundary:
-
-| Area | Status |
-|---|---|
-| Local Codex skills | Preview supported via `.agents/skills` |
-| Runtime scope | Codex-only; Claude Code remains available separately on `main` |
-| Shared skill source | `i18n/<lang>/skills` regenerates the active `.agents/skills` tree |
-| Review LLM | Optional `llm-review` MCP configured through the Codex config example |
-| Daily arXiv | CI is recommendation-only; no repository writeback or unattended ingest |
-
-See [docs/codex-preview.md](docs/codex-preview.md) for the preview notes and known boundaries.
-
-### Qoder Preview
-
-Try the Qoder adaptation on this branch:
-
-```bash
-git clone -b autosci-qoder https://github.com/skyllwt/AutoSci.git
-cd AutoSci
-./setup-qoder.sh --lang zh        # or: powershell -ExecutionPolicy Bypass -File .\setup-qoder.ps1 -Lang zh
-# Open the folder in Qoder, then ask Qoder to run the `init` skill for your research topic.
-```
-
-Current boundary:
-
-| Area | Status |
-|---|---|
-| Local Qoder skills | Preview supported via generated `.qoder/skills` (`tools/convert_to_qoder.py`) |
-| Runtime instructions | Root `AGENTS.md`, generated from the selected language (`i18n/<lang>/AGENTS.md`) |
-| Shared skill source | `i18n/<lang>/skills` remains the bilingual source of truth |
-| Review LLM | Local `llm-review` MCP configured through generated `.qoder/mcp.json` (example in `config/mcp.qoder.json.example`) |
-| Parallel ingest fan-out | Qoder subagents (Agent tool) with the same git-worktree isolation contract |
-| Daily arXiv | Recommendation-only; standalone OpenAI-compatible API with deterministic fallback and optional email |
-
-The Qoder preview does not replace the Claude Code stable release, the Codex Preview, or the OpenCode Preview.
-
----
-
-## 📄 Paper
-
-> ### [AutoSci: A Memory-Centric Agentic System for the Full Scientific Research Lifecycle](https://arxiv.org/abs/2605.31468)
->
-> [![arXiv](https://img.shields.io/badge/arXiv-2605.31468-b31b1b.svg)](https://arxiv.org/abs/2605.31468) &nbsp;·&nbsp; [📄 **Read on arXiv →**](https://arxiv.org/abs/2605.31468)
-
-If you find AutoSci useful in your research, please [cite our paper](#citation).
-
----
-
-## 📌 Poster & Demo
-
-<!--
-  POSTER & VIDEO PLACEHOLDER
-  Drop your files into assets/ and uncomment the blocks below:
-    - Conference poster image  -> assets/poster.png   (or .jpg/.pdf)
-    - Demo video               -> a YouTube/Bilibili link, or assets/demo.mp4 / assets/demo.gif
-  GitHub READMEs cannot embed/play local .mp4 inline; for video, prefer either:
-    (a) a clickable thumbnail linking to the hosted video, or
-    (b) a short looping assets/demo.gif.
--->
-
-<div align="center">
-  <a href="assets/poster.png"><img src="assets/poster.png" width="760" alt="AutoSci conference poster"></a>
-  <br/><sub><em>AutoSci poster — click to view full size.</em></sub>
-</div>
-
-<!-- DEMO VIDEO (uncomment and replace links/thumbnail once available)
-<div align="center">
-  <a href="https://your-video-url">
-    <img src="assets/demo-thumbnail.png" width="640" alt="Watch the AutoSci demo">
-  </a>
-  <br/><sub><em>▶ Watch the AutoSci walkthrough.</em></sub>
-</div>
--->
-
-<div align="center">
-  <a href="https://www.bilibili.com/video/BV19gVg6pEk6/">
-    <img src="assets/demo-thumbnail.jpg" width="640" alt="▶ Watch AutoSci on Bilibili">
-  </a>
-  <br/><sub><em>▶ Watch the AutoSci demo on Bilibili</em></sub>
-</div>
-
----
-
-## 🆕 What's New
-
-### 🛠️ 2026-07-12 · OpenCode Preview adaptation
-
-Published a separate OpenCode adaptation while keeping the existing Claude Code stable release and Codex Preview available. The OpenCode branch provides bilingual project skills under `.opencode/skills`, root `AGENTS.md` instructions, generated machine-local configuration, and `llm-review` MCP integration. Its daily-arXiv automation is recommendation-only and uses a standalone OpenAI-compatible API with deterministic fallback, optional best-effort email, and digest artifacts without repository writeback.
-
-### 🛠️ 2026-07-10 · autosci-codex branch adaptation
-
-Published a separate Codex-only adaptation while keeping the stable Claude Code release on `main` and the OpenCode Preview on `autosci-opencode`. The Codex branch provides bilingual skills under `.agents/skills`, root `AGENTS.md` instructions, Codex-specific setup and Review LLM configuration, and recommendation-only daily-arXiv CI without Claude Action authentication, automatic ingest, or repository writeback. The `$research` workflow delegates cold-wiki bootstrap to `$init` and proceeds only after bootstrap completes.
-
-### 🛠️ 2026-05-19 · Experiment Overhaul
-
-A possible usage process：`/ideate [research-direction-or-topic]`(You can use `--skip-pilot` to decide whether to conduct preliminary experiments) -> `/exp-design <idea-slug>`-> For each experimental block,recommended flow: `/exp-run <slug> [--env local|remote]` to deploy → `/exp-status` to monitor → `/exp-run <slug> --collect` to collect.->`/exp-eval <experiment-slug>`
-
-✨ : New Skills
-`/exp-pilot-run` — Pilot experiment execution: write code, deploy, monitor, collect raw results.
-`/exp-pilot-eval` — Pilot result evaluation: read results, apply lenient verdict logic
-These two skills are built into Phase5 of `/ideate`
-🛠️ : Modified Skills
-`/ideate`
-5 structured generation paths (A-E) for both Claude and Review LLM.
-Phase restructuring: Filter & Validation merged into Phase 3, Write Wiki moved to Phase 4.
-Phase 5: Finish pilot design and workflow invocation
-Your ideas will follow a clearer path, and a more reasonable screening mechanism will be established through pilot experiments.
-`/exp-design`
-A brand-new experimental design process:method candidate generation + 5 experiment block types + iterative ablation loop
-`/exp-run`
-Add the code decision gate, code optimization and config check
-
-### 🎨 2026-05-18 · /poster — drafted paper → print-ready conference poster
-
-Run the poster skill after paper-draft and paper-compile (`/poster` in Claude Code, `$poster` in Codex) to turn your finished draft into a self-contained 1400×900 HTML poster and a print-quality PNG. Figures, booktabs tables, and math macros are extracted automatically from your LaTeX source; the agent walks you through picking which figures land in which sections and customizing the header (venue, affiliation logo). Export to PDF from your browser's print dialog. Pipeline adapted from [PaperX](https://github.com/yutao1024/PaperX) ([arXiv:2602.03866](https://arxiv.org/abs/2602.03866)).
-
-<p align="center">
-  <img src="assets/poster_demo_tikz_tables.png" alt="Example /poster output" width="720" />
-</p>
-
-### 🎯 2026-05-12 · /discover from a venue — "what should I read first from ICLR 2024?"
-
-Use `/discover --venue iclr --year 2024` in Claude Code or `$discover --venue iclr --year 2024` in Codex (or any conference/year) and get a personalized shortlist of papers from that venue, ranked by relevance to what's already in your wiki. Instead of scrolling a 7000-paper proceedings, you see the dozen that actually matter for your research direction, each with a rationale tied to topics and methods you already track. No new API keys, no ingest side-effects on your wiki — just a ranked reading list. Supports NeurIPS, ICLR, ICML, and other venues covered by [Paper Copilot](https://github.com/papercopilot/paperlists).
-
-### 📰 2026-05-09 · Daily arXiv — fresh-paper recommendations, on demand or scheduled
-
-Use `/daily-arxiv` in Claude Code or `$daily-arxiv` in Codex for a one-off pass. The GitHub Actions scheduler supports Codex CLI for unattended `inform` recommendations, with legacy Claude Code Action and Review LLM fallbacks; CI `auto-ingest` remains on the legacy Claude Action path until Codex writeback is separately verified. The skill builds an evidence packet from arXiv + Semantic Scholar + DeepXiv, lets the LLM rank candidates against your wiki interests, and delivers a digest by e-mail. Explicit `--mode auto-ingest` calls the ingest skill for high-confidence picks; `inform` mode just notifies.
-
-### 🌐 2026-05-06 · Knowledge Graph Visualization — browser + Obsidian
-
-Your research graph now has two ways to explore:
-
-- **Web UI** — run `python3 tools/serve.py`, open `http://localhost:8765/#/graph`. Click any node to highlight its neighborhood via BFS, filter by entity type or edge category, double-click to open the full page in the Reader.
-- **Obsidian** — run `/visualize --obsidian` to generate a color-coded graph config, or `/visualize --canvas` to produce a force-layout Canvas with labeled semantic edges.
-
----
-
-## What is AutoSci?
-
-Scientific research has traditionally been **human-intensive**: researchers coordinate literature, ideas, experiments, manuscripts, and review responses across long project cycles. **AutoSci** is a memory-centric agentic system that automates the full research lifecycle — from paper ingestion to rebuttal — while maintaining structured persistent memory across projects and improving its own procedures over time.
+> 📄 论文：[AutoSci: A Memory-Centric Agentic System for the Full Scientific Research Lifecycle](https://arxiv.org/abs/2605.31468)。若本系统对你的研究有帮助，请[引用论文](#引用)。
 
 <div align="center">
 <img src="assets/fig-overview.png" width="820" alt="AutoSci system overview">
@@ -209,352 +37,213 @@ Scientific research has traditionally been **human-intensive**: researchers coor
 
 ---
 
-## 🔬 Works Produced with AutoSci
+## 🚀 快速安装
 
-The following papers were generated end-to-end using AutoSci — from literature ingestion and idea generation to experiment execution and manuscript writing.
+**前置要求：** Python 3.9+（推荐 3.10+，DeepXiv 功能需要）、git、[Qoder](https://qoder.com)。
 
-| Paper | Domain | PDF |
-|-------|--------|-----|
-| Agent-driven iterative optimization of Triton GPU kernels | GPU kernel optimization | [📄 PDF](assets/papers/gpu-kernel-optimization.pdf) |
-| PTM-aware degrader target nomination via calibrated ternary-complex scoring | Biomedical drug discovery | [📄 PDF](assets/papers/protac-target-nomination.pdf) |
-| Forced Honesty Dissociates Polite Speech from Motivated Cognition in LLM Attitude Ratings | LLMs as cognitive models | [📄 PDF](assets/papers/llm-positivity-bias-cognitive-models.pdf) |
-
-**Have you used AutoSci in your own research?** We'd love to feature your work here — open a PR or drop us a message!
-
----
-
-## OpenCode Preview Quick Start
-
-**Prerequisites:** Python 3.9+, Node.js 18+, and OpenCode
-
-```bash
-# 1. Clone the OpenCode Preview branch
-git clone -b autosci-opencode https://github.com/skyllwt/AutoSci.git
-cd AutoSci
-
-# 2. Verify OpenCode
-opencode --version
-
-# 3. Generate the local environment, skills, AGENTS.md, and opencode.json
-chmod +x setup.sh && ./setup.sh --lang en
-
-# 4. Add your papers and optional notes
-#    raw/papers/  raw/notes/  raw/web/
-
-# 5. Start OpenCode and load the init skill
-opencode
-```
-
-The generated `.opencode/` tree and `opencode.json` are machine-local and should not be committed. The English and Chinese sources under `i18n/` remain authoritative.
-
----
-
-## Codex Preview Quick Start
-
-**Prerequisites:** Python 3.9+, Node.js 18+
-
-```bash
-# 1. Clone the Codex Preview branch
-git clone -b autosci-codex https://github.com/skyllwt/AutoSci.git
-cd AutoSci
-
-# 2. Install and sign in to Codex
-# Follow your Codex/OpenAI setup path, then verify:
-codex --version
-
-# 3. One-click setup
-chmod +x setup.sh && ./setup.sh        # Linux / macOS
-# Windows (PowerShell):
-#   powershell -ExecutionPolicy Bypass -File .\setup.ps1
-# setup creates .venv and syncs the Codex `.agents/skills` tree
-
-# 4. Put your own papers in raw/papers/ (.tex or .pdf)
-#    Optional: intent notes in raw/notes/, saved pages in raw/web/
-
-# 5. Build your research memory and start a project
-codex
-# Then invoke: $init [your-research-topic]
-```
-
-Claude Code users should use the stable `main` branch instead:
-
-```bash
-git clone -b main https://github.com/skyllwt/AutoSci.git
-cd AutoSci
-npm install -g @anthropic-ai/claude-code
-claude login
-claude
-# Then type: /init [your-research-topic]
-```
-
-<details>
-<summary><b>Manual setup (Linux / macOS)</b></summary>
-
-```bash
-python3 -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
-cp .env.example .env                 # Edit to add API keys
-mkdir -p .agents/skills/shared-references
-cp -R i18n/en/skills/. .agents/skills/
-cp i18n/en/shared-references/*.md .agents/skills/shared-references/
-mkdir -p .claude/skills/shared-references
-cp -R i18n/en/skills/. .claude/skills/
-cp i18n/en/shared-references/*.md .claude/skills/shared-references/
-cp config/settings.local.json.example .claude/settings.local.json  # Claude Code compatibility
-```
-
-</details>
-
-<details>
-<summary><b>Manual setup (Windows / PowerShell)</b></summary>
+### Windows（PowerShell）
 
 ```powershell
-python -m venv .venv
-.\.venv\Scripts\Activate.ps1
-pip install -r requirements.txt
-Copy-Item .env.example .env          # Edit to add API keys
-New-Item -ItemType Directory -Force .agents\skills\shared-references | Out-Null
-Copy-Item i18n\en\skills\* .agents\skills -Recurse -Force
-Copy-Item i18n\en\shared-references\*.md .agents\skills\shared-references -Force
-New-Item -ItemType Directory -Force .claude\skills\shared-references | Out-Null
-Copy-Item i18n\en\skills\* .claude\skills -Recurse -Force
-Copy-Item i18n\en\shared-references\*.md .claude\skills\shared-references -Force
-Copy-Item config\settings.local.json.example .claude\settings.local.json  # Claude Code compatibility
+# 1. 克隆本仓库
+git clone https://github.com/terryji-lab/AutoSci-Qoder.git
+cd AutoSci-Qoder
+
+# 2. 一键安装（中文 skills；英文用 -Lang en）
+powershell -ExecutionPolicy Bypass -File .\setup-qoder.ps1 -Lang zh
 ```
 
-Note: native Windows is supported for the local pipeline. Remote-GPU
-experiments via `/exp-run --env remote` rely on `ssh`/`rsync`/`screen`
-and are best run from WSL2 or Linux/macOS.
+脚本会自动完成：Python 环境检查 → 创建 `.venv` 并安装依赖 → 从模板生成 `.env` → 将 `i18n/zh/skills` 转换为 Qoder 原生 `.qoder/skills`（28 个 skill）→ 生成根目录 `AGENTS.md` 与 `.qoder/mcp.json` → 逐项验证安装。
 
-</details>
-
-### API Keys
-
-| Key | Required? | How to get | What it enables |
-|-----|-----------|-----------|-----------------|
-| Agent runtime auth | **Yes** | Claude Code: `claude login`; Codex: sign in through Codex | Powers the interactive coding-agent skills |
-| `OPENAI_API_KEY` or `CODEX_ACCESS_TOKEN` | Optional | OpenAI / Codex account | GitHub Actions Codex CLI recommender for daily-arxiv inform mode |
-| `ANTHROPIC_API_KEY` | Claude Code only (or use a third-party compatible API — see below) | `claude login` (automatic) | Powers Claude Code skills |
-| `CLAUDE_CODE_OAUTH_TOKEN` | Optional | `claude setup-token` | GitHub Actions legacy Claude Code auth for Pro/Max users and daily-arxiv auto-ingest |
-| `SEMANTIC_SCHOLAR_API_KEY` | Optional | [semanticscholar.org/product/api](https://www.semanticscholar.org/product/api) (free) | Citation graph, paper search |
-| `DEEPXIV_TOKEN` | Optional | `setup.sh` auto-registers | Semantic search, TLDR, trending |
-| `LLM_API_KEY` + `LLM_BASE_URL` + `LLM_MODEL` | Optional | Any OpenAI-compatible API | Cross-model review; `/daily-arxiv` inform recommendations |
-
-> **Don't have an Anthropic API key?** You can use Codex, or use Claude Code with any Anthropic-protocol-compatible provider — DeepSeek, Kimi, MiMo, GLM, and more. See the [LLM API Configuration](#llm-api-configuration--大模型-api-配置) section below for Claude Code provider snippets.
-
-> **Cross-model review**: AutoSci uses a second LLM as an independent reviewer for ideas, experiments, and paper drafts. Works with **any OpenAI-compatible API** — DeepSeek, OpenAI, Qwen, OpenRouter, SiliconFlow, etc. If not configured, skills still work in single-agent mode.
-
----
-
-## LLM API Configuration / 大模型 API 配置
-
-AutoSci runs on **Claude Code** or **Codex**. Claude Code speaks the **Anthropic API** protocol: you can use Claude directly, or route Claude Code to any third-party provider that exposes an Anthropic-compatible endpoint by overriding a few environment variables. Codex uses the Codex/OpenAI sign-in path and reads the repo skills from `.agents/skills`.
-
-AutoSci 支持 **Claude Code** 与 **Codex**。Claude Code 使用 **Anthropic API** 协议通信：你既可以直接使用 Claude, 也可以通过覆盖几个环境变量, 把 Claude Code 指向任意支持 Anthropic 协议的第三方供应商。Codex 使用 Codex/OpenAI 登录路径，并从 `.agents/skills` 读取 repo skills。
-
-### Option A — Native Claude / 原生 Claude
+### Linux / macOS
 
 ```bash
-claude login   # OAuth, no manual config / OAuth 登录,无需手动配置
+git clone https://github.com/terryji-lab/AutoSci-Qoder.git
+cd AutoSci-Qoder
+chmod +x setup-qoder.sh && ./setup-qoder.sh --lang zh
 ```
-
-### Option B — Third-party Anthropic-compatible API / 第三方 Anthropic 兼容 API
-
-Pick a provider below, paste the snippet into `~/.claude/settings.json` (or the project's `.claude/settings.json`), and replace the `<...>` placeholder with your own API key. Model names and extra options follow each provider's official Claude Code docs.
-
-从下方任选一个供应商,把对应配置粘贴到 `~/.claude/settings.json`(或项目的 `.claude/settings.json`),并把 `<...>` 占位符替换为你自己的 API key。模型名与额外选项均来自各供应商官方 Claude Code 文档。
-
-<details>
-<summary><b>MiMo / DeepSeek / Kimi / GLM 配置示例</b></summary>
-
-#### MiMo (小米)
-
-```json
-{
-  "env": {
-    "ANTHROPIC_BASE_URL": "https://api.xiaomimimo.com/anthropic",
-    "ANTHROPIC_AUTH_TOKEN": "<your-mimo-key>",
-    "ANTHROPIC_MODEL": "mimo-v2.5",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "mimo-v2.5",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "mimo-v2.5-pro",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "mimo-v2.5"
-  }
-}
-```
-
-#### DeepSeek
-
-```json
-{
-  "env": {
-    "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
-    "ANTHROPIC_AUTH_TOKEN": "<your-deepseek-key>",
-    "ANTHROPIC_MODEL": "deepseek-v4-pro[1m]",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-v4-pro[1m]",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro[1m]",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-flash",
-    "CLAUDE_CODE_SUBAGENT_MODEL": "deepseek-v4-flash",
-    "CLAUDE_CODE_EFFORT_LEVEL": "max"
-  }
-}
-```
-
-#### Kimi (Moonshot)
-
-```json
-{
-  "env": {
-    "ANTHROPIC_BASE_URL": "https://api.moonshot.ai/anthropic",
-    "ANTHROPIC_AUTH_TOKEN": "<your-moonshot-key>",
-    "ANTHROPIC_MODEL": "kimi-k2.5",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "kimi-k2.5",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "kimi-k2.5",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "kimi-k2.5",
-    "CLAUDE_CODE_SUBAGENT_MODEL": "kimi-k2.5",
-    "ENABLE_TOOL_SEARCH": "false"
-  }
-}
-```
-
-#### GLM (Z.AI)
-
-```json
-{
-  "env": {
-    "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
-    "ANTHROPIC_AUTH_TOKEN": "<your-zai-key>",
-    "API_TIMEOUT_MS": "3000000"
-  }
-}
-```
-
-> Z.AI applies a default server-side model mapping, so no explicit `ANTHROPIC_MODEL` is needed.
-> Z.AI 默认在服务端做模型映射,无需显式设置 `ANTHROPIC_MODEL`。
-
-</details>
-
-**Skip the Claude Code onboarding** / **跳过 Claude Code 初始引导**: when using a third-party key, create or edit `.claude.json` (`~/.claude.json` on macOS/Linux) and add `{ "hasCompletedOnboarding": true }`.
 
 ---
 
-## Skills
+## ⚙️ 安装后配置
 
-AutoSci ships with 30+ agent skills spanning the full research lifecycle.
+### 1. 用 Qoder 打开项目
 
-- Claude Code: invoke skills as slash commands, for example `/init`.
-- Codex: invoke skills with `$skill-name` or from `/skills`, for example `$init`.
+直接用 Qoder 打开项目根目录。根目录的 `AGENTS.md`（运行时契约）和 `.qoder/skills/`（项目级 skills）会被自动加载。
+
+### 2. 注册 llm-review MCP server（可选但推荐）
+
+`/review`、`/rebuttal`、`/novelty` 等跨模型评审功能依赖本地 `llm-review` MCP server。安装脚本已生成 `.qoder/mcp.json`（来自 `config/mcp.qoder.json.example`）：
+
+```json
+{
+  "mcpServers": {
+    "llm-review": {
+      "command": ".venv/Scripts/python.exe",
+      "args": ["mcp-servers/llm-review/server.py"],
+      "cwd": "${workspaceFolder}"
+    }
+  }
+}
+```
+
+若 Qoder 未自动识别该文件，请在 Qoder 的 MCP 设置中手动添加（Linux/macOS 把 command 改为 `.venv/bin/python`）。不配置也能用，相关 skill 会降级为单模型自审模式。
+
+### 3. 配置 API key
+
+在 Qoder 中让它运行 **`setup` skill**，会交互式引导你配置（全部可选，可随时重跑补充）：
+
+| Key | 建议 | 作用 |
+|-----|------|------|
+| `SEMANTIC_SCHOLAR_API_KEY` | **推荐**（免费） | 引用图谱与论文检索；不配置时 `/init` 速度慢约 3 倍 |
+| `DEEPXIV_TOKEN` | 可选 | 语义检索、TLDR 摘要、热门论文检测（可在 setup 中一键自动注册） |
+| `LLM_API_KEY` + `LLM_BASE_URL` + `LLM_MODEL` | 可选 | 跨模型独立评审（任何 OpenAI 兼容 API：DeepSeek、OpenAI、Qwen、OpenRouter、SiliconFlow 等） |
+
+> Qoder 自身的模型与登录由 Qoder 管理，不需要额外的 agent runtime key。
+
+### 4. 放入你的素材（可选）
+
+- `raw/papers/` — 你自己的论文（`.tex` 或 `.pdf`）
+- `raw/notes/` — 研究意图笔记
+- `raw/web/` — 网页存档
+
+---
+
+## 🧭 使用流程
+
+在 Qoder 对话框中**按名称调用 skill** 即可（文档中的 `/init`、`/ingest` 等写法均表示"调用 skill `init`"）。典型科研流程：
+
+```text
+1. setup       — 配置 API key（一次性）
+2. init <研究主题>  — 消化你的论文 + 自动发现 8-10 篇相关文献，构建 wiki 知识库
+3. ask / check — 向知识库提问 / 体检
+4. ideate      — 生成并筛选研究点子（含预实验试点）
+5. exp-design → exp-run → exp-eval — 实验设计、执行、裁决
+6. paper-plan → paper-draft → paper-compile — 论文大纲、起草、编译 PDF
+7. review / rebuttal / poster — 评审、答辩、学术海报
+```
+
+日常补充文献：`ingest`（单篇，本地路径或 arXiv 链接）、`discover`（候选清单）、`daily-arxiv`（每日推荐）。
 
 <details>
-<summary><b>View all skills</b></summary>
+<summary><b>全部 28 个 skill 一览</b></summary>
 
-Each skill has the same name in both runtimes. Use the Claude Code slash form
-inside Claude Code, and the Codex dollar form inside Codex or select the skill
-from Codex `/skills`.
+### 阶段 0：配置
+| Skill | 作用 |
+|-------|------|
+| setup | 交互式 API key 配置引导（Semantic Scholar、DeepXiv、Review LLM） |
+| reset | 按范围（`wiki / raw / log / checkpoints / all`）重置 wiki 状态 |
 
-### Phase 0: Setup
-| Skill | Claude Code | Codex | What it does |
-|-------|-------------|-------|-------------|
-| setup | `/setup` | `$setup` | Interactive API key configuration — checks `.env` state and walks through Semantic Scholar, DeepXiv, and Review LLM setup |
-| reset | `/reset` | `$reset` | Destructive cleanup — reset wiki state to a clean scaffold by scope (`wiki / raw / log / checkpoints / all`) |
+### 阶段 1：知识库
+| Skill | 作用 |
+|-------|------|
+| prefill | 预填充领域基础知识，避免后续 ingest 重复创建教科书概念页 |
+| init | 从 `raw/` 素材引导构建 wiki，可选外部发现，并行消化最终论文集 |
+| ingest | 消化一篇论文（本地路径或 arXiv URL），建立全部交叉引用与图边 |
+| discover | 构建候选论文排序清单（锚点/主题/会议/w 状态驱动），不入库 |
+| edit | 按用户请求增删原始素材或更新 wiki 内容 |
+| ask | 向 wiki 提问，综合检索相关页面作答，好答案可沉淀回 wiki |
+| check | 全库健康扫描，生成分级修复建议报告 |
 
-### Phase 1: Knowledge Base
-| Skill | Claude Code | Codex | What it does |
-|-------|-------------|-------|-------------|
-| prefill | `/prefill` | `$prefill` | Seed `wiki/foundations/` with domain background so later ingest runs do not create duplicate concept pages for textbook material |
-| init | `/init` | `$init` | Bootstrap the wiki from your source files, with optional discovery, then ingest the final paper set serially by default, with optional parallel worktree mode |
-| ingest | `/ingest` | `$ingest` | Ingest a paper (local path or arXiv URL) — creates pages and builds all cross-references and graph edges |
-| discover | `/discover` | `$discover` | Build a ranked shortlist of candidate papers (anchor-driven, topic-driven, venue-filtered, or from wiki state) without ingesting |
-| edit | `/edit` | `$edit` | Add or remove raw sources, or update wiki content, per user request |
-| ask | `/ask` | `$ask` | Ask the wiki a question — retrieve and synthesize relevant pages, optionally crystallize the answer back into the wiki |
-| check | `/check` | `$check` | Scan the full wiki to detect health issues and produce a tiered fix-recommendation report |
+### 阶段 2：创意与实验
+| Skill | 作用 |
+|-------|------|
+| daily-arxiv | 每日 arXiv 推荐（一次性或定时），邮件推送排序摘要，可选自动入库 |
+| ideate | 多阶段点子生成：领域扫描 → 双模型头脑风暴 → 过滤验证 → 写入 wiki → 试点 |
+| exp-pilot-run | 预实验执行：写代码、部署、监控、收集原始结果 |
+| exp-pilot-eval | 预实验评估：读取结果、应用宽松判定、更新 idea 页面 |
+| novelty | 多源新颖性验证（WebSearch + Semantic Scholar + wiki + Review LLM） |
+| review | 对任意研究产出做跨模型评审，输出结构化评分与改进建议 |
+| exp-design | idea 驱动的实验设计：方法候选 → 基准选择 → 敏感性分析 → 主实验 |
+| exp-run | 完整实验执行流水线：准备代码 → 部署 → 监控 → 收集结果 |
+| exp-status | 查看所有在跑实验状态，可选自动收集并推进流水线 |
+| exp-eval | 实验裁决关卡：Review LLM 独立判定结果并更新 idea 状态与图边 |
+| refine | 多轮迭代打磨产出：评审 → 解析反馈 → 修复 → 更新 wiki，直到目标分数 |
 
-### Phase 2: Ideation & Experiments
-| Skill | Claude Code | Codex | What it does |
-|-------|-------------|-------|-------------|
-| daily-arxiv | `/daily-arxiv` | `$daily-arxiv` | Run or schedule the daily arXiv recommendation feed; delivers a ranked digest by email with optional auto-ingest for high-confidence picks |
-| ideate | `/ideate` | `$ideate` | Multi-phase research idea generation: landscape scan → dual-model brainstorm → filter & validation → write to wiki → pilot |
-| exp-pilot-run | `/exp-pilot-run` | `$exp-pilot-run` | Pilot experiment execution — write code, deploy, monitor, collect raw results as part of the ideation pipeline |
-| exp-pilot-eval | `/exp-pilot-eval` | `$exp-pilot-eval` | Pilot result evaluation — read results, apply success criteria, update idea page as part of the ideation pipeline |
-| novelty | `/novelty` | `$novelty` | Multi-source novelty verification via WebSearch + Semantic Scholar + wiki + Review LLM; outputs novelty score and recommendations |
-| review | `/review` | `$review` | Cross-model review of any research artifact — outputs structured scores, wiki entity mapping, and improvement suggestions |
-| exp-design | `/exp-design` | `$exp-design` | Idea-driven experiment design with iterative ablation — method candidates → benchmark selection → sensitivity analysis → main experiment |
-| exp-run | `/exp-run` | `$exp-run` | Full experiment execution pipeline — prepare code → deploy → monitor → collect results |
-| exp-status | `/exp-status` | `$exp-status` | View the status of all running experiments; optionally auto-collect completed runs and advance the pipeline |
-| exp-eval | `/exp-eval` | `$exp-eval` | Experiment verdict gate — Review LLM independently judges results and auto-updates the linked idea's status and graph edges |
-| refine | `/refine` | `$refine` | Multi-round iterative improvement — repeatedly reviews an artifact, parses feedback, applies fixes, and updates wiki until target score |
+### 阶段 3：写作与传播
+| Skill | 作用 |
+|-------|------|
+| survey | 基于 wiki 生成 Related Work：主题分组 → 叙事结构 → LaTeX 输出 |
+| paper-plan | 从 idea 图谱整理论文大纲：证据地图 → 叙事结构 → 章节/图表/引用计划 |
+| paper-draft | 按大纲起草 LaTeX 论文：逐节写作、生成图表、校验 BibTeX |
+| paper-compile | LaTeX 编译 → PDF：自动修复 + 页数/匿名/字体检查 + 投稿清单 |
+| research | 端到端科研编排：idea 发现 → 实验 → 裁决 → 写作（含人工关卡） |
+| rebuttal | 解析评审意见 → 原子化 → 映射 wiki → Review LLM 压力测试 → 生成 rebuttal |
+| poster | 从已起草论文生成学术海报（单页 HTML + 印刷级 PNG） |
 
-### Phase 3: Writing & Dissemination
-| Skill | Claude Code | Codex | What it does |
-|-------|-------------|-------|-------------|
-| survey | `/survey` | `$survey` | Generate a Related Work section from wiki knowledge — thematic grouping → narrative structure → LaTeX output |
-| paper-plan | `/paper-plan` | `$paper-plan` | Compile a paper outline from the idea graph — evidence map → narrative structure → section + figure + citation plan |
-| paper-draft | `/paper-draft` | `$paper-draft` | Draft a LaTeX paper from `PAPER_PLAN` — write each section from wiki sources, generate figures/tables, verify BibTeX |
-| paper-compile | `/paper-compile` | `$paper-compile` | LaTeX compile → PDF — latexmk compile + auto-fix + page count / anonymity / font checks + submission checklist |
-| research | `/research` | `$research` | End-to-end research orchestrator — idea discovery → experiment design → execution → verdict → paper writing with human gates |
-| rebuttal | `/rebuttal` | `$rebuttal` | Parse review comments → atomize concerns → map to wiki → stress-test with Review LLM → generate rebuttal |
-| poster | `/poster` | `$poster` | Generate an academic poster from a drafted paper — distill sections into a single-page HTML poster with figures |
-
-### Utilities
-| Skill | Claude Code | Codex | What it does |
-|-------|-------------|-------|-------------|
-| visualize | `/visualize` | `$visualize` | Generate Obsidian graph configs and Canvas knowledge maps; the interactive web graph is served by `tools/serve.py` |
+### 工具
+| Skill | 作用 |
+|-------|------|
+| visualize | 生成 Obsidian 图配置与 Canvas 知识地图；交互式网页图由 `tools/serve.py` 提供（`python tools/serve.py` 后访问 `http://localhost:8765/#/graph`） |
 
 </details>
 
 ---
 
-## Contributing
+## 🗂️ 目录结构与适配机制
 
-We welcome contributions and feedback — especially while we're in active iteration. See [CONTRIBUTING.md](CONTRIBUTING.md).
+```text
+.qoder/skills/        ← Qoder 原生 skills（生成物，勿手改）
+AGENTS.md             ← 运行时契约（生成物，勿手改）
+i18n/{en,zh}/         ← 双语 skill 源（唯一事实来源）
+tools/convert_to_qoder.py ← i18n → .qoder 的确定性转换器
+setup-qoder.ps1 / .sh     ← Qoder 一键安装脚本
+runtime/              ← wiki 契约源（schema + policy + templates）
+tools/                ← Python 工具（research_wiki.py 是 wiki 引擎）
+mcp-servers/llm-review/   ← 跨模型评审 MCP server
+wiki/ raw/            ← 你的知识库与素材（本地生成，不入库）
+```
 
-## Community / 交流群
+修改 skill 内容的正确方式：编辑 `i18n/<lang>/skills/` 下的源文件，然后重新运行安装脚本或 `python tools/convert_to_qoder.py --lang zh` 重新生成。
 
-<img src="assets/wechat_group_4_0811.jpg" width="240" alt="WeChat Group QR Code">
+---
 
-Scan to join the AutoSci WeChat group / 扫码加入微信交流群
+## 🔄 同步上游更新
 
-## Citation
+```powershell
+git remote add upstream https://github.com/skyllwt/AutoSci.git
+git fetch upstream
+git merge upstream/main        # 或 rebase；冲突后重跑转换脚本
+python tools/convert_to_qoder.py --lang zh
+```
 
-If you find AutoSci useful in your research, please cite our paper:
+---
+
+## 常见问题
+
+- **Windows 远程 GPU 实验**：`exp-run --env remote` 依赖 `ssh`/`rsync`/`screen`，建议在 WSL2 或 Linux/macOS 上运行；本地流水线原生支持 Windows。
+- **切换语言**：重新运行 `setup-qoder.ps1 -Lang en`（或 `--lang zh`）即可整体切换 skill 语言。
+- **DeepXiv 不可用**：需要 Python ≥ 3.10；缺失时自动降级为 arXiv RSS + Semantic Scholar，不影响主流程。
+
+---
+
+## 致谢
+
+- 上游项目 **[AutoSci](https://github.com/skyllwt/AutoSci)**（MIT 许可）及其作者团队
+- **[Qoder](https://qoder.com)** —— 本适配版运行的智能体 IDE
+- `/poster` 流水线改编自 [PaperX](https://github.com/yutao1024/PaperX)
+
+## 引用
 
 ```bibtex
 @misc{qian2026autosci,
-      title={AutoSci: A Memory-Centric Agentic System for the Full Scientific Research Lifecycle}, 
+      title={AutoSci: A Memory-Centric Agentic System for the Full Scientific Research Lifecycle},
       author={Weitong Qian and Beicheng Xu and Zhongao Xie and Bowen Fan and Guozheng Tang and Jiale Chen and Xinzhe Wu and Mingtian Yang and Chenyang Di and Jiajun Li and Lingching Tung and Peichao Lai and Yifei Xia and Ziyi Guo and Yanwei Xu and Yanzhao Qin and Shaoduo Gan and Xupeng Miao and Bin Cui},
       year={2026},
       eprint={2605.31468},
       archivePrefix={arXiv},
       primaryClass={cs.AI},
-      url={https://arxiv.org/abs/2605.31468}, 
+      url={https://arxiv.org/abs/2605.31468},
 }
 ```
 
-## Acknowledgments
-
-- **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** and **[Codex](https://developers.openai.com/codex)** — supported coding-agent runtimes for AutoSci
-- The `/poster` pipeline is adapted from [PaperX](https://github.com/yutao1024/PaperX)
-
 ## License
 
-[MIT](LICENSE) — use it, fork it, build on it.
+[MIT](LICENSE) — 自由使用、fork、二次开发。
 
-## Star History
-
-<div align="center">
-<a href="https://star-history.com/#skyllwt/AutoSci&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=skyllwt/AutoSci&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=skyllwt/AutoSci&type=Date" />
-    <img alt="AutoSci Star History Chart" src="https://api.star-history.com/svg?repos=skyllwt/AutoSci&type=Date" width="600" />
-  </picture>
-</a>
-</div>
-
+---
 
 <div align="center">
 
-**Built for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [Codex](https://developers.openai.com/codex)**
-
-If this project helps your research, give it a ⭐
+**本适配版为 [Qoder](https://qoder.com) 构建 · 上游项目为 [AutoSci](https://github.com/skyllwt/AutoSci)**
 
 </div>

--- a/config/mcp.qoder.json.example
+++ b/config/mcp.qoder.json.example
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "llm-review": {
+      "command": ".venv/Scripts/python.exe",
+      "args": ["mcp-servers/llm-review/server.py"],
+      "cwd": "${workspaceFolder}"
+    }
+  }
+}

--- a/i18n/en/AGENTS.md
+++ b/i18n/en/AGENTS.md
@@ -1,0 +1,49 @@
+# AutoSci — Runtime Contract (Qoder Edition)
+
+Edit `i18n/en/AGENTS.md`, not the active copy at root. Run `setup-qoder.sh --lang en` (or `setup-qoder.ps1`) to sync.
+
+## Repository Layout
+
+- `wiki/` — product surface. `index.md` is the catalog; `log.md` is append-only; subdirs per entity kind; `wiki/graph/` is auto-generated.
+- `runtime/` — contract source (schema + policy + templates). Read `runtime/CLAUDE.md` before changing any rule.
+- `raw/` — user-owned `{papers,notes,web}/` (read-only) + skill-writable `discovered/`, `tmp/`.
+- `tools/` — Python helpers (`research_wiki.py` is the wiki engine; `lint.py` is the validator).
+- `.qoder/skills/` — Qoder-native skills generated from `i18n/en/skills` by `tools/convert_to_qoder.py`. Never hand-edit; change the i18n source and re-run setup.
+
+Full tree: `docs/runtime-directory-structure.en.md`.
+
+## Link Syntax
+
+Wikilinks: `[[slug]]`. Slugs are lowercase, hyphen-separated, no spaces.
+
+## Skill Invocation Convention (Qoder)
+
+- Skills live in `.qoder/skills/<name>/SKILL.md`. A doc reference such as `/init` or `/ingest` means "invoke skill `init`" / "invoke skill `ingest`" — follow that skill's `SKILL.md` workflow step by step.
+- When a skill delegates work to another skill (e.g. `/init` Step 5 fans out to `/ingest`), launch one Qoder subagent (Agent tool) per unit of work and hand it the delegated skill's instructions plus its inputs.
+- Parallel fan-out uses Qoder subagents; the git-worktree isolation contract in `.qoder/skills/init/references/parallel-ingest.md` applies unchanged. Subagent prompts must use relative paths and the subagent's working directory must be the worktree path.
+- MCP tools of the `llm-review` server are referenced as `llm-review.chat`, `llm-review.chat-reply`, and `llm-review.web_search`. Register the server from `.qoder/mcp.json` (or Qoder MCP settings) before using `/review`, `/rebuttal`, etc.
+- Long-running services (e.g. `tools/serve.py`) run as background Bash processes owned by the Qoder session; do not wrap them in a subagent.
+
+## Hard Rules
+
+1. `raw/{papers,notes,web}` are user-owned, read-only. Skills append only to `raw/discovered/` or `raw/tmp/`.
+2. `wiki/graph/` is derived. Modify only via `tools/research_wiki.py` (`add-edge`, `add-citation`, `rebuild-*`).
+3. `wiki/log.md` is append-only. Never rewrite in place.
+4. Forward link → write reverse simultaneously. Rules in `runtime/schema/xref.yaml`.
+5. User-facing skill flags (those documented in a skill's **Usage** line) are user-owned. Do not invent, flip, or drop them based on repo state. If the user omitted one, use a default only when the skill documents omission behavior; otherwise ask.
+
+## Where to look
+
+| Need | Source |
+|---|---|
+| Page frontmatter fields, enums, defaults, lifecycle | `runtime/schema/entities.yaml` |
+| Page body section structure                          | `runtime/templates/{kind}.md.tmpl` |
+| Edge types, attributes, direction, confidence       | `runtime/schema/edges.yaml` |
+| Forward → reverse link rules                         | `runtime/schema/xref.yaml` |
+| Slug rule, ownership, edge storage location          | `runtime/schema/conventions.yaml` |
+| Field/edge write permissions per skill               | `runtime/policy/writers.yaml` |
+| Changing the contract / regen                        | `runtime/CLAUDE.md` |
+
+## Python Environment
+
+Prefer in order: `.venv/bin/python` (`.venv/Scripts/python.exe` on Windows) → active conda env → `python3` (`python` on Windows). Tools auto-load API keys from `~/.env` and project-root `.env` via `tools/_env.py`.

--- a/i18n/zh/AGENTS.md
+++ b/i18n/zh/AGENTS.md
@@ -1,0 +1,49 @@
+# AutoSci — 运行时契约（Qoder 版）
+
+编辑 `i18n/zh/AGENTS.md`,不要改根目录下的副本。运行 `setup-qoder.sh --lang zh`(或 `setup-qoder.ps1`)同步。
+
+## 仓库布局
+
+- `wiki/` — 产物面。`index.md` 是目录;`log.md` 是 append-only;每类实体一个子目录;`wiki/graph/` 自动生成。
+- `runtime/` — 契约源(schema + policy + templates)。修改任何规则前先读 `runtime/CLAUDE.md`。
+- `raw/` — 用户自有 `{papers,notes,web}/`(只读)+ skill 可写的 `discovered/`、`tmp/`。
+- `tools/` — Python 助手(`research_wiki.py` 是 wiki 引擎,`lint.py` 是校验器)。
+- `.qoder/skills/` — 由 `tools/convert_to_qoder.py` 从 `i18n/zh/skills` 生成的 Qoder 原生 skills。不要手改;改 i18n 源后重跑 setup。
+
+完整目录树:`docs/runtime-directory-structure.zh.md`。
+
+## 链接语法
+
+Wikilink:`[[slug]]`。slug 全小写、连字符分隔、无空格。
+
+## Skill 调用约定（Qoder）
+
+- Skill 位于 `.qoder/skills/<name>/SKILL.md`。文档中的 `/init`、`/ingest` 等写法表示"调用 skill `init`"、"调用 skill `ingest`" —— 按该 skill 的 `SKILL.md` 工作流逐步执行。
+- 当一个 skill 把任务委托给另一个 skill(如 `/init` Step 5 扇出到 `/ingest`)时,为每个工作单元启动一个 Qoder 子代理(Agent 工具),把被委托 skill 的指令和输入交给它。
+- 并行扇出使用 Qoder 子代理;`.qoder/skills/init/references/parallel-ingest.md` 中的 git worktree 隔离契约保持不变。子代理 prompt 必须用相对路径,且子代理的工作目录必须是 worktree 路径。
+- `llm-review` MCP server 的工具写作 `llm-review.chat`、`llm-review.chat-reply`、`llm-review.web_search`。使用 `/review`、`/rebuttal` 等之前,先从 `.qoder/mcp.json`(或 Qoder 的 MCP 设置)注册该 server。
+- 长跑服务(如 `tools/serve.py`)以后台 Bash 进程运行,归 Qoder 会话所有;不要用子代理包裹。
+
+## 硬规则
+
+1. `raw/{papers,notes,web}` 归用户所有,只读。skill 只能向 `raw/discovered/` 或 `raw/tmp/` 追加。
+2. `wiki/graph/` 是派生态。仅通过 `tools/research_wiki.py`(`add-edge`、`add-citation`、`rebuild-*`)修改。
+3. `wiki/log.md` 是 append-only。绝不就地重写。
+4. 写正向链接 → 同步写反向链接。完整规则在 `runtime/schema/xref.yaml`。
+5. 用户面 skill 参数(记录在 skill 的 **Usage** 行中的 flag)归用户所有。不得仅根据仓库状态擅自补出、翻转或删除它们。用户未提供时,只有 skill 文档化了省略行为才用默认值;否则询问用户。
+
+## 查阅索引
+
+| 需要 | 去哪 |
+|---|---|
+| 页面 frontmatter 字段、enum、默认值、生命周期 | `runtime/schema/entities.yaml` |
+| 页面正文章节结构                                | `runtime/templates/{kind}.md.tmpl` |
+| 边类型、属性、方向、confidence                | `runtime/schema/edges.yaml` |
+| 正向 → 反向链接规则                            | `runtime/schema/xref.yaml` |
+| slug 规则、ownership、edge 存储位置            | `runtime/schema/conventions.yaml` |
+| 各 skill 对字段/边的写权限                     | `runtime/policy/writers.yaml` |
+| 改契约本身 / 重新 regen                        | `runtime/CLAUDE.md` |
+
+## Python 环境
+
+按优先级:`.venv/bin/python`(Windows 上 `.venv/Scripts/python.exe`)→ 当前激活的 conda 环境 → `python3`(Windows 上 `python`)。tools/ 通过 `tools/_env.py` 自动从 `~/.env` 和项目根 `.env` 加载 API key。

--- a/setup-qoder.ps1
+++ b/setup-qoder.ps1
@@ -1,0 +1,223 @@
+# ============================================================================
+# AutoSci - One-Click Setup for Qoder (Windows / PowerShell)
+# ============================================================================
+# Usage:
+#   powershell -ExecutionPolicy Bypass -File .\setup-qoder.ps1            # English (default)
+#   powershell -ExecutionPolicy Bypass -File .\setup-qoder.ps1 -Lang zh   # Chinese
+#
+# Mirrors setup.ps1 but targets Qoder instead of Claude Code:
+#   prerequisites -> venv + deps -> config -> convert i18n skills into
+#   .qoder/skills (tools/convert_to_qoder.py) -> verify.
+# API key configuration (Semantic Scholar, DeepXiv, Review LLM) is handled
+# interactively by Qoder - invoke the `setup` skill after opening the project.
+# ============================================================================
+
+[CmdletBinding()]
+param(
+    [ValidateSet("en", "zh")]
+    [string]$Lang = "en"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Info($msg) { Write-Host "[INFO]  $msg" -ForegroundColor Blue }
+function Write-Ok($msg)   { Write-Host "[OK]    $msg" -ForegroundColor Green }
+function Write-Warn2($msg){ Write-Host "[WARN]  $msg" -ForegroundColor Yellow }
+function Write-Fail($msg) { Write-Host "[FAIL]  $msg" -ForegroundColor Red }
+
+$ProjectRoot = $PSScriptRoot
+$I18nDir = Join-Path $ProjectRoot "i18n\$Lang"
+if (-not (Test-Path $I18nDir)) {
+    Write-Fail "i18n\$Lang not found - run from the project root"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "============================================"
+Write-Host "  AutoSci - Setup for Qoder (Windows)"
+Write-Host "============================================"
+Write-Host ""
+
+# -- Step 1: Check prerequisites -------------------------------------------
+Write-Info "Checking prerequisites..."
+
+# Python: prefer `python`, fall back to `py -3`
+$PythonCmd = $null
+foreach ($candidate in @("python", "python3", "py")) {
+    if (Get-Command $candidate -ErrorAction SilentlyContinue) {
+        $PythonCmd = $candidate
+        break
+    }
+}
+if (-not $PythonCmd) {
+    Write-Fail "Python not found. Install Python 3.9+ from https://www.python.org/downloads/"
+    exit 1
+}
+
+$pyVersionRaw = & $PythonCmd --version 2>&1
+if ($pyVersionRaw -match "(\d+)\.(\d+)\.(\d+)") {
+    $pyMajor = [int]$Matches[1]
+    $pyMinor = [int]$Matches[2]
+    if ($pyMajor -lt 3 -or ($pyMajor -eq 3 -and $pyMinor -lt 9)) {
+        Write-Fail "Python >= 3.9 required, found $pyVersionRaw"
+        exit 1
+    }
+    Write-Ok "Python $pyVersionRaw"
+} else {
+    Write-Fail "Could not parse Python version: $pyVersionRaw"
+    exit 1
+}
+
+# pip
+& $PythonCmd -m pip --version 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Fail "pip not found. Run: $PythonCmd -m ensurepip"
+    exit 1
+}
+Write-Ok "pip available"
+
+# -- Step 2: Python environment + dependencies -----------------------------
+Write-Host ""
+Write-Info "Setting up Python environment..."
+
+Push-Location $ProjectRoot
+try {
+    if ($env:VIRTUAL_ENV -or ($env:CONDA_DEFAULT_ENV -and $env:CONDA_DEFAULT_ENV -ne "base")) {
+        Write-Warn2 "Active environment detected; setup always installs AutoSci into .venv"
+    }
+
+    if (Test-Path ".venv") {
+        Write-Warn2 ".venv already exists, using it"
+    } else {
+        & $PythonCmd -m venv .venv
+        if ($LASTEXITCODE -ne 0) { throw "venv creation failed" }
+        Write-Ok "Created .venv"
+    }
+
+    $VenvPython = Join-Path $ProjectRoot ".venv\Scripts\python.exe"
+    if (-not (Test-Path $VenvPython)) {
+        Write-Fail "Expected $VenvPython but it does not exist"
+        exit 1
+    }
+    Write-Ok "Using .venv\Scripts\python.exe"
+
+    Write-Info "Installing dependencies into .venv..."
+    & $VenvPython -m pip install -r requirements.txt -q
+    if ($LASTEXITCODE -ne 0) { throw "pip install failed" }
+    Write-Ok "Dependencies installed into .venv"
+
+    # -- Step 3: Configuration files ---------------------------------------
+    Write-Host ""
+    Write-Info "Setting up configuration..."
+
+    if (Test-Path ".env") {
+        Write-Warn2 ".env already exists, not overwriting"
+    } else {
+        Copy-Item "config\.env.example" ".env"
+        Write-Ok "Created .env from template"
+    }
+
+    if (-not (Test-Path ".qoder")) { New-Item -ItemType Directory -Path ".qoder" | Out-Null }
+
+    # -- Step 3b: Convert i18n skills into Qoder-native assets -------------
+    Write-Host ""
+    Write-Info "Converting skills for Qoder (lang=$Lang)..."
+    & $VenvPython (Join-Path $ProjectRoot "tools\convert_to_qoder.py") --lang $Lang --project-root $ProjectRoot
+    if ($LASTEXITCODE -ne 0) { throw "convert_to_qoder.py failed" }
+    Write-Ok "Qoder skills activated ($Lang)"
+
+    # -- Step 4: Verify installation ---------------------------------------
+    Write-Host ""
+    Write-Info "Verifying installation..."
+
+    $script:VerificationErrors = 0
+    $script:VerificationWarnings = 0
+
+    function Invoke-PythonCheck {
+        param(
+            [string]$Label,
+            [string]$Code,
+            [string]$WorkingDirectory = $ProjectRoot,
+            [switch]$WarningOnly
+        )
+
+        Push-Location $WorkingDirectory
+        try {
+            & $VenvPython -c $Code 2>$null | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Ok $Label
+            } elseif ($WarningOnly) {
+                Write-Warn2 $Label
+                $script:VerificationWarnings++
+            } else {
+                Write-Fail $Label
+                $script:VerificationErrors++
+            }
+        } finally {
+            Pop-Location
+        }
+    }
+
+    Invoke-PythonCheck -Label "PyMuPDF (fitz)" -Code "import fitz"
+    Invoke-PythonCheck -Label "requests" -Code "import requests"
+    Invoke-PythonCheck -Label "feedparser" -Code "import feedparser"
+
+    $toolChecks = @(
+        @{ name = "tools/init_discovery.py"; import = "from init_discovery import prepare_inputs" },
+        @{ name = "tools/fetch_s2.py";       import = "from fetch_s2 import search" },
+        @{ name = "tools/fetch_arxiv.py";    import = "from fetch_arxiv import fetch_recent" },
+        @{ name = "tools/research_wiki.py";  import = "from research_wiki import slugify" },
+        @{ name = "tools/lint.py";           import = "from lint import check_missing_fields" }
+    )
+    foreach ($c in $toolChecks) {
+        Invoke-PythonCheck -Label $c.name -Code $c.import -WorkingDirectory (Join-Path $ProjectRoot "tools")
+    }
+
+    & $VenvPython -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        & $VenvPython -c "import deepxiv_sdk" 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Ok "deepxiv-sdk (optional)"
+        } else {
+            Write-Warn2 "deepxiv-sdk unavailable; DeepXiv features will degrade but setup can continue"
+            $script:VerificationWarnings++
+        }
+    } else {
+        Write-Warn2 "Python < 3.10 detected inside .venv; deepxiv-sdk may be unavailable, so DeepXiv features may degrade"
+        $script:VerificationWarnings++
+    }
+} finally {
+    Pop-Location
+}
+
+# -- Done ------------------------------------------------------------------
+Write-Host ""
+Write-Host "============================================"
+if ($script:VerificationErrors -eq 0 -and $script:VerificationWarnings -eq 0) {
+    Write-Host "  Setup complete!" -ForegroundColor Green
+} elseif ($script:VerificationErrors -eq 0) {
+    Write-Host "  Setup complete with $script:VerificationWarnings warning(s)" -ForegroundColor Yellow
+} else {
+    Write-Host "  Setup complete with $script:VerificationErrors error(s) and $script:VerificationWarnings warning(s)" -ForegroundColor Yellow
+}
+Write-Host "============================================"
+Write-Host ""
+Write-Host "  Next steps:"
+Write-Host ""
+Write-Host "  1. Open this folder in Qoder. AGENTS.md is picked up automatically;"
+Write-Host "     project skills were generated into .qoder\skills\."
+Write-Host ""
+Write-Host "  2. Register the llm-review MCP server (needed by /review, /rebuttal, ...):"
+Write-Host "     .qoder\mcp.json was generated from config\mcp.qoder.json.example."
+Write-Host "     If Qoder does not pick it up, add it manually in Qoder MCP settings:"
+Write-Host "       command: .venv\Scripts\python.exe"
+Write-Host "       args:    mcp-servers/llm-review/server.py"
+Write-Host ""
+Write-Host "  3. Complete API key configuration (guided) - ask Qoder to run the"
+Write-Host "     'setup' skill."
+Write-Host ""
+Write-Host "  4. Then initialize your wiki - ask Qoder to run the 'init' skill:"
+Write-Host "       init [your-research-topic]"
+Write-Host ""
+Write-Host "  For more, see README.md"
+Write-Host ""

--- a/setup-qoder.sh
+++ b/setup-qoder.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# ============================================================================
+# AutoSci — One-Click Setup for Qoder
+# ============================================================================
+# Usage:
+#   chmod +x setup-qoder.sh && ./setup-qoder.sh            # English (default)
+#   chmod +x setup-qoder.sh && ./setup-qoder.sh --lang zh  # Chinese / 中文
+#
+# What it does:
+#   1. Checks prerequisites (Python, pip)
+#   2. Creates virtual environment and installs dependencies
+#   3. Copies configuration templates
+#   4. Converts i18n skills into Qoder-native assets (tools/convert_to_qoder.py)
+#   5. Verifies the installation
+#
+# API key configuration (Semantic Scholar, DeepXiv, Review LLM) is handled
+# interactively by Qoder — invoke the `setup` skill after opening the project.
+# ============================================================================
+
+set -e
+
+# --- Colors ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+info()  { echo -e "${BLUE}[INFO]${NC}  $1"; }
+ok()    { echo -e "${GREEN}[OK]${NC}    $1"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $1"; }
+fail()  { echo -e "${RED}[FAIL]${NC}  $1"; }
+
+# ── Language selection ──────────────────────────────────────────────
+LANG_CODE="en"
+_ARGS=("$@")
+for i in "${!_ARGS[@]}"; do
+  case "${_ARGS[$i]}" in
+    --lang=*) LANG_CODE="${_ARGS[$i]#*=}" ;;
+    --lang)   LANG_CODE="${_ARGS[$((i+1))]}" ;;
+  esac
+done
+PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
+[[ "$LANG_CODE" == "en" || "$LANG_CODE" == "zh" ]] || { fail "Unknown lang: $LANG_CODE (use 'en' or 'zh')"; exit 1; }
+I18N_DIR="$PROJECT_ROOT/i18n/$LANG_CODE"
+[ -d "$I18N_DIR" ] || { fail "i18n/$LANG_CODE not found — run from the project root"; exit 1; }
+cd "$PROJECT_ROOT"
+
+echo ""
+echo "============================================"
+echo "  AutoSci — Setup for Qoder"
+echo "============================================"
+echo ""
+
+# ── Step 1: Check prerequisites ─────────────────────────────────────────
+
+info "Checking prerequisites..."
+
+# Python
+if command -v python3 &>/dev/null; then
+    PYTHON_CMD="python3"
+    PY_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
+    PY_MAJOR=$(echo "$PY_VERSION" | cut -d. -f1)
+    PY_MINOR=$(echo "$PY_VERSION" | cut -d. -f2)
+    if [ "$PY_MAJOR" -ge 3 ] && [ "$PY_MINOR" -ge 9 ]; then
+        ok "Python $PY_VERSION"
+    else
+        fail "Python >= 3.9 required, found $PY_VERSION"
+        exit 1
+    fi
+else
+    fail "Python3 not found. Install Python 3.9+ first."
+    exit 1
+fi
+
+# pip
+if "$PYTHON_CMD" -m pip --version &>/dev/null; then
+    ok "pip available"
+else
+    fail "pip not found. Install with: $PYTHON_CMD -m ensurepip"
+    exit 1
+fi
+
+# ── Step 2: Python environment + dependencies ───────────────────────────
+
+echo ""
+info "Setting up Python environment..."
+
+if [ -n "$VIRTUAL_ENV" ] || { [ -n "$CONDA_DEFAULT_ENV" ] && [ "$CONDA_DEFAULT_ENV" != "base" ]; }; then
+    warn "Active environment detected; setup always installs AutoSci into .venv"
+fi
+
+if [ -d ".venv" ]; then
+    warn ".venv already exists, using it"
+else
+    "$PYTHON_CMD" -m venv .venv
+    ok "Created .venv"
+fi
+
+VENV_PYTHON="$PROJECT_ROOT/.venv/bin/python"
+if [ ! -x "$VENV_PYTHON" ]; then
+    fail "Expected $VENV_PYTHON but it does not exist"
+    exit 1
+fi
+ok "Using $VENV_PYTHON"
+
+info "Installing dependencies into .venv..."
+"$VENV_PYTHON" -m pip install -r requirements.txt -q
+ok "Dependencies installed into .venv"
+
+# ── Step 3: Configuration files ─────────────────────────────────────────
+
+echo ""
+info "Setting up configuration..."
+
+# .env
+if [ -f ".env" ]; then
+    warn ".env already exists, not overwriting"
+else
+    cp .env.example .env
+    ok "Created .env from template"
+fi
+
+mkdir -p .qoder
+
+# ── Step 3b: Convert i18n skills into Qoder-native assets ──────────
+
+echo ""
+info "Converting skills for Qoder (lang=$LANG_CODE)..."
+"$VENV_PYTHON" tools/convert_to_qoder.py --lang "$LANG_CODE" --project-root "$PROJECT_ROOT"
+ok "Qoder skills activated ($LANG_CODE)"
+
+# ── Step 4: Verify installation ─────────────────────────────────────────
+
+echo ""
+info "Verifying installation..."
+
+ERRORS=0
+WARNINGS=0
+
+check_python_snippet() {
+    local label="$1"
+    local snippet="$2"
+    if "$VENV_PYTHON" -c "$snippet" >/dev/null 2>&1; then
+        ok "$label"
+    else
+        fail "$label missing"
+        ERRORS=$((ERRORS+1))
+    fi
+}
+
+check_tool_import() {
+    local label="$1"
+    local import_stmt="$2"
+    if (cd tools && "$VENV_PYTHON" -c "$import_stmt") >/dev/null 2>&1; then
+        ok "$label"
+    else
+        fail "$label import error"
+        ERRORS=$((ERRORS+1))
+    fi
+}
+
+# Check real runtime dependencies first.
+check_python_snippet "PyMuPDF (fitz)" "import fitz"
+check_python_snippet "requests" "import requests"
+check_python_snippet "feedparser" "import feedparser"
+
+# Then check the current-stage tools with the same interpreter.
+check_tool_import "tools/init_discovery.py" "from init_discovery import prepare_inputs"
+check_tool_import "tools/fetch_s2.py" "from fetch_s2 import search"
+check_tool_import "tools/fetch_arxiv.py" "from fetch_arxiv import fetch_recent"
+check_tool_import "tools/research_wiki.py" "from research_wiki import slugify"
+check_tool_import "tools/lint.py" "from lint import check_missing_fields"
+check_tool_import "tools/wiki2dag.py" "from wiki2dag import build_dag"
+check_tool_import "tools/poster.py" "from poster import build_poster"
+
+# DeepXiv is optional; surface it as a warning-only diagnostic.
+if "$VENV_PYTHON" -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" >/dev/null 2>&1; then
+    if "$VENV_PYTHON" -c "import deepxiv_sdk" >/dev/null 2>&1; then
+        ok "deepxiv-sdk (optional)"
+    else
+        warn "deepxiv-sdk unavailable; DeepXiv features will degrade but setup can continue"
+        WARNINGS=$((WARNINGS+1))
+    fi
+else
+    warn "Python < 3.10 detected inside .venv; deepxiv-sdk may be unavailable, so DeepXiv features may degrade"
+    WARNINGS=$((WARNINGS+1))
+fi
+
+# ── Done ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "============================================"
+if [ $ERRORS -eq 0 ] && [ $WARNINGS -eq 0 ]; then
+    echo -e "  ${GREEN}Setup complete!${NC}"
+elif [ $ERRORS -eq 0 ]; then
+    echo -e "  ${YELLOW}Setup complete with $WARNINGS warning(s)${NC}"
+else
+    echo -e "  ${YELLOW}Setup complete with $ERRORS error(s) and $WARNINGS warning(s)${NC}"
+fi
+echo "============================================"
+echo ""
+echo "  Next steps:"
+echo ""
+echo "  1. Open this folder in Qoder. AGENTS.md is picked up automatically;"
+echo "     project skills were generated into .qoder/skills/."
+echo ""
+echo "  2. Register the llm-review MCP server (needed by /review, /rebuttal, ...):"
+echo "     .qoder/mcp.json was generated from config/mcp.qoder.json.example."
+echo "     On Linux/macOS set command to .venv/bin/python if needed."
+echo ""
+echo "  3. Complete API key configuration (guided) — ask Qoder to run the"
+echo "     'setup' skill."
+echo ""
+echo "  4. Then initialize your wiki — ask Qoder to run the 'init' skill:"
+echo "     init [your-research-topic]"
+echo ""
+echo "  For more, see README.md"
+echo ""

--- a/tools/_env.py
+++ b/tools/_env.py
@@ -1,7 +1,7 @@
 """Shared environment loader for OmegaWiki tools.
 
 Loads environment variables from .env files so that API keys configured
-by the user are available even when Claude Code spawns a fresh shell.
+by the user are available even when the host agent (Qoder) spawns a fresh shell.
 
 Load order (later files do NOT override earlier ones):
   1. ~/.env          (global, e.g. DEEPXIV_TOKEN auto-registered here)

--- a/tools/convert_to_qoder.py
+++ b/tools/convert_to_qoder.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Convert AutoSci's bilingual skill source into Qoder-native assets.
+
+This is the Qoder counterpart of the Claude Code activation step in
+``setup.ps1`` / ``setup.sh``. It regenerates, from the shared source of
+truth ``i18n/<lang>/skills``, the following Qoder artifacts:
+
+- ``.qoder/skills/<skill>/``      — Qoder Agent Skills (SKILL.md frontmatter
+  gains the required ``name`` field; ``argument-hint`` becomes a Usage line)
+- ``.qoder/skills/shared-references/`` — shared reference docs
+- ``AGENTS.md``                    — runtime contract read by Qoder
+- ``.qoder/mcp.json``              — llm-review MCP server registration
+- ``.qoder/.current-lang``         — activated language marker
+
+The script is idempotent: the generated trees are wiped and rebuilt on every
+run. Never hand-edit generated files; change the ``i18n/<lang>`` source and
+re-run this script (or ``setup-qoder.ps1`` / ``setup-qoder.sh``).
+
+Usage:
+    python tools/convert_to_qoder.py --lang zh
+    python tools/convert_to_qoder.py --lang en --project-root .
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# Text substitutions applied to every generated markdown / yaml file.
+# Order matters: most specific patterns first.
+REPLACEMENTS = [
+    # CI scaffold wording (daily-arxiv references)
+    ("Claude Code Action", "Qoder agent runtime"),
+    # setup skill status lines
+    ("由 Claude Code 管理（claude login）", "由 Qoder 管理（Qoder 登录）"),
+    ("managed by Claude Code (claude login)", "managed by Qoder (Qoder login)"),
+    ("claude login", "Qoder login"),
+    # skill asset paths
+    (".claude/skills/shared-references/", ".qoder/skills/shared-references/"),
+    (".claude/skills/", ".qoder/skills/"),
+    (".claude/", ".qoder/"),
+    # MCP tool naming: Claude Code `mcp__server__tool` -> Qoder `server.tool`
+    ("mcp__llm-review__", "llm-review."),
+    # MCP registration file
+    (".mcp.json", ".qoder/mcp.json"),
+    # Claude Code MCP permission setting
+    ("enableAllProjectMcpServers", "MCP server enablement in Qoder settings"),
+    # dependency section headers
+    ("### Claude Code Native", "### Qoder Native"),
+    # generic platform name last
+    ("Claude Code", "Qoder"),
+]
+
+TEXT_EXTENSIONS = {".md", ".markdown", ".yaml", ".yml", ".txt", ".json"}
+
+FRONTMATTER_RE = re.compile(r"^---\r?\n(.*?)\r?\n---\r?\n", re.S)
+
+
+def transform_text(text: str) -> str:
+    for old, new in REPLACEMENTS:
+        text = text.replace(old, new)
+    return text
+
+
+def _strip_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
+def insert_usage_line(body: str, hint: str, lang: str) -> tuple[str, bool]:
+    """Insert a Usage callout right after the first H1 heading."""
+    label = "> **用法**：" if lang == "zh" else "> **Usage**: "
+    lines = body.split("\n")
+    for idx, line in enumerate(lines):
+        if line.startswith("# "):
+            lines[idx + 1 : idx + 1] = ["", f"{label}`{hint}`", ""]
+            return "\n".join(lines), True
+    return body, False
+
+
+def convert_frontmatter(text: str, skill_name: str, lang: str) -> tuple[str, list[str]]:
+    """Rewrite SKILL.md frontmatter to Qoder requirements.
+
+    Qoder requires ``name`` + ``description``; Claude Code's
+    ``argument-hint`` is preserved as a Usage line below the H1 title.
+    """
+    warnings: list[str] = []
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return text, [f"{skill_name}: no YAML frontmatter found, left unchanged"]
+
+    description = None
+    hint = None
+    other_lines: list[str] = []
+    for line in match.group(1).splitlines():
+        if line.startswith("description:"):
+            description = line[len("description:") :].strip()
+        elif line.startswith("argument-hint:"):
+            hint = _strip_quotes(line[len("argument-hint:") :].strip())
+        elif line.startswith("name:"):
+            continue  # regenerated below
+        else:
+            other_lines.append(line)
+
+    body = text[match.end() :]
+    if hint:
+        body, inserted = insert_usage_line(body, hint, lang)
+        if not inserted:
+            warnings.append(f"{skill_name}: no H1 heading for Usage line, hint kept in frontmatter")
+            other_lines.append(f"argument-hint: {hint}")
+
+    fm_lines = [f"name: {skill_name}"]
+    if description:
+        fm_lines.append(f"description: {description}")
+    fm_lines.extend(other_lines)
+    return "---\n" + "\n".join(fm_lines) + "\n---\n" + body, warnings
+
+
+def convert_file(src: Path, dst: Path, skill_name: str | None, lang: str) -> list[str]:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if src.suffix.lower() not in TEXT_EXTENSIONS:
+        shutil.copy2(src, dst)
+        return []
+    text = src.read_text(encoding="utf-8")
+    warnings: list[str] = []
+    if skill_name is not None and src.name == "SKILL.md":
+        text, warnings = convert_frontmatter(text, skill_name, lang)
+    text = transform_text(text)
+    dst.write_text(text, encoding="utf-8", newline="\n")
+    return warnings
+
+
+def wipe_generated(path: Path) -> None:
+    if not path.exists():
+        return
+    # Safety: only ever wipe paths inside the project's .qoder/ tree.
+    if ".qoder" not in path.parts:
+        raise RuntimeError(f"refusing to wipe non-generated path: {path}")
+    shutil.rmtree(path)
+
+
+def validate_skill(skill_md: Path) -> list[str]:
+    problems: list[str] = []
+    text = skill_md.read_text(encoding="utf-8")
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return [f"{skill_md}: missing frontmatter"]
+    fm = match.group(1)
+    if not re.search(r"^name:\s*[a-z0-9][a-z0-9-]*\s*$", fm, re.M):
+        problems.append(f"{skill_md}: invalid or missing `name` field")
+    if not re.search(r"^description:\s*\S", fm, re.M):
+        problems.append(f"{skill_md}: missing `description` field")
+    for bad in ("mcp__", ".claude/"):
+        if bad in text:
+            problems.append(f"{skill_md}: leftover Claude Code token `{bad}`")
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lang", required=True, choices=["en", "zh"])
+    parser.add_argument("--project-root", default=str(PROJECT_ROOT))
+    args = parser.parse_args()
+
+    root = Path(args.project_root).resolve()
+    i18n_dir = root / "i18n" / args.lang
+    skills_src = i18n_dir / "skills"
+    if not skills_src.is_dir():
+        print(f"ERROR: {skills_src} not found — run from the project root", file=sys.stderr)
+        return 1
+
+    qoder_dir = root / ".qoder"
+    skills_dst = qoder_dir / "skills"
+
+    # 1. Regenerate the skill tree (idempotent wipe + rebuild).
+    wipe_generated(skills_dst)
+    all_warnings: list[str] = []
+    skill_count = 0
+    for skill_dir in sorted(skills_src.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        skill_count += 1
+        for src in sorted(skill_dir.rglob("*")):
+            if src.is_file():
+                rel = src.relative_to(skill_dir)
+                all_warnings += convert_file(
+                    src, skills_dst / skill_dir.name / rel, skill_dir.name, args.lang
+                )
+
+    # 2. Shared references (loaded by several skills via relative .qoder paths).
+    shared_src = i18n_dir / "shared-references"
+    if shared_src.is_dir():
+        for src in sorted(shared_src.rglob("*")):
+            if src.is_file():
+                convert_file(src, skills_dst / "shared-references" / src.relative_to(shared_src), None, args.lang)
+
+    # 3. Runtime contract -> AGENTS.md (the file Qoder reads automatically).
+    agents_src = i18n_dir / "AGENTS.md"
+    if agents_src.is_file():
+        agents_text = transform_text(agents_src.read_text(encoding="utf-8"))
+        (root / "AGENTS.md").write_text(agents_text, encoding="utf-8", newline="\n")
+        print(f"[ok] AGENTS.md generated from i18n/{args.lang}/AGENTS.md")
+    else:
+        all_warnings.append(f"i18n/{args.lang}/AGENTS.md missing — AGENTS.md not generated")
+
+    # 4. MCP registration example -> .qoder/mcp.json (kept if user edited it).
+    mcp_example = root / "config" / "mcp.qoder.json.example"
+    mcp_dst = qoder_dir / "mcp.json"
+    if mcp_example.is_file() and not mcp_dst.exists():
+        shutil.copy2(mcp_example, mcp_dst)
+        print("[ok] .qoder/mcp.json created from config/mcp.qoder.json.example")
+
+    # 5. Language marker (mirrors .claude/.current-lang).
+    (qoder_dir / ".current-lang").write_text(args.lang, encoding="utf-8")
+
+    # 6. Validate the generated tree.
+    problems: list[str] = []
+    for skill_md in sorted(skills_dst.glob("*/SKILL.md")):
+        problems += validate_skill(skill_md)
+
+    print(f"[ok] {skill_count} skills converted into .qoder/skills (lang={args.lang})")
+    for warning in all_warnings:
+        print(f"[warn] {warning}")
+    if problems:
+        for problem in problems:
+            print(f"[FAIL] {problem}", file=sys.stderr)
+        return 1
+    print("[ok] validation passed: frontmatter + terminology clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/daily_arxiv.py
+++ b/tools/daily_arxiv.py
@@ -1294,7 +1294,7 @@ def run_third_party_recommendation(
     temperature: float = 0.1,
 ) -> dict[str, Any]:
     if context.get("mode") != "inform":
-        raise RuntimeError("third-party LLM recommendation is inform-mode only; auto-ingest requires Claude Code runtime")
+        raise RuntimeError("third-party LLM recommendation is inform-mode only; auto-ingest requires an agent runtime (Qoder/Claude Code)")
     env = _require_llm_env()
     compact = _compact_llm_context(context, limit)
     allowed_ids = {

--- a/tools/serve.py
+++ b/tools/serve.py
@@ -41,13 +41,13 @@ and other skills can distinguish SPA-originated edits):
 
 Skill-intent boundary
 ---------------------
-The SPA cannot run /skill X — slash-commands need a Claude Code LLM
+The SPA cannot run /skill X — slash-commands need a Qoder LLM
 session. Naive UX would silently call a different code path and produce
 results that diverge from /skill X's actual behavior. So every UI button
 that wants a skill posts to /api/intent/{skill}; the backend assembles
 the right "/skill ..." command (filling in slug/arxiv-id/etc. from page
 context) and returns it. The SPA opens a copy-to-clipboard modal with the
-command. The user pastes it into Claude Code. The boundary is explicit
+command. The user pastes it into Qoder. The boundary is explicit
 in the API surface itself — no silent skill faking.
 
 Live reload (SSE)
@@ -58,7 +58,7 @@ to all connected /api/events clients. The SPA's EventSource listener
 refetches data and re-renders the current view. A 2.5s grace window
 after each SPA-initiated write suppresses redundant re-renders triggered
 by the SPA's own write — state.lastWriteAt is consulted before
-re-rendering. External edits (Obsidian, Claude Code editing wiki/* during
+re-rendering. External edits (Obsidian, Qoder editing wiki/* during
 a running ingest, manual research_wiki.py invocations) all reflect in the
 SPA within ~1.5 seconds with no manual refresh.
 
@@ -769,10 +769,10 @@ class WikiHandler(SimpleHTTPRequestHandler):
     #
     # These return ready-to-paste `/skill ...` command strings. They do NOT
     # execute the skill (the SPA has no LLM session). The frontend shows
-    # the command in a copy-to-clipboard modal; user pastes into Claude Code.
+    # the command in a copy-to-clipboard modal; user pastes into Qoder.
 
     INTENT_DEFAULT_MESSAGE = (
-        "Run this in Claude Code. The SPA cannot orchestrate /skill — "
+        "Run this in Qoder. The SPA cannot orchestrate /skill — "
         "skills require an LLM session."
     )
 
@@ -796,7 +796,7 @@ class WikiHandler(SimpleHTTPRequestHandler):
             return
         out = b(body)
         out.setdefault("skill", skill)
-        out.setdefault("doc_url", f".claude/skills/{skill}/SKILL.md")
+        out.setdefault("doc_url", f".qoder/skills/{skill}/SKILL.md")
         out.setdefault("message", self.INTENT_DEFAULT_MESSAGE)
         self._send_json(out)
 
@@ -809,7 +809,7 @@ class WikiHandler(SimpleHTTPRequestHandler):
             "command": "/ingest <local-path-or-arXiv-URL>",
             "message": ("Replace <local-path-or-arXiv-URL> with a "
                         ".pdf path, .tex path, or arXiv link, then run in "
-                        "Claude Code."),
+                        "Qoder."),
         }
 
     @staticmethod
@@ -852,7 +852,7 @@ class WikiHandler(SimpleHTTPRequestHandler):
 
     @staticmethod
     def _intent_discover(body: dict) -> dict:
-        # /discover has four seed modes (see .claude/skills/discover/SKILL.md).
+        # /discover has four seed modes (see .qoder/skills/discover/SKILL.md).
         # Priority when multiple fields are present: anchor > topic > venue/year
         # > from-wiki. `--limit` is universal and tacks on at the end.
         anchor = (body.get("anchor") or "").strip()
@@ -905,7 +905,7 @@ class WikiHandler(SimpleHTTPRequestHandler):
     # `tools/lint.py` is the deterministic core of `/check`. It already
     # supports `--json` and `--fix` (with `--dry-run` for preview). Exposing
     # it here lets the SPA show lint results inline without going through
-    # the intent → copy → paste → Claude Code round trip.
+    # the intent → copy → paste → Qoder round trip.
 
     def _handle_lint(self, fix: bool, dry_run: bool = False) -> None:
         args = ["--wiki-dir", str(WIKI_ROOT), "--json"]


### PR DESCRIPTION
- tools/convert_to_qoder.py: deterministic converter from i18n/<lang>/skills to Qoder-native .qoder/skills (adds required name frontmatter, argument-hint -> Usage line, Claude Code -> Qoder terminology, mcp__server__tool -> server.tool MCP naming) with built-in validation

- i18n/{en,zh}/AGENTS.md: runtime contract for Qoder with skill invocation convention (slash refs = skill name, Qoder subagents for parallel ingest fan-out)

- setup-qoder.ps1 / setup-qoder.sh: one-click setup without Claude Code prerequisite

- config/mcp.qoder.json.example: llm-review MCP registration template

- tools/{serve,daily_arxiv,_env}.py: adapt platform wording

- README: Qoder Preview section and badge; .gitignore: Qoder entries

## Summary

What changed and why?

## Checklist

- [ ] `python -m pytest tests/ -v` passes
- [ ] Both `i18n/en/` and `i18n/zh/` updated (if modifying skills/CLAUDE.md/shared-references)
- [ ] `./setup.sh` run to sync active files (if i18n files changed)
- [ ] [`docs/extending.md`](docs/extending.md) checklist followed (if adding new module)
- [ ] No `src/` packages created (this is a Claude Code skill project)
