### PR TITLE
docs: add OrcaRouter as a named provider for Review LLM and Claude Code

### DIFF
--- a/.claude/skills/shared-references/cross-model-review.md
+++ b/.claude/skills/shared-references/cross-model-review.md
@@ -76,7 +76,7 @@ When the review MCP server is **unavailable**:
    > "Cross-model review is not configured. This skill works best with an independent review LLM. Would you like to set it up now, or proceed with Claude-only analysis?"
 
 2. **If the user wants to configure**, guide them interactively:
-   - Ask which OpenAI-compatible API provider they have (DeepSeek, OpenAI, Qwen, OpenRouter, etc.)
+   - Ask which OpenAI-compatible API provider they have (DeepSeek, OpenAI, Qwen, OpenRouter, OrcaRouter, etc.)
    - Help them edit `.env` to set `LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL`
    - Tell them to restart Claude Code so the MCP server picks up the new config
    - Reference `.env.example` for the full provider table

--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,7 @@ DEEPXIV_TOKEN=
 #   DeepSeek      | https://api.deepseek.com/v1                                | deepseek-chat
 #   OpenAI        | https://api.openai.com/v1                                  | gpt-4o
 #   OpenRouter    | https://openrouter.ai/api/v1                               | (any model slug)
+#   OrcaRouter    | https://api.orcarouter.ai/v1                               | orcarouter/auto
 #   Qwen          | https://dashscope.aliyuncs.com/compatible-mode/v1          | qwen-max
 #   SiliconFlow   | https://api.siliconflow.cn/v1                              | (see docs)
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **OrcaRouter provider support**: add [OrcaRouter](https://www.orcarouter.ai) as a named provider for the Review LLM (OpenAI-compatible) and Claude Code (Anthropic protocol). The Review LLM provider table in `config/setup-guide.md` and the provider tables in `.env.example` / `config/.env.example` now include OrcaRouter (`LLM_BASE_URL=https://api.orcarouter.ai/v1`, example model `orcarouter/auto`). README Option B gains an OrcaRouter `settings.json` snippet for Claude Code via `ANTHROPIC_BASE_URL=https://api.orcarouter.ai` with the three `ANTHROPIC_DEFAULT_*_MODEL` pins. Cross-model review references (`cross-model-review.md`) and the `llm-review` MCP server docstring list OrcaRouter as well.
+
 ## [1.4.0] - 2026-05-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -315,9 +315,9 @@ and are best run from WSL2 or Linux/macOS.
 | `DEEPXIV_TOKEN` | Optional | `setup.sh` auto-registers | Semantic search, TLDR, trending |
 | `LLM_API_KEY` + `LLM_BASE_URL` + `LLM_MODEL` | Optional | Any OpenAI-compatible API | Cross-model review; `/daily-arxiv` inform recommendations |
 
-> **Don't have an Anthropic API key?** You can use Codex, or use Claude Code with any Anthropic-protocol-compatible provider — DeepSeek, Kimi, MiMo, GLM, and more. See the [LLM API Configuration](#llm-api-configuration--大模型-api-配置) section below for Claude Code provider snippets.
+> **Don't have an Anthropic API key?** You can use Codex, or use Claude Code with any Anthropic-protocol-compatible provider — DeepSeek, Kimi, MiMo, GLM, OrcaRouter, and more. See the [LLM API Configuration](#llm-api-configuration--大模型-api-配置) section below for Claude Code provider snippets.
 
-> **Cross-model review**: AutoSci uses a second LLM as an independent reviewer for ideas, experiments, and paper drafts. Works with **any OpenAI-compatible API** — DeepSeek, OpenAI, Qwen, OpenRouter, SiliconFlow, etc. If not configured, skills still work in single-agent mode.
+> **Cross-model review**: AutoSci uses a second LLM as an independent reviewer for ideas, experiments, and paper drafts. Works with **any OpenAI-compatible API** — DeepSeek, OpenAI, Qwen, OpenRouter, SiliconFlow, OrcaRouter, etc. If not configured, skills still work in single-agent mode.
 
 ---
 
@@ -340,7 +340,7 @@ Pick a provider below, paste the snippet into `~/.claude/settings.json` (or the 
 从下方任选一个供应商,把对应配置粘贴到 `~/.claude/settings.json`(或项目的 `.claude/settings.json`),并把 `<...>` 占位符替换为你自己的 API key。模型名与额外选项均来自各供应商官方 Claude Code 文档。
 
 <details>
-<summary><b>MiMo / DeepSeek / Kimi / GLM 配置示例</b></summary>
+<summary><b>MiMo / DeepSeek / Kimi / GLM / OrcaRouter 配置示例</b></summary>
 
 #### MiMo (小米)
 
@@ -405,6 +405,21 @@ Pick a provider below, paste the snippet into `~/.claude/settings.json` (or the 
 
 > Z.AI applies a default server-side model mapping, so no explicit `ANTHROPIC_MODEL` is needed.
 > Z.AI 默认在服务端做模型映射,无需显式设置 `ANTHROPIC_MODEL`。
+
+#### OrcaRouter
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.orcarouter.ai",
+    "ANTHROPIC_AUTH_TOKEN": "<your-orcarouter-key>",
+    "ANTHROPIC_MODEL": "anthropic/claude-sonnet-4.6",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "anthropic/claude-opus-4.6",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "anthropic/claude-sonnet-4.6",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "anthropic/claude-haiku-4.5"
+  }
+}
+```
 
 </details>
 

--- a/config/.env.example
+++ b/config/.env.example
@@ -71,6 +71,7 @@ DEEPXIV_TOKEN=
 #   DeepSeek      | https://api.deepseek.com/v1                                | deepseek-chat
 #   OpenAI        | https://api.openai.com/v1                                  | gpt-4o
 #   OpenRouter    | https://openrouter.ai/api/v1                               | (any model slug)
+#   OrcaRouter    | https://api.orcarouter.ai/v1                               | orcarouter/auto
 #   Qwen          | https://dashscope.aliyuncs.com/compatible-mode/v1          | qwen-max
 #   SiliconFlow   | https://api.siliconflow.cn/v1                              | (see docs)
 #

--- a/config/setup-guide.md
+++ b/config/setup-guide.md
@@ -124,6 +124,7 @@ cross-model review is unavailable.
 | DeepSeek | `https://api.deepseek.com/v1` | `deepseek-chat` |
 | OpenAI | `https://api.openai.com/v1` | `gpt-4o` |
 | OpenRouter | `https://openrouter.ai/api/v1` | any model slug |
+| OrcaRouter | `https://api.orcarouter.ai/v1` | `orcarouter/auto` |
 | Qwen (DashScope) | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen-max` |
 | SiliconFlow | `https://api.siliconflow.cn/v1` | see their docs |
 | Local (Ollama) | `http://localhost:11434/v1` | `llama3.2` |

--- a/i18n/en/shared-references/cross-model-review.md
+++ b/i18n/en/shared-references/cross-model-review.md
@@ -76,7 +76,7 @@ When the review MCP server is **unavailable**:
    > "Cross-model review is not configured. This skill works best with an independent review LLM. Would you like to set it up now, or proceed with Claude-only analysis?"
 
 2. **If the user wants to configure**, guide them interactively:
-   - Ask which OpenAI-compatible API provider they have (DeepSeek, OpenAI, Qwen, OpenRouter, etc.)
+   - Ask which OpenAI-compatible API provider they have (DeepSeek, OpenAI, Qwen, OpenRouter, OrcaRouter, etc.)
    - Help them edit `.env` to set `LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL`
    - Tell them to restart Claude Code so the MCP server picks up the new config
    - Reference `.env.example` for the full provider table

--- a/i18n/zh/shared-references/cross-model-review.md
+++ b/i18n/zh/shared-references/cross-model-review.md
@@ -76,7 +76,7 @@ After both models have independently assessed:
    > "跨模型 review 尚未配置。此 skill 在独立 review LLM 辅助下效果更好。你想现在配置，还是仅用 Claude 继续？"
 
 2. **若用户选择配置**，交互引导：
-   - 询问用户使用哪个 OpenAI 兼容 API（DeepSeek、OpenAI、Qwen、OpenRouter 等）
+   - 询问用户使用哪个 OpenAI 兼容 API（DeepSeek、OpenAI、Qwen、OpenRouter、OrcaRouter 等）
    - 帮助用户编辑 `.env`，设置 `LLM_API_KEY`、`LLM_BASE_URL`、`LLM_MODEL`
    - 提示用户重启 Claude Code 以使 MCP server 加载新配置
    - 引导参考 `.env.example` 中的 provider 列表

--- a/mcp-servers/llm-review/server.py
+++ b/mcp-servers/llm-review/server.py
@@ -7,7 +7,7 @@ Provides three tools:
   - web_search: web search via LLM (provider-specific, may not work with all APIs)
 
 Works with any OpenAI-compatible API provider:
-  - DeepSeek, Qwen (DashScope), OpenRouter, SiliconFlow, OpenAI, etc.
+  - DeepSeek, Qwen (DashScope), OpenRouter, SiliconFlow, OpenAI, OrcaRouter, etc.
 
 Configuration: set LLM_* variables in the project root .env file.
   LLM_API_KEY         - API key (required)


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a named provider for both the Review LLM (OpenAI-compatible) and Claude Code (Anthropic protocol). OrcaRouter is an OpenAI-compatible model routing gateway that brings 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint and API key. Beyond routing, it runs gateway-level, zero-trust security for AI agents on the same endpoint. The gateway screens every prompt and response and governs every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

- `config/setup-guide.md`: adds an OrcaRouter row to the Review LLM provider table (`LLM_BASE_URL=https://api.orcarouter.ai/v1`, example model `orcarouter/auto`)
- `.env.example` and `config/.env.example`: adds an aligned OrcaRouter row to the OpenAI-compatible provider table
- `README.md`: lists OrcaRouter in the Anthropic-compatible provider note and the cross-model review note, and adds an OrcaRouter snippet under LLM API Configuration Option B for Claude Code (`ANTHROPIC_BASE_URL=https://api.orcarouter.ai` with the three `ANTHROPIC_DEFAULT_*_MODEL` pins)
- `.claude/skills/shared-references/cross-model-review.md` and the `i18n/en|zh` mirrors: lists OrcaRouter among the OpenAI-compatible providers a user may have
- `mcp-servers/llm-review/server.py`: lists OrcaRouter in the MCP server docstring
- `CHANGELOG.md`: adds an Unreleased entry

## How to use it

- Review LLM: set `LLM_BASE_URL=https://api.orcarouter.ai/v1`, `LLM_API_KEY` (keys start with `sk-orca-`), and `LLM_MODEL=orcarouter/auto` in `.env`.
- Claude Code: paste the OrcaRouter block from README Option B into `~/.claude/settings.json` (or the project `.claude/settings.json`), then replace `<your-orcarouter-key>`.

## Verification

- Unit tests: `python -m pytest .sleepcode/tests/ -q` -> 20 passed, 12 subtests passed. Note this repo has no `tests/` directory (CONTRIBUTING references it); the only test suite is under `.sleepcode/tests/`.
- i18n sync: `i18n/en/shared-references/cross-model-review.md` and the active `.claude/skills/shared-references/cross-model-review.md` are byte-identical (`cmp`), and `i18n/zh` mirrors the change.
- Live API (real key, 2026-08-10):
  - `POST https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/auto` -> 200 (the model id used as the example in the provider tables)
  - `POST https://api.orcarouter.ai/v1/messages` with `anthropic/claude-sonnet-4.6` and `anthropic/claude-haiku-4.5` -> 200 (the model ids used in the README Claude Code snippet)
  - Keyless `GET https://api.orcarouter.ai/v1/models` lists `orcarouter/auto`, `anthropic/claude-sonnet-4.6`, `anthropic/claude-haiku-4.5`, `anthropic/claude-opus-4.6`, all ids referenced in this PR
- The JSON snippet added to the README parses as valid JSON.

## Checklist

- [x] `python -m pytest tests/ -v` passes (no `tests/` directory exists in this repo; the `.sleepcode/tests/` suite passes 20/20)
- [x] Both `i18n/en/` and `i18n/zh/` updated (shared-references changed)
- [x] `./setup.sh` run to sync active files (active `.claude/` copy verified byte-identical to `i18n/en/`)
- [x] [`docs/extending.md`](docs/extending.md) checklist followed (N/A, no new module)
- [x] No `src/` packages created
